### PR TITLE
chore(deps): update cargo dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,15 +128,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arc-swap"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ded5f9a03ac8f24d1b8a25101ee812cd32cdc8c50a4c50237de2c4915850e73"
+checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
 dependencies = [
  "rustversion",
 ]
@@ -197,7 +197,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -261,6 +261,28 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9a7b350e3bb1767102698302bc37256cbd48422809984b98d292c40e2579aa9"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.37.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b092fe214090261288111db7a2b2c2118e5a7f30dc2569f1732c4069a6840549"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
 
 [[package]]
 name = "axum"
@@ -364,9 +386,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 dependencies = [
  "serde_core",
 ]
@@ -423,9 +445,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytemuck"
@@ -462,13 +484,21 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.55"
+version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -484,9 +514,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -535,9 +565,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.57"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -545,9 +575,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.57"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
 dependencies = [
  "anstream",
  "anstyle",
@@ -564,14 +594,23 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+
+[[package]]
+name = "cmake"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "cobs"
@@ -587,6 +626,16 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "compact_str"
@@ -657,6 +706,16 @@ checksum = "688d7fbb8092b8de775ef2536f36c8c31f2bc4006ece2e8d8ad2d17d00ce0a2a"
 dependencies = [
  "loom",
  "tracing",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -779,7 +838,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -903,7 +962,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -937,7 +996,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -950,7 +1009,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -961,7 +1020,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -972,7 +1031,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1014,9 +1073,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.8.0-rc.10"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c1d73e9668ea6b6a28172aa55f3ebec38507131ce179051c8033b5c6037653"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
 dependencies = [
  "const-oid 0.10.2",
  "pem-rfc7468 1.0.0",
@@ -1025,9 +1084,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
 ]
@@ -1050,7 +1109,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1060,7 +1119,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1082,7 +1141,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.114",
+ "syn 2.0.117",
  "unicode-xid",
 ]
 
@@ -1121,7 +1180,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "block2",
  "libc",
  "objc2",
@@ -1135,7 +1194,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1180,6 +1239,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1201,7 +1266,7 @@ version = "3.0.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6e914c7c52decb085cea910552e24c63ac019e3ab8bf001ff736da9a9d9d890"
 dependencies = [
- "pkcs8 0.11.0-rc.10",
+ "pkcs8 0.11.0-rc.11",
  "serde",
  "signature 3.0.0-rc.10",
 ]
@@ -1259,7 +1324,7 @@ dependencies = [
  "postcard",
  "postcard-derive",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -1285,7 +1350,7 @@ dependencies = [
  "base64ct",
  "clap",
  "eidetica",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tokio",
@@ -1326,7 +1391,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1337,7 +1402,7 @@ checksum = "3ed8956bd5c1f0415200516e78ff07ec9e16415ade83c056c230d7b7ea0d55b7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1538,10 +1603,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.31"
+name = "fs_extra"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1554,9 +1625,9 @@ dependencies = [
 
 [[package]]
 name = "futures-buffered"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8e0e1f38ec07ba4abbde21eed377082f17ccb988be9d988a5adbf4bafc118fd"
+checksum = "4421cb78ee172b6b06080093479d3c50f058e7c81b7d577bbb8d118d551d4cd5"
 dependencies = [
  "cordyceps",
  "diatomic-waker",
@@ -1567,9 +1638,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1577,15 +1648,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1605,9 +1676,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-lite"
@@ -1624,32 +1695,32 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1659,7 +1730,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -1712,6 +1782,21 @@ dependencies = [
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
  "wasm-bindgen",
 ]
 
@@ -1784,7 +1869,7 @@ checksum = "e46dbf6b28fbb72d11388a8664af3a63e34b5fcaa61ad8b1e36012a8d556c902"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2162,6 +2247,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2223,6 +2314,8 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2253,7 +2346,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2315,10 +2408,10 @@ dependencies = [
  "papaya",
  "pin-project",
  "pkarr",
- "pkcs8 0.11.0-rc.10",
+ "pkcs8 0.11.0-rc.11",
  "portmapper",
  "rand 0.9.2",
- "reqwest",
+ "reqwest 0.12.28",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
@@ -2381,7 +2474,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2473,7 +2566,7 @@ dependencies = [
  "pkarr",
  "postcard",
  "rand 0.9.2",
- "reqwest",
+ "reqwest 0.12.28",
  "rustls",
  "rustls-pki-types",
  "serde",
@@ -2536,10 +2629,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
-name = "js-sys"
-version = "0.3.85"
+name = "jni"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2572,10 +2697,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.180"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.182"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "libm"
@@ -2585,13 +2716,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "libc",
- "redox_syscall 0.7.0",
+ "plain",
+ "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -2611,14 +2743,14 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f4de44e98ddbf09375cbf4d17714d18f39195f4f4894e8524501726fd9a8a4a"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -2718,9 +2850,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmem"
@@ -2796,7 +2928,7 @@ checksum = "03755949235714b2b307e5ae89dd8c1c2531fb127d9b8b7b4adf9c876cd3ed18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2868,7 +3000,7 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ec2f5b6839be2a19d7fa5aab5bc444380f6311c2b693551cb80f45caaa7b5ef"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "libc",
  "log",
  "netlink-packet-core",
@@ -2880,7 +3012,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ce3636fa715e988114552619582b530481fd5ef176a1e5c1bf024077c2c9445"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "libc",
  "log",
  "netlink-packet-core",
@@ -2955,7 +3087,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3026,7 +3158,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3078,7 +3210,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3105,7 +3237,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "block2",
  "dispatch2",
  "libc",
@@ -3124,7 +3256,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -3135,7 +3267,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "dispatch2",
  "libc",
  "objc2",
@@ -3170,6 +3302,12 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "ordered-float"
@@ -3300,7 +3438,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3363,7 +3501,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3377,29 +3515,29 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -3409,9 +3547,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkarr"
-version = "5.0.2"
+version = "5.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d346b545765a0ef58b6a7e160e17ddaa7427f439b7b9a287df6c88c9e04bf2"
+checksum = "2f950360d31be432c0c9467fba5024a94f55128e7f32bc9d32db140369f24c77"
 dependencies = [
  "async-compat",
  "base32",
@@ -3422,11 +3560,11 @@ dependencies = [
  "ed25519-dalek 3.0.0-pre.1",
  "futures-buffered",
  "futures-lite",
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "log",
  "lru",
  "ntimestamp",
- "reqwest",
+ "reqwest 0.13.2",
  "self_cell",
  "serde",
  "sha1_smol",
@@ -3461,11 +3599,11 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.11.0-rc.10"
+version = "0.11.0-rc.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b226d2cc389763951db8869584fd800cbbe2962bf454e2edeb5172b31ee99774"
+checksum = "12922b6296c06eb741b02d7b5161e3aaa22864af38dfa025a1a3ba3f68c84577"
 dependencies = [
- "der 0.8.0-rc.10",
+ "der 0.8.0",
  "spki 0.8.0-rc.4",
 ]
 
@@ -3474,6 +3612,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
@@ -3586,7 +3730,7 @@ checksum = "e0232bd009a197ceec9cc881ba46f727fcd8060a2d8d6a9dde7a69030a6fe2bb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3611,6 +3755,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3666,6 +3820,7 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -3789,7 +3944,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "compact_str",
  "hashbrown 0.16.1",
  "indoc",
@@ -3841,7 +3996,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "hashbrown 0.16.1",
  "indoc",
  "instability",
@@ -3880,16 +4035,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -3917,9 +4072,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -3960,6 +4115,41 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -4019,11 +4209,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -4032,10 +4222,11 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -4043,6 +4234,18 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -4056,11 +4259,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -4074,9 +4305,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -4085,6 +4316,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4098,6 +4338,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "seize"
@@ -4164,7 +4427,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4316,7 +4579,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dee851d0e5e7af3721faea1843e8015e820a234f81fda3dea9247e15bac9a86a"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -4383,7 +4646,7 @@ checksum = "c87e960f4dca2788eeb86bbdde8dd246be8948790b7618d656e68f9b720a86e8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4418,7 +4681,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8baeff88f34ed0691978ec34440140e1572b68c7dd4a495fd14a3dc1944daa80"
 dependencies = [
  "base64ct",
- "der 0.8.0-rc.10",
+ "der 0.8.0",
 ]
 
 [[package]]
@@ -4478,7 +4741,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4501,7 +4764,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.114",
+ "syn 2.0.117",
  "tokio",
  "url",
 ]
@@ -4514,7 +4777,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "byteorder",
  "bytes",
  "crc",
@@ -4556,7 +4819,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "byteorder",
  "crc",
  "dotenvy",
@@ -4656,7 +4919,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4678,9 +4941,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4704,7 +4967,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4715,12 +4978,12 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tempfile"
-version = "3.24.0"
+version = "3.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -4755,7 +5018,7 @@ checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
  "base64",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "fancy-regex",
  "filedescriptor",
  "finl_unicode",
@@ -4815,7 +5078,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4826,7 +5089,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4932,7 +5195,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5016,9 +5279,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.6+spec-1.1.0"
+version = "1.0.9+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
  "winnow",
 ]
@@ -5060,7 +5323,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bytes",
  "futures-util",
  "http",
@@ -5104,7 +5367,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5172,9 +5435,9 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-normalization"
@@ -5263,12 +5526,12 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.20.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
+checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
 dependencies = [
  "atomic",
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -5384,6 +5647,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wasite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5391,9 +5663,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5404,9 +5676,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.58"
+version = "0.4.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -5418,9 +5690,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5428,24 +5700,46 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
 ]
 
 [[package]]
@@ -5462,10 +5756,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.85"
+name = "wasmparser"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5479,6 +5785,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -5662,7 +5977,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5673,7 +5988,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5708,6 +6023,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -5753,6 +6077,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -5814,6 +6153,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -5832,6 +6177,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -5847,6 +6198,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5880,6 +6237,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -5895,6 +6258,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5916,6 +6285,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -5931,6 +6306,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5974,6 +6355,88 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "wmi"
@@ -6049,7 +6512,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -6079,22 +6542,22 @@ checksum = "2164e798d9e3d84ee2c91139ace54638059a3b23e361f5c11781c2c6459bde0f"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.38"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57cf3aa6855b23711ee9852dfc97dfaa51c45feaba5b645d0c777414d494a961"
+checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.38"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a616990af1a287837c4fe6596ad77ef57948f787e46ce28e166facc0cc1cb75"
+checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6114,7 +6577,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -6135,7 +6598,7 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6168,11 +6631,11 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.19"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"


### PR DESCRIPTION
## Cargo Dependency Update

Monthly `cargo update` of `Cargo.lock` dependencies.

<details>
<summary>cargo update output</summary>

```
warning: ignoring untrusted flake configuration setting 'extra-substituters'.
Pass '--accept-flake-config' to trust it
warning: ignoring untrusted flake configuration setting 'extra-trusted-public-keys'.
Pass '--accept-flake-config' to trust it
unpacking 'github:hercules-ci/flake-parts/57928607ea566b5db3ad13af0e57e921e6b12381?narHash=sha256-AnYjnFWgS49RlqX7LrC4uA%2BsCCDBj0Ry/WOJ5XWAsa0%3D' into the Git cache...
unpacking 'github:nixos/nixpkgs/00c21e4c93d963c50d4c0c89bfa84ed6e0694df2?narHash=sha256-AYqlWrX09%2BHvGs8zM6ebZ1pwUqjkfpnv8mewYwAo%2BiM%3D' into the Git cache...
unpacking 'github:numtide/treefmt-nix/337a4fe074be1042a35086f15481d763b8ddc0e7?narHash=sha256-wQ6NJSuFqAEmIg2VMnLdCnUc0b7vslUohqqGGD%2BFyxk%3D' into the Git cache...
unpacking 'github:nix-community/fenix/6dbe5750c68a55e7cb3f8b62883c4dbfeecf14d5?narHash=sha256-ZBpEh6aTvdoZvIM8sojnr43FPyegq/sjUkNWtF4kDO8%3D' into the Git cache...
unpacking 'github:ipetkov/crane/8254ccf3b5b5131890ee073776f2e61c6d1e55d4?narHash=sha256-iPiy13xzDQ9GjpOez%2BNNIjh/qjl7i4RDf9dF2x5mF9I%3D' into the Git cache...
copying path '/nix/store/6zs6abm8qwvjgdi5832cvhircrd4f9y5-cargoHelperFunctionsHook' from 'http://127.0.0.1:37515'...
copying path '/nix/store/p2prdxm8awpcd9xpggqxhf3q0ybf322x-configureCargoCommonVarsHook' from 'http://127.0.0.1:37515'...
copying path '/nix/store/ljprl9m5yl9ckm9qw77aqlfnz4ybbn8n-configureCargoVendoredDepsHook' from 'http://127.0.0.1:37515'...
copying path '/nix/store/bjgsr6vjn2zvp6xp28zf73ny8fnyy74b-gnu-config-2024-01-01' from 'http://127.0.0.1:37515'...
copying path '/nix/store/y1s3b1j0vs9iw8ic98f57xjidbmws98j-inheritCargoArtifactsHook' from 'http://127.0.0.1:37515'...
copying path '/nix/store/d5ngrrdxypqxlvj2bhl9ih2d9a17fskj-installCargoArtifactsHook' from 'http://127.0.0.1:37515'...
copying path '/nix/store/0fcmv6kr1qw5h2ahd95yjfcal427676j-nss-cacert-3.119.1' from 'http://127.0.0.1:37515'...
copying path '/nix/store/wjw6m7mhsh40sl2sc86h3qc5ihjcsfaz-removeReferencesToRustToolchainHook' from 'http://127.0.0.1:37515'...
copying path '/nix/store/9xmghl5pvfjfaqwf2n32jgjc0zwfnhin-removeReferencesToVendoredSourcesHook' from 'http://127.0.0.1:37515'...
copying path '/nix/store/ppkgiw440s2kid5sq6slnrm2lr3n7f1p-replaceCargoLockHook' from 'http://127.0.0.1:37515'...
copying path '/nix/store/d8kc4kqzcrbcj92msxrpdsdjglh2q5gp-git-2.52.0-doc' from 'http://127.0.0.1:37515'...
copying path '/nix/store/dm16iwd2p8abxly30iy0idkvzpp0w5zy-iana-etc-20250505' from 'http://127.0.0.1:37515'...
copying path '/nix/store/3n5kqpahwmk8va5mkygqjj0mn9hqd72n-mailcap-2.1.54' from 'http://127.0.0.1:37515'...
copying path '/nix/store/z831l01qqsic95ik33x70mxvdb6vhahc-perl5.42.0-Capture-Tiny-0.48' from 'http://127.0.0.1:37515'...
copying path '/nix/store/qjjvfd2n5lvij88cxlpws6w28w5lgza3-perl5.42.0-Class-Data-Inheritable-0.09' from 'http://127.0.0.1:37515'...
copying path '/nix/store/vnvm4x2fkfs875ifn1izn5kc8vqirx1i-perl5.42.0-Class-Inspector-1.36' from 'http://127.0.0.1:37515'...
copying path '/nix/store/3b4p38fk6hgwaf2p6jcci5k93b9cnxc8-ada-3.4.1' from 'http://127.0.0.1:37515'...
copying path '/nix/store/y6n0g6yj0hzdq31q1258jn372kflb4dg-attr-2.5.2' from 'http://127.0.0.1:37515'...
copying path '/nix/store/q4r5an0l3p32b0idhhnqsnxibfhkmrr1-aws-c-common-0.12.4' from 'http://127.0.0.1:37515'...
copying path '/nix/store/q5hdxy658850yynggmkjblbqfgs1w4nq-brotli-1.2.0-lib' from 'http://127.0.0.1:37515'...
copying path '/nix/store/m3dxfi2gq218pw8h73al024f6r69a5mj-busybox-1.37.0' from 'http://127.0.0.1:37515'...
copying path '/nix/store/bhz2i66mwm3vdyslixazss6a46h48ib5-bzip2-1.0.8' from 'http://127.0.0.1:37515'...
copying path '/nix/store/dkvxkb5cb4zl792gz2msbgxhhk2mh43i-c-ares-1.34.6' from 'http://127.0.0.1:37515'...
copying path '/nix/store/j02bpb9f7w3kh0rbbpmbhv6svcc8p3n3-c-ares-1.34.6' from 'http://127.0.0.1:37515'...
copying path '/nix/store/ka8g6nlpb9h5q350fx7n3zgszm6w5rdw-cargo-nightly-complete-2026-02-04' from 'http://127.0.0.1:37515'...
copying path '/nix/store/99fxa44avp85rc06nn7w4dijy5xxfrir-cargo-stable-2026-01-22' from 'http://127.0.0.1:37515'...
copying path '/nix/store/y309ixb0kh2p7d885fc91qb9wdrvcp3b-clippy-preview-nightly-complete-2026-02-04' from 'http://127.0.0.1:37515'...
copying path '/nix/store/h605nypvskwjm42kgm1dby9h2gcxb3w6-clippy-preview-stable-2026-01-22' from 'http://127.0.0.1:37515'...
copying path '/nix/store/rpjhgrbvzrhbih2ilqp40x3ryk9y5ggf-d3-flame-graph-templates-4.1.3' from 'http://127.0.0.1:37515'...
copying path '/nix/store/im7j49npizac0d5ldi5ikyyfy7x5nd2s-dav1d-1.5.3' from 'http://127.0.0.1:37515'...
copying path '/nix/store/6gz4kzl3i8x44pssbnyiahvl5vyc9vcq-acl-2.3.2' from 'http://127.0.0.1:37515'...
copying path '/nix/store/zm7p349xn0a5vxr9g7wg8gb2xd43h03m-dejavu-fonts-minimal-2.37' from 'http://127.0.0.1:37515'...
copying path '/nix/store/90yw24gqmwph4xjp4mqhpx1y1gcrvqla-bzip2-1.0.8-bin' from 'http://127.0.0.1:37515'...
copying path '/nix/store/g043h47ws2x7icy7qmy7ggqhybbcfk9k-ed-1.22.4' from 'http://127.0.0.1:37515'...
copying path '/nix/store/64a1rvdxzqnbyvn55w537p8zsr2lrv7p-editline-1.17.1-unstable-2025-05-24' from 'http://127.0.0.1:37515'...
copying path '/nix/store/xjqicsm7q0pb1hr271cki2f6k18d4sc2-c-ares-1.34.6-dev' from 'http://127.0.0.1:37515'...
copying path '/nix/store/737dqp5fsczjn8isjs7jhws09aks64mh-expand-response-params' from 'http://127.0.0.1:37515'...
copying path '/nix/store/9v1irc5cj2644cf3j5r3z7x833cablh5-expand-response-params' from 'http://127.0.0.1:37515'...
copying path '/nix/store/494flzsx9j86bshnds5sy6f4iy4g7gxi-brotli-1.2.0' from 'http://127.0.0.1:37515'...
copying path '/nix/store/7mf304gpbyw54m11pjvscbjif21ggzdn-aws-c-compression-0.3.1' from 'http://127.0.0.1:37515'...
copying path '/nix/store/lh9gi204p80jx8281bc202j3jg9r56dv-aws-c-sdkutils-0.2.4' from 'http://127.0.0.1:37515'...
copying path '/nix/store/km5l772my9z7j7haxdrm6hpa52jknnwx-aws-checksums-0.2.7' from 'http://127.0.0.1:37515'...
copying path '/nix/store/p5gjx03bq07a80zqibfi35yrryg5d74f-expat-2.7.3' from 'http://127.0.0.1:37515'...
copying path '/nix/store/x3li8bcdrgnwfh397sjfk1sgsbax6wxn-find-xml-catalogs-hook' from 'http://127.0.0.1:37515'...
copying path '/nix/store/2xq9rayckw8zq26k274xxlikn77jn60j-gawk-5.3.2' from 'http://127.0.0.1:37515'...
copying path '/nix/store/yjmjazfwljzajwq54xlr7vfz77spzr9y-gcc-15.2.0-libgcc' from 'http://127.0.0.1:37515'...
copying path '/nix/store/4dacmvrkh5zyj3v7gbmv5hchnkcb2qhj-gdbm-1.26-lib' from 'http://127.0.0.1:37515'...
copying path '/nix/store/gm1v2azbnb96yi4fapfd1jx9f0jrnpzq-brotli-1.2.0-dev' from 'http://127.0.0.1:37515'...
copying path '/nix/store/idjmaw31clp502av2aa62d98vwvpwx9w-giflib-5.2.2' from 'http://127.0.0.1:37515'...
copying path '/nix/store/0bdqq2z98kg2hfn3k60if6pb5fd5p10h-glibc-2.42-47-bin' from 'http://127.0.0.1:37515'...
copying path '/nix/store/q9lw7mrvhc2d14nrzwvm2fszz6861xvc-fontconfig-2.17.1' from 'http://127.0.0.1:37515'...
copying path '/nix/store/1gzg2vdnhdbmbspyvw5gygn9hjjmlff0-gmp-6.3.0' from 'http://127.0.0.1:37515'...
copying path '/nix/store/kachqlzpp4nkjjq4pf90r9abymkc18zq-gnum4-1.4.20' from 'http://127.0.0.1:37515'...
copying path '/nix/store/vbah5c4rzy1q1hbqhginyxjhj8d4dj8j-gnumake-4.4.1' from 'http://127.0.0.1:37515'...
copying path '/nix/store/ryz8kcrm2bxpccllfqlb7qldsfnqp5c2-gnused-4.9' from 'http://127.0.0.1:37515'...
copying path '/nix/store/qyg62bc2xnpwz0fa9prqxvvk00zj4g9q-gnutar-1.35' from 'http://127.0.0.1:37515'...
copying path '/nix/store/j2kgllgds4w7na8zqv1msi0mpvpjxda8-gcc-15.2.0-lib' from 'http://127.0.0.1:37515'...
copying path '/nix/store/84yyzmxs7mb8nhkvcfv9n1l9irpb6mnq-gzip-1.14' from 'http://127.0.0.1:37515'...
copying path '/nix/store/sy4dflf9clk1lnp3xdqfsdinb899k6g8-hwloc-2.12.2-lib' from 'http://127.0.0.1:37515'...
copying path '/nix/store/kn9jqbdnq8ngp0375r7nvlvn40gxlqfd-json-c-0.18' from 'http://127.0.0.1:37515'...
copying path '/nix/store/igdw3jkpj7m445gfynips033jbf6179l-keyutils-1.6.3-lib' from 'http://127.0.0.1:37515'...
copying path '/nix/store/dlv50v62v4zm9ssjpl76q1s20rdv1wa9-libcap-2.77-lib' from 'http://127.0.0.1:37515'...
copying path '/nix/store/79x341sy9nhg8g7901dcqdm3z32k4mra-libcap-ng-0.8.5' from 'http://127.0.0.1:37515'...
copying path '/nix/store/b5wsday0zv2a7jmjwimqbjfhamscr383-libcpuid-0.8.1' from 'http://127.0.0.1:37515'...
copying path '/nix/store/slgxjm6vc103ddsywpnfr9ss2zzpm5ks-libdeflate-1.25' from 'http://127.0.0.1:37515'...
copying path '/nix/store/9dxykk10ci82p4rbalcj1plqm9cgc3yh-libev-4.33' from 'http://127.0.0.1:37515'...
copying path '/nix/store/56q5bvy8f9njwsqj723cjkfhaz70y5i7-isl-0.20' from 'http://127.0.0.1:37515'...
copying path '/nix/store/s644cyhhkg9zjgk924ap5wwr96jn71d3-libffi-3.5.2' from 'http://127.0.0.1:37515'...
copying path '/nix/store/0cdfypplpvbsqll2kp2kl418bjyfhjcz-libjpeg-turbo-3.1.3' from 'http://127.0.0.1:37515'...
copying path '/nix/store/2f728vasd29dnc2ys09mn45058mkzvc2-bison-3.8.2' from 'http://127.0.0.1:37515'...
copying path '/nix/store/cx3mp71jzyvqk1mfxghcsdycrhzfj8v1-audit-4.1.2-unstable-2025-09-06-lib' from 'http://127.0.0.1:37515'...
copying path '/nix/store/d0nnc1ldn91xqmf622llbsiwvzf2nsw7-libpfm-4.13.0' from 'http://127.0.0.1:37515'...
copying path '/nix/store/8wh6imqacivhslwql0gqpx373xzz88k3-flex-2.6.4' from 'http://127.0.0.1:37515'...
copying path '/nix/store/w4p8q8lyvy8469bl0g152c3blgm5f558-libseccomp-2.6.0-lib' from 'http://127.0.0.1:37515'...
copying path '/nix/store/pgc8rn7d8pv9ssr87r6783bcir8rfqpc-libsodium-1.0.20-unstable-2025-12-31' from 'http://127.0.0.1:37515'...
copying path '/nix/store/x8s54s8s3d2cyhrixjwa1qbwd2nlq1v3-libtraceevent-1.8.7' from 'http://127.0.0.1:37515'...
copying path '/nix/store/y890wk5v7h4dzfs69jycv3fj0fx5y9i5-libuv-1.51.0' from 'http://127.0.0.1:37515'...
copying path '/nix/store/lyzx1sjycvj94jni888r1hcywglz4g17-libxau-1.0.12' from 'http://127.0.0.1:37515'...
copying path '/nix/store/bjzcn2mi0vi0wpn5hpn213vfqhyd3yng-libxcrypt-4.5.2' from 'http://127.0.0.1:37515'...
copying path '/nix/store/zynxxzvp6pjbvhdyynj2my0c25djarpb-libxdmcp-1.1.5' from 'http://127.0.0.1:37515'...
copying path '/nix/store/81cfgyhfaadhh0vs4nf74yhcclgbav87-libxml2-2.15.1' from 'http://127.0.0.1:37515'...
copying path '/nix/store/0s3m1rr713h04x5spxs31qvp8ribkjv5-libyaml-0.2.5' from 'http://127.0.0.1:37515'...
copying path '/nix/store/3h3vbisciry5r5rvwbmn4ij8fvy1zx4b-linux-headers-6.18' from 'http://127.0.0.1:37515'...
copying path '/nix/store/8kwysbrm9zrfcsfbix7hkjj72r5kgiwv-llhttp-9.3.0' from 'http://127.0.0.1:37515'...
copying path '/nix/store/bs0ls3jy3krsjfwz0vawmff0cv1zk4ix-lowdown-2.0.4-lib' from 'http://127.0.0.1:37515'...
copying path '/nix/store/s0syhfj85p6zr4gz44v8fh59qz9s3dmk-lz4-1.10.0' from 'http://127.0.0.1:37515'...
copying path '/nix/store/4h7ak3pg4y1bynhmdrxndx70ljxxgqyy-lz4-1.10.0-lib' from 'http://127.0.0.1:37515'...
copying path '/nix/store/0pxl3sgz8igwks4rmq3gnidi3hfwdcgs-libuv-1.51.0-dev' from 'http://127.0.0.1:37515'...
copying path '/nix/store/x2bvs20lq9vzf1p6y5k4brdabkw3z3pl-mpdecimal-4.0.1' from 'http://127.0.0.1:37515'...
copying path '/nix/store/fqc2w0lqhnfilywlf8q2r6dc98q9ppby-alejandra-4.0.0' from 'http://127.0.0.1:37515'...
copying path '/nix/store/q8lxdd4c7rj97kd3w92n70kqdr49s6v3-boehm-gc-8.2.8' from 'http://127.0.0.1:37515'...
copying path '/nix/store/r9qxsrmg6lq3q85n0dbjx53gd8j3hc10-cargo-careful-0.4.9' from 'http://127.0.0.1:37515'...
copying path '/nix/store/hadf76x1xknx2w6ydp05gzl2w3j40hqy-cargo-nextest-0.9.124' from 'http://127.0.0.1:37515'...
copying path '/nix/store/2chg2ibabrnzcsynwadhzv7gwkwb5nbi-compiler-rt-libc-20.1.8' from 'http://127.0.0.1:37515'...
copying path '/nix/store/9gdbdb3nwv46g92pzha8y5dmwk10fmhb-db-4.8.30' from 'http://127.0.0.1:37515'...
copying path '/nix/store/sg9jxawvfpz67hg0q0ys23v15cw8sqqz-deadnix-1.3.1' from 'http://127.0.0.1:37515'...
copying path '/nix/store/ykz6g9bnl3kka132wiw355rzk0bibdqn-gettext-0.25.1' from 'http://127.0.0.1:37515'...
copying path '/nix/store/3lm7am3fk2g7na9dc7hjnbqa3sr9wkaq-git-cliff-2.12.0' from 'http://127.0.0.1:37515'...
copying path '/nix/store/c5p8phmycgqjfrwzf0cpc740b6gvdac5-gmp-with-cxx-6.3.0' from 'http://127.0.0.1:37515'...
copying path '/nix/store/fg597zq78kc4dpbh0is4khy1qfd81xw4-gmp-with-cxx-6.3.0' from 'http://127.0.0.1:37515'...
copying path '/nix/store/q34rjcffjcmhbnsx8nd6w0i2xamz66i3-icu4c-76.1' from 'http://127.0.0.1:37515'...
copying path '/nix/store/n4g7fjn0b4m0rfjaqw2y4czvz6za1iwr-just-1.46.0' from 'http://127.0.0.1:37515'...
copying path '/nix/store/xr94ln20i0lg01p1nv393cpiry1w1vhh-lerc-4.0.0' from 'http://127.0.0.1:37515'...
copying path '/nix/store/wi2ryivmdlgfh7r2hmsj70r5dnrrw5bc-libxcb-1.17.0' from 'http://127.0.0.1:37515'...
copying path '/nix/store/d2lx32d1w9b5x984zswcyxjck3cv0xzj-libvmaf-3.0.0' from 'http://127.0.0.1:37515'...
copying path '/nix/store/r40kqrp7ghjypfc0p9kjwgb14mxmjciw-libxml2-2.15.1-bin' from 'http://127.0.0.1:37515'...
copying path '/nix/store/i2vmgx46q9hd3z6rigaiman3wl3i2gc4-coreutils-9.9' from 'http://127.0.0.1:37515'...
copying path '/nix/store/xalcq9nknyj05ylzg5xss54z825sbfv0-libxslt-1.1.45' from 'http://127.0.0.1:37515'...
copying path '/nix/store/w1ibaawl9nq9p5xra08sggrh8gk0wrmb-libyuv-1908' from 'http://127.0.0.1:37515'...
copying path '/nix/store/mfsjcsi2p23zkcd58g003binzmak18vx-llhttp-9.3.0-dev' from 'http://127.0.0.1:37515'...
copying path '/nix/store/nznfyp77k061rsy71ir83ajzpm2nvyzv-llvm-bitcode-linker-preview-stable-2026-01-22' from 'http://127.0.0.1:37515'...
copying path '/nix/store/88lgndhs08kfy8zvni94gw9lnj8mk99f-lz4-1.10.0-dev' from 'http://127.0.0.1:37515'...
copying path '/nix/store/yl9p47yg3qzw1xf9b3pnfav0mgy1qik9-libxml2-2.15.1-dev' from 'http://127.0.0.1:37515'...
copying path '/nix/store/0iwk3dvbzgdhd05zxys60n0ba413kcxn-libx11-1.8.12' from 'http://127.0.0.1:37515'...
copying path '/nix/store/0j472hdyg6n40gajm6ii2c5k4mcynnsb-mdbook-0.5.2' from 'http://127.0.0.1:37515'...
copying path '/nix/store/48i66s6pnxqpgzx4n1q24jvzxwj10jdx-mdbook-mermaid-0.17.0' from 'http://127.0.0.1:37515'...
copying path '/nix/store/lbqkpfdwlsa416grb3prnqnf6fvn8bsd-libaom-3.12.1' from 'http://127.0.0.1:37515'...
copying path '/nix/store/ap2hh8x4qm3cfvh2ain8ygl31w453pah-libxslt-1.1.45-bin' from 'http://127.0.0.1:37515'...
copying path '/nix/store/chywwj1qah8cjlgfm84hsqvag614nq21-mimalloc-3.1.5' from 'http://127.0.0.1:37515'...
copying path '/nix/store/v68a321jp4xqmbk0ly5yn1x4a3ky1y8a-mpfr-4.2.2' from 'http://127.0.0.1:37515'...
copying path '/nix/store/3p87h6dn5i87i3iq9364imzbqgwvkg2p-diffutils-3.12' from 'http://127.0.0.1:37515'...
copying path '/nix/store/16wfacfgap3chf7mcjnd8dwi85dj4qqi-findutils-4.10.0' from 'http://127.0.0.1:37515'...
copying path '/nix/store/rh9aygdm7yqjp3pzxc02ri61ij85s6i9-ncompress-5.0' from 'http://127.0.0.1:37515'...
copying path '/nix/store/z2903hglhpxv4hyczli0ncdf09wmma92-ncurses-6.6' from 'http://127.0.0.1:37515'...
copying path '/nix/store/rwalsamz4246k8f1zzxa54qx7w3fbzdg-glibc-2.42-47-dev' from 'http://127.0.0.1:37515'...
copying path '/nix/store/qmqc18y38gfd8ld9s9hsvrlpi6v8h7mz-ncurses-6.6-man' from 'http://127.0.0.1:37515'...
copying path '/nix/store/j45rf4zx05ckp2d3fj6nb7js7zhs10dx-nghttp2-1.67.1-lib' from 'http://127.0.0.1:37515'...
copying path '/nix/store/pp25xaldx1banfr67b6crg0vzpqvg6p9-nghttp2-1.67.1-lib' from 'http://127.0.0.1:37515'...
copying path '/nix/store/0jwkg5vcr4b4zi5r5xlg4nizd7h26776-libmpc-1.3.1' from 'http://127.0.0.1:37515'...
copying path '/nix/store/x1avvg7xfcb6699afppcbd5qk24smg4n-nghttp3-1.13.1' from 'http://127.0.0.1:37515'...
copying path '/nix/store/8vc3h46fniyxd7mxr5svffj3iylzds48-libxpm-3.5.17' from 'http://127.0.0.1:37515'...
copying path '/nix/store/h0x0p1ikp9svk1ri7xxacaczqawyz4sm-numactl-2.0.18' from 'http://127.0.0.1:37515'...
copying path '/nix/store/4k5wayklhvnfqzqp3kcff0g8gfi9hw1c-oniguruma-6.9.10-lib' from 'http://127.0.0.1:37515'...
copying path '/nix/store/ppqag75iayz02cj7ab3frkq0m8zrdfxi-onetbb-2022.3.0' from 'http://127.0.0.1:37515'...
copying path '/nix/store/g7lir5wb7g1a31szgw6n5wa0kbsq04zd-openssl-3.6.0' from 'http://127.0.0.1:37515'...
copying path '/nix/store/wwij6563c6wbg4kzgjhng7vlhf7api19-patch-2.8' from 'http://127.0.0.1:37515'...
copying path '/nix/store/c2p7haf4zzkbrir9zs662r68c5dmylbq-patchelf-0.15.2' from 'http://127.0.0.1:37515'...
copying path '/nix/store/0kgwmi3n8ml2a041a5y9y9ycga3md4dq-pcre2-10.46' from 'http://127.0.0.1:37515'...
copying path '/nix/store/4rxy8jxpq43pk7q1003phghpcyb64vkb-perl5.42.0-CPAN-Meta-Check-0.018' from 'http://127.0.0.1:37515'...
copying path '/nix/store/j00whl78misjdihyhdlmk437dicipfib-perl5.42.0-Canary-Stability-2013' from 'http://127.0.0.1:37515'...
copying path '/nix/store/lf3a8jxvhrs5fd0nbq3iy4j09hi57vib-nghttp3-1.13.1-dev' from 'http://127.0.0.1:37515'...
copying path '/nix/store/mq29ixqd1ghd5rjhjfrp60n1gaaqxf31-perl5.42.0-Class-Singleton-1.6' from 'http://127.0.0.1:37515'...
copying path '/nix/store/blmnas2gb4j00471fq494gc6lr10rafp-perl5.42.0-Clone-0.46' from 'http://127.0.0.1:37515'...
copying path '/nix/store/d33pccb6kzhra878d71xiwm44274zmhi-perl5.42.0-Crypt-URandom-0.54' from 'http://127.0.0.1:37515'...
copying path '/nix/store/nbsn2li6xgfq6513n03vcn0pbiwzhfa9-perl5.42.0-Devel-StackTrace-2.04' from 'http://127.0.0.1:37515'...
copying path '/nix/store/hr7asb01ihjx7d1ilgqknl6nvb4cnshh-perl5.42.0-Digest-HMAC-1.05' from 'http://127.0.0.1:37515'...
copying path '/nix/store/lbl7p052h1gvbqphdvwxxman94bz7mhc-perl5.42.0-Encode-Locale-1.05' from 'http://127.0.0.1:37515'...
copying path '/nix/store/fgsvqffyvcpjqs093wwf2d6dzxnmnqnv-jq-1.8.1' from 'http://127.0.0.1:37515'...
copying path '/nix/store/bc4wvkbw119gfby5if2z6yq3w51shgq9-libblake3-1.8.2' from 'http://127.0.0.1:37515'...
copying path '/nix/store/ngkscv2ic2j72d7990044v3bwapqxqym-perl5.42.0-Eval-Closure-0.14' from 'http://127.0.0.1:37515'...
copying path '/nix/store/qsgxw3cq1wc3bf5bpfr6anfa7xcg1358-perl5.42.0-FCGI-0.82' from 'http://127.0.0.1:37515'...
copying path '/nix/store/p32hghrmdww891fwwcwy8m32c5qlklc9-perl5.42.0-FCGI-ProcManager-0.28' from 'http://127.0.0.1:37515'...
copying path '/nix/store/2a5k15jmd590ybh2gdh5mjy0h7vmfyx0-perl5.42.0-File-ShareDir-1.118' from 'http://127.0.0.1:37515'...
copying path '/nix/store/lq4dsddkbqdr6da0r3vnnm1ncd9n1rba-perl5.42.0-HTML-TagCloud-0.38' from 'http://127.0.0.1:37515'...
copying path '/nix/store/02vv0r262agf9j5n2y1gmbjvdf12zkl0-gnugrep-3.12' from 'http://127.0.0.1:37515'...
copying path '/nix/store/h4qwa74a377wj4xgglkg6wjiwf72ab9z-libselinux-3.8.1' from 'http://127.0.0.1:37515'...
copying path '/nix/store/cnd7bcjxyq3mkim35p3cz8dp4mx8lray-perl5.42.0-HTML-Tagset-3.20' from 'http://127.0.0.1:37515'...
copying path '/nix/store/8rjp0cj4asx2zzpkm4lpya2cyicy8a5p-perl5.42.0-IO-HTML-1.004' from 'http://127.0.0.1:37515'...
copying path '/nix/store/dzmyl82i2hhr0ckw6nvk4nbg6fhd14ll-perl5.42.0-Exception-Class-1.45' from 'http://127.0.0.1:37515'...
copying path '/nix/store/v1qj5val6m0pavn6pvd88l16vs7vhf8w-perl5.42.0-Authen-SASL-2.1900' from 'http://127.0.0.1:37515'...
copying path '/nix/store/xkcmcixv3hdww5x9yqqnvh9k6sy3yqp9-perl5.42.0-LWP-MediaTypes-6.04' from 'http://127.0.0.1:37515'...
copying path '/nix/store/rwlznivjxd53wygwha0ark62yy8ys219-compiler-rt-libc-20.1.8-dev' from 'http://127.0.0.1:37515'...
copying path '/nix/store/jr06ks0jx92yz6vfkgjdpdx3mwh8vy8l-perl5.42.0-MRO-Compat-0.15' from 'http://127.0.0.1:37515'...
copying path '/nix/store/4i0cyrfsvdhmqq98xxb5j1ym6a1zv2mk-perl5.42.0-Module-Runtime-0.016' from 'http://127.0.0.1:37515'...
copying path '/nix/store/bg4xrcp3jpjsh8a0xqx6d2niqhdal9pg-perl5.42.0-Mozilla-CA-20230821' from 'http://127.0.0.1:37515'...
copying path '/nix/store/hj2kp3pq0n334p7smgvndgy3hyg1463j-perl5.42.0-Readonly-2.05' from 'http://127.0.0.1:37515'...
copying path '/nix/store/vl84lh715ns87aiignlknf10224mapaq-perl5.42.0-PathTools-3.75' from 'http://127.0.0.1:37515'...
copying path '/nix/store/vmk56vnz78rz9gjxlgh6ya54044x9prv-perl5.42.0-Role-Tiny-2.002004' from 'http://127.0.0.1:37515'...
copying path '/nix/store/d1n5ga3jck86wrhj0pwz88017qx0iv3n-perl5.42.0-Sub-Exporter-Progressive-0.001013' from 'http://127.0.0.1:37515'...
copying path '/nix/store/cx5jxd7l6m7bwxm4z29xwmiz1b8pz7vq-perl5.42.0-Sub-Identify-0.14' from 'http://127.0.0.1:37515'...
copying path '/nix/store/4nlxwdl1sqgvi46a60vmk0l3vdgzbxp5-perl5.42.0-Params-ValidationCompiler-0.31' from 'http://127.0.0.1:37515'...
copying path '/nix/store/qnaw7i777j52fpgbl5pgmzkq85znp083-jq-1.8.1-bin' from 'http://127.0.0.1:37515'...
copying path '/nix/store/3sz01711qra1gawmzsw71qpdyg27r7nh-perl5.42.0-Sub-Quote-2.006008' from 'http://127.0.0.1:37515'...
copying path '/nix/store/dwl69lprim813i4v6dasi582ab4gznm4-libedit-20251016-3.1' from 'http://127.0.0.1:37515'...
copying path '/nix/store/n7iyqawbhv90ikx7casy5sapwpqj870b-ncurses-6.6-dev' from 'http://127.0.0.1:37515'...
copying path '/nix/store/z7wnnjh9ql68zrfr4m9dz9mkr784dkp2-perl5.42.0-TermReadKey-2.38' from 'http://127.0.0.1:37515'...
copying path '/nix/store/4iqsaypxn63fbbrsfih044ns4ljxijcf-perl5.42.0-Test-Needs-0.002010' from 'http://127.0.0.1:37515'...
copying path '/nix/store/1a6xz5fwvcamk23rjsj79a7v378yzigg-perl5.42.0-Test-Requires-0.11' from 'http://127.0.0.1:37515'...
copying path '/nix/store/31jb75cchmhg8z0dw77j1byw0pjjkb0k-perl5.42.0-Dist-CheckConflicts-0.11' from 'http://127.0.0.1:37515'...
copying path '/nix/store/3hqjmimz9l0821gg3s0c2f45ix5dlnxh-perl5.42.0-Test-RequiresInternet-0.05' from 'http://127.0.0.1:37515'...
copying path '/nix/store/ymg5c4sm915p76lab2wrfkhzhy7lhcbm-perl5.42.0-TimeDate-2.33' from 'http://127.0.0.1:37515'...
copying path '/nix/store/q46m74icglsbbxblbwvah69bxhkryxcn-installFromCargoBuildLogHook' from 'http://127.0.0.1:37515'...
copying path '/nix/store/nj0bggdnc3lb5vnnr0y6s04xz24gfi7f-aws-c-cal-0.9.2' from 'http://127.0.0.1:37515'...
copying path '/nix/store/53a0zhhn109mz9fs9fvvqjimvj0f2srl-cargo-tarpaulin-0.35.1' from 'http://127.0.0.1:37515'...
copying path '/nix/store/hxaad039hqmbdk4b215kxajx3j7iqrfw-cargo-udeps-0.1.60' from 'http://127.0.0.1:37515'...
copying path '/nix/store/hia37415k8ckpwnp8wqi54lw6xfxhvgl-krb5-1.22.1-lib' from 'http://127.0.0.1:37515'...
copying path '/nix/store/y3b549nnjrn2apah7mfwzz6zwnidpflq-icu4c-76.1-dev' from 'http://127.0.0.1:37515'...
copying path '/nix/store/shif2m9jgiddvxy0q4qd2wp7dlxs1rkg-lychee-0.22.0-unstable-2025-12-05' from 'http://127.0.0.1:37515'...
copying path '/nix/store/zi565pibhgz582kxliylqpvmq1gq9z71-ngtcp2-1.18.0' from 'http://127.0.0.1:37515'...
copying path '/nix/store/1p8kvf8pyqb8h85f81vhahyj04wjzv5d-openssl-3.6.0-bin' from 'http://127.0.0.1:37515'...
copying path '/nix/store/72f3lbsj0szyadqbrqidjs52kdl3k4ik-perl5.42.0-Net-SSLeay-1.92' from 'http://127.0.0.1:37515'...
copying path '/nix/store/209048nij35mn980llay0dk5l9zd7rd7-perl5.42.0-Try-Tiny-0.31' from 'http://127.0.0.1:37515'...
copying path '/nix/store/2jqg49kx50za5qxq3v0fyj82jhv14i6n-perl5.42.0-URI-5.21' from 'http://127.0.0.1:37515'...
copying path '/nix/store/9r6cd5ij1ma5kvld6xfiqyr1irnml83v-perl5.42.0-common-sense-3.75' from 'http://127.0.0.1:37515'...
copying path '/nix/store/0cqrh2z4jznc5nzrvfsk6m5smq77gz7r-perl5.42.0-libnet-3.15' from 'http://127.0.0.1:37515'...
copying path '/nix/store/g3kc0p65g67798kkl58k3knrz5xzfqzv-pkg-config-0.29.2' from 'http://127.0.0.1:37515'...
copying path '/nix/store/yywbzjm7yy89y5z23jazngbv4585rqbr-popt-1.19' from 'http://127.0.0.1:37515'...
copying path '/nix/store/jysmr95bcn3xxh5vhvxxfk8dlq4pmwxc-postgresql-17.7-doc' from 'http://127.0.0.1:37515'...
copying path '/nix/store/g9js21qckjnan7v3acw82m6ax59801n5-postgresql-17.7-man' from 'http://127.0.0.1:37515'...
copying path '/nix/store/q5zpk39z2jq0ardi1g6mz7k43hnps2lf-perl5.42.0-HTTP-Date-6.06' from 'http://127.0.0.1:37515'...
copying path '/nix/store/bmhyg1a3szh94p8lc0arcbh5k8m5pigh-perl5.42.0-Net-HTTP-6.23' from 'http://127.0.0.1:37515'...
copying path '/nix/store/z641mcfp9x3q0v2sm4lhy34dkrc67kq3-perl5.42.0-Types-Serialiser-1.01' from 'http://127.0.0.1:37515'...
copying path '/nix/store/99b682kgwcp3944rcq47f3whsfpij80c-ngtcp2-1.18.0-dev' from 'http://127.0.0.1:37515'...
copying path '/nix/store/9z0650vi7qs19aqwwl2b350gfwdz04kr-perl5.42.0-IO-Socket-SSL-2.083' from 'http://127.0.0.1:37515'...
copying path '/nix/store/kpg3xarm646mwaknqjzqd5i1q55qjgxh-perl5.42.0-WWW-RobotRules-6.02' from 'http://127.0.0.1:37515'...
copying path '/nix/store/rvp7qlpf5jqvdckjy1afjb6aha6j8dxg-pkg-config-wrapper-0.29.2' from 'http://127.0.0.1:37515'...
copying path '/nix/store/wzch4417m2inmr4xgh4y43acbbc2m41z-publicsuffix-list-0-unstable-2025-12-28' from 'http://127.0.0.1:37515'...
copying path '/nix/store/6ibw5irnlxyvfm4d2fblb57w5hlmxiy5-perl5.42.0-File-Listing-6.16' from 'http://127.0.0.1:37515'...
copying path '/nix/store/ffx1qbg2658nklqpjri3d4d71jxrnxgm-perl5.42.0-HTTP-CookieJar-0.014' from 'http://127.0.0.1:37515'...
copying path '/nix/store/xps75qp8na3zd39ppaqvxf42g2jqmgbr-perl5.42.0-HTTP-Message-6.45' from 'http://127.0.0.1:37515'...
copying path '/nix/store/8pqj80100baxyhcl9g03b7ywpj4s5mah-readline-8.3p3' from 'http://127.0.0.1:37515'...
copying path '/nix/store/a539lz29hmax56xq74xj428rla4jiars-perl5.42.0-Module-Implementation-0.09' from 'http://127.0.0.1:37515'...
copying path '/nix/store/zgyh1qq7aikx1iqbc0g5wwgfpwfibsf9-perl5.42.0-Specio-0.48' from 'http://127.0.0.1:37515'...
copying path '/nix/store/fgm3pz8486ksh3f94629lpb7xjr2wjp7-openssl-3.6.0-dev' from 'http://127.0.0.1:37515'...
copying path '/nix/store/91837gb92djfh64dp9jbwk8nv9jgnjlq-krb5-1.22.1' from 'http://127.0.0.1:37515'...
copying path '/nix/store/c7iniinll51q40xfrxrjj6kf2ggzgiy9-perl5.42.0-Test-Fatal-0.017' from 'http://127.0.0.1:37515'...
copying path '/nix/store/3fziqvk0v05y5fy9mimflsbwp7n9n6qf-perl5.42.0-Net-SMTP-SSL-1.04' from 'http://127.0.0.1:37515'...
copying path '/nix/store/k7ksxvn6q8qma28276yg0m0smnzkfrdi-postgresql-17.7-lib' from 'http://127.0.0.1:37515'...
copying path '/nix/store/x6qm4b8mikn1kkmdrsx812fi30xvx7wh-reproducible-artifacts-stable-2026-01-22' from 'http://127.0.0.1:37515'...
copying path '/nix/store/hm0ajvpwz1007ych9vz6qkhs06rm9xfx-perl5.42.0-HTML-Parser-3.81' from 'http://127.0.0.1:37515'...
copying path '/nix/store/s32a727k1cxwqz0zzq2fk28jzlnaskkw-perl5.42.0-HTTP-Cookies-6.10' from 'http://127.0.0.1:37515'...
copying path '/nix/store/379bgshl922v3zjx64ljsnnfc3wrl16w-perl5.42.0-HTTP-Daemon-6.16' from 'http://127.0.0.1:37515'...
copying path '/nix/store/x12lw455sq6qy2wcya85d7rb88ybc3df-bash-interactive-5.3p9' from 'http://127.0.0.1:37515'...
copying path '/nix/store/gmhmkl7vnkcwsm9pzykpi3wgwjrlgkwc-libpsl-0.21.5' from 'http://127.0.0.1:37515'...
copying path '/nix/store/pyw98sp2272jr7d1klb0x2xfws3dz7z2-perl5.42.0-HTTP-Negotiate-6.01' from 'http://127.0.0.1:37515'...
copying path '/nix/store/nldbqqf8gsg8h0vqjmb9pg75nxf3iwqn-readline-8.3p3-dev' from 'http://127.0.0.1:37515'...
copying path '/nix/store/7j0kqh3v55332v34nbyxbk99ky182zkp-perl5.42.0-B-Hooks-EndOfScope-0.26' from 'http://127.0.0.1:37515'...
copying path '/nix/store/r17a93q0kz1nzckivh29p9dmw2kbyzhh-rust-src-nightly-complete-2026-02-04' from 'http://127.0.0.1:37515'...
copying path '/nix/store/bn46bwkgipv06pijnr9vhhqqzkxrxfvg-rust-src-stable-2026-01-22' from 'http://127.0.0.1:37515'...
copying path '/nix/store/kyg4nm1mgivfgsmf91449kccgg80x4as-perl5.42.0-CGI-4.59' from 'http://127.0.0.1:37515'...
copying path '/nix/store/n6rm8h57c486hmrqyczg7km3in2rmn50-rust-std-nightly-complete-2026-02-04' from 'http://127.0.0.1:37515'...
copying path '/nix/store/27pirzc2ri5c6cxvzk4pygwm9y29k6b6-rustc-docs-stable-2026-01-22' from 'http://127.0.0.1:37515'...
copying path '/nix/store/qnaj1q3692yw09i8k14k9yixxpl1rqdn-s2n-tls-1.5.27' from 'http://127.0.0.1:37515'...
copying path '/nix/store/3mg43r6bvdvf0zm3rxj1x9v2vwg6kwmn-simdjson-4.2.4' from 'http://127.0.0.1:37515'...
copying path '/nix/store/9iadf2abrkmj2x8whcwf9jif8w9a6pmx-krb5-1.22.1-dev' from 'http://127.0.0.1:37515'...
copying path '/nix/store/7h3jpcp1sl36kcnxjvdnwhcliv7a6lsz-simdutf-6.5.0' from 'http://127.0.0.1:37515'...
copying path '/nix/store/bfpbk8xi48kgb9a1qhpdng7rjmrl5dsx-statix-0.5.8' from 'http://127.0.0.1:37515'...
copying path '/nix/store/wb6qhxgxwcy2b5ik965qvcxkz0di85z8-perl5.42.0-CGI-Fast-2.16' from 'http://127.0.0.1:37515'...
copying path '/nix/store/s4rgqv7brrcq2jm8m00dyair22knq10s-typos-1.42.3' from 'http://127.0.0.1:37515'...
copying path '/nix/store/r29gp232igs3m47s7lfcaalfashd82bf-tzdata-2025c' from 'http://127.0.0.1:37515'...
copying path '/nix/store/y03z7y8cgdck7vk8qpim30vps4d22gzv-update-autotools-gnu-config-scripts-hook' from 'http://127.0.0.1:37515'...
copying path '/nix/store/sc9cwplj8mhb0vh165qnagngb29cxlbr-util-linux-minimal-2.41.3' from 'http://127.0.0.1:37515'...
copying path '/nix/store/8fwg7nzmn4jvyw1r7y1653aiz1gz5d4z-util-linux-minimal-2.41.3-lib' from 'http://127.0.0.1:37515'...
copying path '/nix/store/33qn65idbn06p18ms5c6gy1ywv0ddsp5-aws-c-io-0.22.0' from 'http://127.0.0.1:37515'...
copying path '/nix/store/c2mdl65f2jq8qngj4smb7f8y15zm3s7d-util-linux-minimal-2.41.3-login' from 'http://127.0.0.1:37515'...
copying path '/nix/store/x0bq7h936cp5dz83wq0wdhnimzcy85fd-uvwasi-0.0.23' from 'http://127.0.0.1:37515'...
copying path '/nix/store/y842yg6nv4k8rc9jpcfb93zwzy8pfabj-xxHash-0.8.3' from 'http://127.0.0.1:37515'...
copying path '/nix/store/59k463mhfy0i74i6w7d9jabd2rzand2v-xz-5.8.2' from 'http://127.0.0.1:37515'...
copying path '/nix/store/ri9paa3mri4kqakljak8ldvbcp7lpmif-zlib-1.3.1' from 'http://127.0.0.1:37515'...
copying path '/nix/store/hqjka260vqvnl1k73dwqqqhcx0yiy6c0-zstd-1.5.7' from 'http://127.0.0.1:37515'...
copying path '/nix/store/2xazfdiazlxjphvhqcghy74bj9890vq1-zlib-ng-2.3.2' from 'http://127.0.0.1:37515'...
copying path '/nix/store/j03k2ixa399jyadfkgcjvsl1sid6yli6-systemd-minimal-libs-258.3' from 'http://127.0.0.1:37515'...
copying path '/nix/store/29dp2s13wyawgm1m5kvsl8n4mh107h8r-act-0.2.84' from 'http://127.0.0.1:37515'...
copying path '/nix/store/37v6wknb3fdlgxpgwilffaxipfy8f1fx-gitleaks-8.30.0' from 'http://127.0.0.1:37515'...
copying path '/nix/store/bm9kfmhbvxyr7axhn8qsianz38ck9gkf-tcl-8.6.16' from 'http://127.0.0.1:37515'...
copying path '/nix/store/cjyr0g84h3948zaaxql0p5vnadxsgbdl-aws-c-event-stream-0.5.7' from 'http://127.0.0.1:37515'...
copying path '/nix/store/v8cpwr36769wszzi1j28xqgn2clvb9hs-aws-c-http-0.10.4' from 'http://127.0.0.1:37515'...
copying path '/nix/store/c9fc5jv4nm5c6n60k3m38n57c66hb9i0-binutils-2.44-lib' from 'http://127.0.0.1:37515'...
copying path '/nix/store/nyy0bvgjwd98x7ih8pl6pr79qjljgsf7-file-5.45' from 'http://127.0.0.1:37515'...
copying path '/nix/store/mjf8jlq9grydcdvyw6hb063x5c34g5gf-gcc-15.2.0' from 'http://127.0.0.1:37515'...
copying path '/nix/store/fgzpllmvbk3l258j0f3ib7k44lksbqnp-glib-2.86.3' from 'http://127.0.0.1:37515'...
copying path '/nix/store/2izjh733byjickw9719nnkckxd63ghpm-boost-1.87.0' from 'http://127.0.0.1:37515'...
copying path '/nix/store/fl02yv3ax1qf1xkq64ik8qz5bjxyyd71-cargo-deny-0.19.0' from 'http://127.0.0.1:37515'...
copying path '/nix/store/mrvl2wb00cxdbp68ja94ydw3cc8jbvik-aws-c-auth-0.9.1' from 'http://127.0.0.1:37515'...
copying path '/nix/store/2677y91n9lbabyrqyay8ffb2mjqjik0i-aws-c-mqtt-0.13.3' from 'http://127.0.0.1:37515'...
copying path '/nix/store/47mn80zqpygykqailwzw8zlag4cgl75q-binutils-2.44' from 'http://127.0.0.1:37515'...
copying path '/nix/store/dl74hiicwsr3b9ci8ssmqzr92vd4r2nm-libarchive-3.8.4-lib' from 'http://127.0.0.1:37515'...
copying path '/nix/store/2sxzsi57ps8m5sz3119mqbjk40fdcxk9-libpng-apng-1.6.53' from 'http://127.0.0.1:37515'...
copying path '/nix/store/l4x6bj0296s13skl4b9crll36svhqp14-aws-c-s3-0.8.7' from 'http://127.0.0.1:37515'...
copying path '/nix/store/6jdchk7hlm0mzi9lgq69p0292y7n89vj-libssh2-1.11.1' from 'http://127.0.0.1:37515'...
copying path '/nix/store/3ccwp233h2cxk472x9si9vavhbbdngmf-linux-pam-1.7.1' from 'http://127.0.0.1:37515'...
copying path '/nix/store/iy1z856vk4np905gfvi0rfxng5v1khmn-llvm-20.1.8-lib' from 'http://127.0.0.1:37515'...
copying path '/nix/store/agn116lan9vkc5gvnvs30zrnykvgdq67-aws-crt-cpp-0.34.3' from 'http://127.0.0.1:37515'...
copying path '/nix/store/mjj7524kagv013g0kh0wbw0da62yfr1i-freetype-2.13.3' from 'http://127.0.0.1:37515'...
copying path '/nix/store/8ylzjm58ghiq60vklfy58j14sgryjjzw-curl-8.17.0' from 'http://127.0.0.1:37515'...
copying path '/nix/store/h3q8dijig03n22q4gh338y7vwniy25ay-libgit2-1.9.2-lib' from 'http://127.0.0.1:37515'...
copying path '/nix/store/chqgdbzpa05cai3spap6l8iz948vnzf2-libwebp-1.6.0' from 'http://127.0.0.1:37515'...
copying path '/nix/store/cmpddlfv1l4g1y77z7g8pxmdhsqjz0w1-fontconfig-2.17.1-lib' from 'http://127.0.0.1:37515'...
copying path '/nix/store/psnn2m4cd0d1rjdwa6rhnmz2pwiiv70i-llvm-tools-preview-nightly-complete-2026-02-04' from 'http://127.0.0.1:37515'...
copying path '/nix/store/alpfi0ywl9ya3hzl7a2wiq7ha1vjg9qa-llvm-tools-preview-stable-2026-01-22' from 'http://127.0.0.1:37515'...
copying path '/nix/store/gkna718gf9x6xjzv8yjlyrbqvv695d0l-mold-unwrapped-2.40.4' from 'http://127.0.0.1:37515'...
copying path '/nix/store/xvi39ds16r6nym6n4ygnz20grmw8zjap-nghttp2-1.67.1' from 'http://127.0.0.1:37515'...
copying path '/nix/store/i60mhv6blia5vcbd735fnj9869zf74si-nix-util-2.33.1+1' from 'http://127.0.0.1:37515'...
copying path '/nix/store/0m9dv7ml6vddmxj79s98l102d03sf9f1-perl-5.42.0' from 'http://127.0.0.1:37515'...
copying path '/nix/store/wf2yfa70lv7n5mg839h7i84ci73v9n37-elfutils-0.194' from 'http://127.0.0.1:37515'...
copying path '/nix/store/ygn5gy4adsyxqmbf0h2d9830p3jbfj5c-libtiff-4.7.1' from 'http://127.0.0.1:37515'...
copying path '/nix/store/4ymb19kxf4jhvxgpgcpla0v873fj6gk7-postgresql-17.7' from 'http://127.0.0.1:37515'...
copying path '/nix/store/ijrb2qkj27mzy3b5gswxnr3mqir8sv0g-nghttp2-1.67.1-dev' from 'http://127.0.0.1:37515'...
copying path '/nix/store/pgjja711w3aysxqd3g67zfmpgnx8smfy-rsync-3.4.1' from 'http://127.0.0.1:37515'...
copying path '/nix/store/miayv1fzd5n6491zsgb3293r84195lff-babeltrace-1.5.11' from 'http://127.0.0.1:37515'...
copying path '/nix/store/l3b4wkn2jks8i4nwk75p8ydjwa2z2plk-hadolint-2.14.0' from 'http://127.0.0.1:37515'...
copying path '/nix/store/izs6bs8fflbyg7djv7p1c753jyinxvx3-gdk-pixbuf-2.44.4' from 'http://127.0.0.1:37515'...
copying path '/nix/store/cqa5y7jmlaby9hz2khcpryv2z27n2wri-libwebp-1.6.0' from 'http://127.0.0.1:37515'...
copying path '/nix/store/gjnid5brvaczfgqmz91jxw4vb9mlm9xw-nix-output-monitor-2.1.8' from 'http://127.0.0.1:37515'...
copying path '/nix/store/3kbpzb543xb0yij5pylnjfjgf82hgqm9-rust-stable-2026-01-22' from 'http://127.0.0.1:37515'...
copying path '/nix/store/x6gk6w0cda5m41p9ghvq7qcnv431x4rh-rustc-nightly-complete-2026-02-04' from 'http://127.0.0.1:37515'...
copying path '/nix/store/i6ppbrlpp6yki8qvka7nyv091xa8dchx-binutils-wrapper-2.44' from 'http://127.0.0.1:37515'...
copying path '/nix/store/ghz6z8fvri862mgdg5kl95cpfls931h5-shellcheck-0.11.0-bin' from 'http://127.0.0.1:37515'...
copying path '/nix/store/akyk771cdl3vfmr1cmyzxv807xq71c21-libavif-1.3.0' from 'http://127.0.0.1:37515'...
copying path '/nix/store/lzmwqivfbcmdbhhsf1bfrrf97d25pa8z-slang-2.3.3' from 'http://127.0.0.1:37515'...
copying path '/nix/store/bn7m7qn8k7b27jy5lkq3bg4vcxnyjpq0-sqlite-3.51.2' from 'http://127.0.0.1:37515'...
copying path '/nix/store/qr1xrmpcizc6cfs683vi4ldkfdijsfj7-gd-2.3.3' from 'http://127.0.0.1:37515'...
copying path '/nix/store/ryc68h6m05msqkf2wqm306cwrvx2fqr2-sqlite-3.51.2-bin' from 'http://127.0.0.1:37515'...
copying path '/nix/store/zrh7hlkglk74pix0bczhkslw2w4qdpzg-shellcheck-0.11.0' from 'http://127.0.0.1:37515'...
copying path '/nix/store/1kw1drg8bbv97lpp7z6fsl7k78v0pnxs-systemd-minimal-libs-258.3-dev' from 'http://127.0.0.1:37515'...
copying path '/nix/store/h4i7isda5kz7r8m2zjxy1lla5aw7m6bx-util-linux-minimal-2.41.3-mount' from 'http://127.0.0.1:37515'...
copying path '/nix/store/xnpaz2kkn0iwy8xywk70ab9ww9yq7s20-nix-store-2.33.1+1' from 'http://127.0.0.1:37515'...
copying path '/nix/store/slhpx9glq7vl99bwi93bgrhn3syv98s1-python3-3.13.11' from 'http://127.0.0.1:37515'...
copying path '/nix/store/6k6dpcdv1bxcipcgdbi89g9fxws0vhvc-sqlite-3.51.2-dev' from 'http://127.0.0.1:37515'...
copying path '/nix/store/40hw42yqxg3ppycayx9lqm24icl1z82z-util-linux-minimal-2.41.3-swap' from 'http://127.0.0.1:37515'...
copying path '/nix/store/zys6d102zp171wpwcs08g632886w2qxs-xz-5.8.2-bin' from 'http://127.0.0.1:37515'...
copying path '/nix/store/wlafyp4d5mjdfvkj88m4l2a84fzcxjfv-zlib-1.3.1-dev' from 'http://127.0.0.1:37515'...
copying path '/nix/store/8p25dmhc71km8cnxk7gdfpqbr8aihx0p-zstd-1.5.7-bin' from 'http://127.0.0.1:37515'...
copying path '/nix/store/99212qy5fiz2kwlsfhm4xav727brhsf2-util-linux-minimal-2.41.3-bin' from 'http://127.0.0.1:37515'...
copying path '/nix/store/gvqdhbqc83w6bxxv0y6iyx78da8flpkq-mold-unwrapped-wrapper-2.40.4' from 'http://127.0.0.1:37515'...
copying path '/nix/store/1bcqjd3dfxv0lp607dqfwffrxx8srvrk-nix-main-2.33.1+1' from 'http://127.0.0.1:37515'...
copying path '/nix/store/j7l4vbhljna662i19v4g8d2jm2caizw5-nix-fetchers-2.33.1+1' from 'http://127.0.0.1:37515'...
copying path '/nix/store/jqg7km1ki8in7njqn4q0095p10w8fgm0-zstd-1.5.7-dev' from 'http://127.0.0.1:37515'...
copying path '/nix/store/wli083md87aqp0rcpc3qdwvj13n6dfrn-nix-expr-2.33.1+1' from 'http://127.0.0.1:37515'...
copying path '/nix/store/9cyx2v23dip6p9q98384k9v06c96qskb-nodejs-24.13.0' from 'http://127.0.0.1:37515'...
copying path '/nix/store/yy54fq8g6n7snqginvx7m933c2acwq7g-util-linux-minimal-2.41.3-dev' from 'http://127.0.0.1:37515'...
copying path '/nix/store/sds7kgcxwxa6x073qyj0azcg9jmil6qv-nix-flake-2.33.1+1' from 'http://127.0.0.1:37515'...
copying path '/nix/store/5cxdlnzr361ag1b6ir5zg3wb1i1akann-nix-cmd-2.33.1+1' from 'http://127.0.0.1:37515'...
copying path '/nix/store/zwy0n9fhlc07avqb9qph4grlv4gpbnzh-nix-2.33.1+1' from 'http://127.0.0.1:37515'...
copying path '/nix/store/qqk4ljr77yyq425kla5hkcs6b1xridnm-nix-eval-jobs-2.33.0' from 'http://127.0.0.1:37515'...
copying path '/nix/store/2zxbb8v6hy0ilsvmmkbvxg6cr2nv6kvs-perl5.42.0-Devel-Cover-1.44' from 'http://127.0.0.1:37515'...
copying path '/nix/store/rlzla4s39f4xq5xw6hdwv96p4f4y48qv-perl5.42.0-GD-2.78' from 'http://127.0.0.1:37515'...
copying path '/nix/store/6r6996j047dmsv8bax2srw5s6r03kg3i-perl5.42.0-Memory-Usage-0.201' from 'http://127.0.0.1:37515'...
copying path '/nix/store/vj8rwrb5h5bdfqz93n1nzjzz1zq3gwlx-perl5.42.0-JSON-XS-4.03' from 'http://127.0.0.1:37515'...
copying path '/nix/store/ipw5kzwbw81zlzy7hk7z97gccqxplvpp-perl5.42.0-Package-Stash-0.40' from 'http://127.0.0.1:37515'...
copying path '/nix/store/88fp95r3jzqs9q641sljw0zm737m2zfx-perl5.42.0-libwww-perl-6.72' from 'http://127.0.0.1:37515'...
copying path '/nix/store/1a8ycwf0rq2r540sr9j2yxvzphivh6ys-perl5.42.0-namespace-clean-0.27' from 'http://127.0.0.1:37515'...
copying path '/nix/store/v4fqxks13hw3r53yz9m1jih7xp82rnlv-perl5.42.0-Memory-Process-0.06' from 'http://127.0.0.1:37515'...
copying path '/nix/store/5g2lnzy4c7w0qw6xasp1x99gqnw3zcma-perl5.42.0-namespace-autoclean-0.29' from 'http://127.0.0.1:37515'...
copying path '/nix/store/6fh6yi9pxp4s8c90pfp5akq5adwg78k3-perl5.42.0-DateTime-Locale-1.39' from 'http://127.0.0.1:37515'...
copying path '/nix/store/yc50pcz7g2sj86b5gmvpbbw69y5p5dz4-perl5.42.0-DateTime-TimeZone-2.60' from 'http://127.0.0.1:37515'...
copying path '/nix/store/ghw61nixnxfa6yllm6vwv2w6h6i48xag-perl5.42.0-DateTime-1.59' from 'http://127.0.0.1:37515'...
copying path '/nix/store/15ivbqf28nbckmhx4lf1wqlljqnjbdmw-perl5.42.0-DateTime-Format-W3CDTF-0.08' from 'http://127.0.0.1:37515'...
copying path '/nix/store/0xf3ga1c7hapnxk75f6b98qhw4nnggn8-prettier-3.6.2' from 'http://127.0.0.1:37515'...
copying path '/nix/store/ipwndaag56mm8g8gn8j98z0jvn8x4mk1-git-2.52.0' from 'http://127.0.0.1:37515'...
copying path '/nix/store/6lqi98faw9z33wcs8g50lvb0qvkwrsvh-lcov-2.3.2' from 'http://127.0.0.1:37515'...
copying path '/nix/store/v58pqr1g3lki5nshvvzxkyc7h0l2a2xm-markdownlint-cli-0.47.0' from 'http://127.0.0.1:37515'...
copying path '/nix/store/58icaj94qjmi4xn1gdiz5kir5k7br8kv-nix-fast-build-1.3.0' from 'http://127.0.0.1:37515'...
copying path '/nix/store/6v5i77yvcr2xa4pyalk050fz6wgq6mj4-perf-linux-6.18.8' from 'http://127.0.0.1:37515'...
copying path '/nix/store/7vc1dbsdsi2wmals0rva6574vvrc9j0k-python3.13-pathspec-0.12.1' from 'http://127.0.0.1:37515'...
copying path '/nix/store/7kramlhm4r2gyyrqhsryl9vsgw675i8y-python3.13-pyflakes-3.4.0' from 'http://127.0.0.1:37515'...
copying path '/nix/store/bdyka6dsdzj58r53a7pbmkzbss08b402-python3.13-pyyaml-6.0.3' from 'http://127.0.0.1:37515'...
copying path '/nix/store/r9iw80i3mm22lj116h1bxvnc53kkry2s-actionlint-1.7.10' from 'http://127.0.0.1:37515'...
copying path '/nix/store/lzwcf9qa8his4m3damb4q6h2d9ijvfhz-python3.13-yamllint-1.37.1' from 'http://127.0.0.1:37515'...
copying path '/nix/store/lh72rffv70s5q43iv165l4ypk73v2mjy-cargo-flamegraph-0.6.11' from 'http://127.0.0.1:37515'...
copying path '/nix/store/h2bxvkyqga65jbq9lbck7vql6vh11lhc-rust-nightly-complete-with-components-2026-02-04' from 'http://127.0.0.1:37515'...
copying path '/nix/store/a245z3cvf9x9sn0xlk6k8j9xhxbhda1z-gcc-wrapper-15.2.0' from 'http://127.0.0.1:37515'...
copying path '/nix/store/h4jg0ngkjwv2hzx4nn4s65cm3c5vn8cr-release-plz-0.3.153' from 'http://127.0.0.1:37515'...
copying path '/nix/store/gidygr7l2i5kckd3zv9kfjcymxcycw6y-stdenv-linux' from 'http://127.0.0.1:37515'...
copying path '/nix/store/18jb4d150l7hfmcjxhz6r4kcpf8hy0r2-miri-preview-nightly-complete-2026-02-04' from 'http://127.0.0.1:37515'...
copying path '/nix/store/b3fq13mfl2hnn9qp13xx0p57h17mcmks-rustfmt-preview-nightly-complete-2026-02-04' from 'http://127.0.0.1:37515'...
copying path '/nix/store/v7rsm55a01kgynz44aq80is1bfnzsjb1-rust-nightly-complete-with-components-2026-02-04' from 'http://127.0.0.1:37515'...
copying path '/nix/store/74xg3a74swnbay6pga4dzn780rnyriv6-rust-nightly-complete-with-components-2026-02-04' from 'http://127.0.0.1:37515'...
copying path '/nix/store/pgiv6j3dsm3hkkbc1kkva0lg11n67w4w-clang-20.1.8-lib' from 'http://127.0.0.1:37515'...
copying path '/nix/store/fckd7y1w94w2jqp0gsap96hzw9vgs2k6-lld-20.1.8' from 'http://127.0.0.1:37515'...
copying path '/nix/store/d59ilnaw045vi30lm0cg356kqhxl7hjk-llvm-20.1.8' from 'http://127.0.0.1:37515'...
copying path '/nix/store/zadv2dy9r335m5bznx2gvrb2hpbrzcdw-llvm-binutils-20.1.8' from 'http://127.0.0.1:37515'...
copying path '/nix/store/hmwxs0dxr2dw13jfm2wik0a8p00z94p6-llvm-20.1.8-dev' from 'http://127.0.0.1:37515'...
copying path '/nix/store/hxcj7rwwp4xb6i79x81rr8d5ykkaww17-llvm-binutils-wrapper-20.1.8' from 'http://127.0.0.1:37515'...
copying path '/nix/store/5vrd2z4304jl42z4w51npwvs0kj7lazi-cargo-nightly' from 'http://127.0.0.1:37515'...
copying path '/nix/store/b0i3ysr2vnap73l0a8agfwxidx77sz8p-clang-20.1.8' from 'http://127.0.0.1:37515'...
copying path '/nix/store/jn513w7h9hcl6qs9lj7fkzchna5vsjjk-clang-wrapper-20.1.8' from 'http://127.0.0.1:37515'...
copying path '/nix/store/c0lzaq5al5rh9a6ssi2lvi01ca27db0c-postgresql-17.7-dev' from 'http://127.0.0.1:37515'...
copying path '/nix/store/h27rgraygvzlvgjjk30n7fljd7i5hd5g-rust-stable-2026-01-22' from 'http://127.0.0.1:37515'...
copying path '/nix/store/fzhfzy1wb07dbbi9q32dgqdjg55w1jbz-eidetica-env' from 'http://127.0.0.1:37515'...
this path will be fetched (0.0 KiB download, 107.4 KiB unpacked):
  /nix/store/1yg24id0csjk4nq1a3apimwf8dqisr9d-bash-interactive-5.3p9-man
copying path '/nix/store/1yg24id0csjk4nq1a3apimwf8dqisr9d-bash-interactive-5.3p9-man' from 'http://127.0.0.1:37515'...
Eidetica Development Shell

Run 'just' to see available commands

    Updating crates.io index
     Locking 93 packages to latest compatible versions
    Updating anyhow v1.0.100 -> v1.0.102
    Updating arc-swap v1.8.1 -> v1.8.2
      Adding aws-lc-rs v1.16.0
      Adding aws-lc-sys v0.37.1
    Updating bitflags v2.10.0 -> v2.11.0
    Updating bumpalo v3.19.1 -> v3.20.2
    Updating cc v1.2.55 -> v1.2.56
      Adding cesu8 v1.1.0
    Updating chrono v0.4.43 -> v0.4.44
    Updating clap v4.5.57 -> v4.5.60
    Updating clap_builder v4.5.57 -> v4.5.60
    Updating clap_lex v0.7.7 -> v1.0.0
      Adding cmake v0.1.57
      Adding combine v4.6.7
      Adding core-foundation v0.10.1
    Updating der v0.8.0-rc.10 -> v0.8.0
    Updating deranged v0.5.5 -> v0.5.8
      Adding dunce v1.0.5
      Adding fs_extra v1.3.0
    Updating futures v0.3.31 -> v0.3.32
    Updating futures-buffered v0.2.12 -> v0.2.13
    Updating futures-channel v0.3.31 -> v0.3.32
    Updating futures-core v0.3.31 -> v0.3.32
    Updating futures-executor v0.3.31 -> v0.3.32
    Updating futures-io v0.3.31 -> v0.3.32
    Updating futures-macro v0.3.31 -> v0.3.32
    Updating futures-sink v0.3.31 -> v0.3.32
    Updating futures-task v0.3.31 -> v0.3.32
    Updating futures-util v0.3.31 -> v0.3.32
      Adding getrandom v0.4.1
      Adding id-arena v2.3.0
      Adding jni v0.21.1
      Adding jni-sys v0.3.0
      Adding jobserver v0.1.34
    Updating js-sys v0.3.85 -> v0.3.91
      Adding leb128fmt v0.1.0
    Updating libc v0.2.180 -> v0.2.182
    Updating libredox v0.1.12 -> v0.1.14
    Updating linux-raw-sys v0.11.0 -> v0.12.1
    Updating memchr v2.7.6 -> v2.8.0
      Adding openssl-probe v0.2.1
    Updating pin-project v1.1.10 -> v1.1.11
    Updating pin-project-internal v1.1.10 -> v1.1.11
    Updating pin-project-lite v0.2.16 -> v0.2.17
    Updating pkarr v5.0.2 -> v5.0.3
    Updating pkcs8 v0.11.0-rc.10 -> v0.11.0-rc.11
      Adding plain v0.2.3
      Adding prettyplease v0.2.37
    Updating redox_syscall v0.7.0 -> v0.7.3
    Updating regex-syntax v0.8.9 -> v0.8.10
      Adding reqwest v0.13.2
    Updating rustix v1.1.3 -> v1.1.4
    Updating rustls v0.23.36 -> v0.23.37
      Adding rustls-native-certs v0.8.3
      Adding rustls-platform-verifier v0.6.2
      Adding rustls-platform-verifier-android v0.1.1
    Updating ryu v1.0.22 -> v1.0.23
      Adding schannel v0.1.28
      Adding security-framework v3.7.0
      Adding security-framework-sys v2.17.0
    Updating syn v2.0.114 -> v2.0.117
    Updating tempfile v3.24.0 -> v3.26.0
    Updating toml_parser v1.0.6+spec-1.1.0 -> v1.0.9+spec-1.1.0
    Updating unicode-ident v1.0.22 -> v1.0.24
    Updating uuid v1.20.0 -> v1.21.0
      Adding wasip3 v0.4.0+wasi-0.3.0-rc-2026-01-06
    Updating wasm-bindgen v0.2.108 -> v0.2.114
    Updating wasm-bindgen-futures v0.4.58 -> v0.4.64
    Updating wasm-bindgen-macro v0.2.108 -> v0.2.114
    Updating wasm-bindgen-macro-support v0.2.108 -> v0.2.114
    Updating wasm-bindgen-shared v0.2.108 -> v0.2.114
      Adding wasm-encoder v0.244.0
      Adding wasm-metadata v0.244.0
      Adding wasmparser v0.244.0
    Updating web-sys v0.3.85 -> v0.3.91
      Adding webpki-root-certs v1.0.6
      Adding windows-sys v0.45.0
      Adding windows-targets v0.42.2
      Adding windows_aarch64_gnullvm v0.42.2
      Adding windows_aarch64_msvc v0.42.2
      Adding windows_i686_gnu v0.42.2
      Adding windows_i686_msvc v0.42.2
      Adding windows_x86_64_gnu v0.42.2
      Adding windows_x86_64_gnullvm v0.42.2
      Adding windows_x86_64_msvc v0.42.2
      Adding wit-bindgen-core v0.51.0
      Adding wit-bindgen-rust v0.51.0
      Adding wit-bindgen-rust-macro v0.51.0
      Adding wit-component v0.244.0
      Adding wit-parser v0.244.0
    Updating zerocopy v0.8.38 -> v0.8.40
    Updating zerocopy-derive v0.8.38 -> v0.8.40
    Updating zmij v1.0.19 -> v1.0.21
note: pass `--verbose` to see 8 unchanged dependencies behind latest
```

</details>

<details>
<summary>Diff stats</summary>

```
 Cargo.lock | 815 ++++++++++++++++++++++++++++++++++++++++++++++++-------------
 1 file changed, 639 insertions(+), 176 deletions(-)
```

</details>

### Hold

This PR is on hold until **2026-03-08** (7-day waiting period).
The `on-hold` label will be automatically removed after the hold expires.

<!-- hold-until: 2026-03-08 -->