### PR TITLE
chore(deps): update cargo dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,7 +20,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -78,9 +78,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -93,15 +93,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -128,15 +128,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arc-swap"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ded5f9a03ac8f24d1b8a25101ee812cd32cdc8c50a4c50237de2c4915850e73"
+checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
 dependencies = [
  "rustversion",
 ]
@@ -149,7 +149,7 @@ checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
 dependencies = [
  "base64ct",
  "blake2",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "password-hash",
 ]
 
@@ -197,7 +197,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -261,6 +261,28 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
 
 [[package]]
 name = "axum"
@@ -380,9 +402,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 dependencies = [
  "serde_core",
 ]
@@ -420,16 +442,16 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.3"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -461,9 +483,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytemuck"
@@ -509,13 +531,21 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.55"
+version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
+checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -531,9 +561,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -596,9 +626,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.57"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -606,9 +636,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.57"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -618,21 +648,30 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.7"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "cobs"
@@ -645,9 +684,19 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "compact_str"
@@ -727,6 +776,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -746,6 +805,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -855,7 +923,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -944,7 +1012,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto 0.2.9",
@@ -960,7 +1028,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f9200d1d13637f15a6acb71e758f64624048d85b31a5fdbfd8eca1e2687d0b7"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.11.0-rc.10",
  "fiat-crypto 0.3.0",
@@ -979,7 +1047,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1013,7 +1081,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1026,7 +1094,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1037,7 +1105,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1048,7 +1116,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1088,7 +1156,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1110,9 +1178,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.8.0-rc.10"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c1d73e9668ea6b6a28172aa55f3ebec38507131ce179051c8033b5c6037653"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
 dependencies = [
  "const-oid 0.10.2",
  "pem-rfc7468 1.0.0",
@@ -1121,9 +1189,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
 ]
@@ -1146,7 +1214,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1156,7 +1224,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1178,7 +1246,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.114",
+ "syn 2.0.117",
  "unicode-xid",
 ]
 
@@ -1217,7 +1285,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "block2",
  "libc",
  "objc2",
@@ -1231,7 +1299,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1276,6 +1344,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1297,7 +1371,7 @@ version = "3.0.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6e914c7c52decb085cea910552e24c63ac019e3ab8bf001ff736da9a9d9d890"
 dependencies = [
- "pkcs8 0.11.0-rc.10",
+ "pkcs8 0.11.0-rc.11",
  "serde",
  "signature 3.0.0-rc.10",
 ]
@@ -1356,7 +1430,7 @@ dependencies = [
  "postcard",
  "postcard-derive",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_ipld_dagcbor",
  "serde_json",
@@ -1382,7 +1456,7 @@ dependencies = [
  "base64ct",
  "clap",
  "eidetica",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tokio",
@@ -1423,7 +1497,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1434,7 +1508,7 @@ checksum = "3ed8956bd5c1f0415200516e78ff07ec9e16415ade83c056c230d7b7ea0d55b7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1466,9 +1540,9 @@ dependencies = [
 
 [[package]]
 name = "euclid"
-version = "0.22.13"
+version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df61bf483e837f88d5c2291dcf55c67be7e676b3a51acc48db3a7b163b91ed63"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
 dependencies = [
  "num-traits",
 ]
@@ -1635,10 +1709,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.31"
+name = "fs_extra"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1651,9 +1731,9 @@ dependencies = [
 
 [[package]]
 name = "futures-buffered"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8e0e1f38ec07ba4abbde21eed377082f17ccb988be9d988a5adbf4bafc118fd"
+checksum = "4421cb78ee172b6b06080093479d3c50f058e7c81b7d577bbb8d118d551d4cd5"
 dependencies = [
  "cordyceps",
  "diatomic-waker",
@@ -1664,9 +1744,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1674,15 +1754,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1702,9 +1782,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-lite"
@@ -1721,32 +1801,32 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1756,7 +1836,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -1807,8 +1886,23 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
  "wasm-bindgen",
 ]
 
@@ -1881,7 +1975,7 @@ checksum = "e46dbf6b28fbb72d11388a8664af3a63e34b5fcaa61ad8b1e36012a8d556c902"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2083,18 +2177,18 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.7"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1b229d73f5803b562cc26e4da0396c8610a4ee209f4fac8fa4f8d709166dc45"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2107,7 +2201,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -2147,7 +2240,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -2259,6 +2352,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2320,6 +2419,8 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2342,27 +2443,28 @@ dependencies = [
 
 [[package]]
 name = "instability"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357b7205c6cd18dd2c86ed312d1e70add149aea98e7ef72b9fdf0270e555c11d"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
  "darling 0.23.0",
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "ipconfig"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 dependencies = [
- "socket2 0.5.10",
+ "socket2",
  "widestring",
- "windows-sys 0.48.0",
- "winreg",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2378,15 +2480,15 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -2423,10 +2525,10 @@ dependencies = [
  "papaya",
  "pin-project",
  "pkarr",
- "pkcs8 0.11.0-rc.10",
+ "pkcs8 0.11.0-rc.11",
  "portmapper",
  "rand 0.9.2",
- "reqwest",
+ "reqwest 0.12.28",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
@@ -2467,13 +2569,14 @@ dependencies = [
 
 [[package]]
 name = "iroh-metrics"
-version = "0.38.2"
+version = "0.38.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c946095f060e6e59b9ff30cc26c75cdb758e7fb0cde8312c89e2144654989fcb"
+checksum = "761b45ba046134b11eb3e432fa501616b45c4bf3a30c21717578bc07aa6461dd"
 dependencies = [
  "iroh-metrics-derive",
  "itoa",
  "n0-error",
+ "portable-atomic",
  "postcard",
  "ryu",
  "serde",
@@ -2489,7 +2592,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2505,7 +2608,7 @@ dependencies = [
  "pin-project-lite",
  "rustc-hash",
  "rustls",
- "socket2 0.6.2",
+ "socket2",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -2547,7 +2650,7 @@ checksum = "f981dadd5a072a9e0efcd24bdcc388e570073f7e51b33505ceb1ef4668c80c86"
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.6.2",
+ "socket2",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -2581,7 +2684,7 @@ dependencies = [
  "pkarr",
  "postcard",
  "rand 0.9.2",
- "reqwest",
+ "reqwest 0.12.28",
  "rustls",
  "rustls-pki-types",
  "serde",
@@ -2639,25 +2742,81 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "kasuari"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fe90c1150662e858c7d5f945089b7517b0a80d8bf7ba4b1b5ffc984e7230a5b"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
 dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
@@ -2670,7 +2829,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -2689,10 +2848,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.180"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.183"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libm"
@@ -2702,13 +2867,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.12"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "libc",
- "redox_syscall 0.7.0",
+ "plain",
+ "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -2724,18 +2890,18 @@ dependencies = [
 
 [[package]]
 name = "line-clipping"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4de44e98ddbf09375cbf4d17714d18f39195f4f4894e8524501726fd9a8a4a"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -2816,7 +2982,7 @@ checksum = "757aee279b8bdbb9f9e676796fd459e4207a1f986e87886700abf589f5abf771"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2846,9 +3012,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmem"
@@ -2879,9 +3045,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "log",
@@ -2891,9 +3057,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.13"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac832c50ced444ef6be0767a008b02c106a909ba79d1d830501e94b96f6b7e"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
@@ -2968,7 +3134,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -2990,7 +3156,7 @@ checksum = "03755949235714b2b307e5ae89dd8c1c2531fb127d9b8b7b4adf9c876cd3ed18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3027,9 +3193,9 @@ dependencies = [
 
 [[package]]
 name = "netdev"
-version = "0.40.0"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc9815643a243856e7bd84524e1ff739e901e846cfb06ad9627cd2b6d59bd737"
+checksum = "1b0a0096d9613ee878dba89bbe595f079d373e3f1960d882e4f2f78ff9c30a0a"
 dependencies = [
  "block2",
  "dispatch2",
@@ -3038,7 +3204,7 @@ dependencies = [
  "libc",
  "mac-addr",
  "netlink-packet-core",
- "netlink-packet-route 0.25.1",
+ "netlink-packet-route 0.29.0",
  "netlink-sys",
  "objc2-core-foundation",
  "objc2-system-configuration",
@@ -3058,11 +3224,11 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.25.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ec2f5b6839be2a19d7fa5aab5bc444380f6311c2b693551cb80f45caaa7b5ef"
+checksum = "4ce3636fa715e988114552619582b530481fd5ef176a1e5c1bf024077c2c9445"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "libc",
  "log",
  "netlink-packet-core",
@@ -3070,11 +3236,11 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ce3636fa715e988114552619582b530481fd5ef176a1e5c1bf024077c2c9445"
+checksum = "df9854ea6ad14e3f4698a7f03b65bce0833dd2d81d594a0e4a984170537146b6"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "libc",
  "log",
  "netlink-packet-core",
@@ -3132,7 +3298,7 @@ dependencies = [
  "objc2-system-configuration",
  "pin-project-lite",
  "serde",
- "socket2 0.6.2",
+ "socket2",
  "time",
  "tokio",
  "tokio-util",
@@ -3149,7 +3315,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3208,9 +3374,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-derive"
@@ -3220,7 +3386,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3255,9 +3421,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
  "num_enum_derive",
  "rustversion",
@@ -3265,14 +3431,14 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3299,7 +3465,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "block2",
  "dispatch2",
  "libc",
@@ -3318,7 +3484,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -3329,7 +3495,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "dispatch2",
  "libc",
  "objc2",
@@ -3339,9 +3505,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 dependencies = [
  "critical-section",
  "portable-atomic",
@@ -3366,6 +3532,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "ordered-float"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3386,9 +3558,9 @@ dependencies = [
 
 [[package]]
 name = "papaya"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92dd0b07c53a0a0c764db2ace8c541dc47320dad97c2200c2a637ab9dd2328f"
+checksum = "997ee03cd38c01469a7046643714f0ad28880bcb9e6679ff0666e24817ca19b7"
 dependencies = [
  "equivalent",
  "seize",
@@ -3494,7 +3666,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3557,7 +3729,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3571,41 +3743,35 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkarr"
-version = "5.0.2"
+version = "5.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d346b545765a0ef58b6a7e160e17ddaa7427f439b7b9a287df6c88c9e04bf2"
+checksum = "d7bfb9143bbba379f246211eb68074d78db9cc048e4c5701f3b0e6cb1ec67ca2"
 dependencies = [
  "async-compat",
  "base32",
@@ -3616,11 +3782,11 @@ dependencies = [
  "ed25519-dalek 3.0.0-pre.1",
  "futures-buffered",
  "futures-lite",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "log",
  "lru",
  "ntimestamp",
- "reqwest",
+ "reqwest 0.13.2",
  "self_cell",
  "serde",
  "sha1_smol",
@@ -3655,11 +3821,11 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.11.0-rc.10"
+version = "0.11.0-rc.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b226d2cc389763951db8869584fd800cbbe2962bf454e2edeb5172b31ee99774"
+checksum = "12922b6296c06eb741b02d7b5161e3aaa22864af38dfa025a1a3ba3f68c84577"
 dependencies = [
- "der 0.8.0-rc.10",
+ "der 0.8.0",
  "spki 0.8.0-rc.4",
 ]
 
@@ -3668,6 +3834,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
@@ -3717,7 +3889,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -3727,6 +3899,9 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "portmapper"
@@ -3749,7 +3924,7 @@ dependencies = [
  "rand 0.9.2",
  "serde",
  "smallvec",
- "socket2 0.6.2",
+ "socket2",
  "time",
  "tokio",
  "tokio-util",
@@ -3780,7 +3955,7 @@ checksum = "e0232bd009a197ceec9cc881ba46f727fcd8060a2d8d6a9dde7a69030a6fe2bb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3808,10 +3983,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-crate"
-version = "3.4.0"
+name = "prettyplease"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
 ]
@@ -3847,7 +4032,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.2",
+ "socket2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3856,10 +4041,11 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -3884,16 +4070,16 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.2",
+ "socket2",
  "tracing",
  "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -3903,6 +4089,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -3983,7 +4175,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "compact_str",
  "hashbrown 0.16.1",
  "indoc",
@@ -4035,7 +4227,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "hashbrown 0.16.1",
  "indoc",
  "instability",
@@ -4074,16 +4266,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -4111,9 +4303,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -4154,6 +4346,41 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -4207,9 +4434,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -4222,11 +4449,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -4235,10 +4462,11 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -4246,6 +4474,18 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -4259,11 +4499,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-webpki"
-version = "0.103.9"
+name = "rustls-platform-verifier"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -4277,9 +4545,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -4288,6 +4556,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4301,6 +4578,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "seize"
@@ -4367,7 +4667,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4425,7 +4725,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -4442,7 +4742,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -4453,7 +4753,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1e3878ab0f98e35b2df35fe53201d088299b41a6bb63e3e34dada2ac4abd924"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.11.0-rc.10",
 ]
 
@@ -4537,11 +4837,11 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simple-dns"
-version = "0.9.3"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee851d0e5e7af3721faea1843e8015e820a234f81fda3dea9247e15bac9a86a"
+checksum = "df350943049174c4ae8ced56c604e28270258faec12a6a48637a7655287c9ce0"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -4576,22 +4876,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
-dependencies = [
- "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4608,7 +4898,7 @@ checksum = "c87e960f4dca2788eeb86bbdde8dd246be8948790b7618d656e68f9b720a86e8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4643,7 +4933,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8baeff88f34ed0691978ec34440140e1572b68c7dd4a495fd14a3dc1944daa80"
 dependencies = [
  "base64ct",
- "der 0.8.0-rc.10",
+ "der 0.8.0",
 ]
 
 [[package]]
@@ -4703,7 +4993,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4726,7 +5016,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.114",
+ "syn 2.0.117",
  "tokio",
  "url",
 ]
@@ -4739,7 +5029,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "byteorder",
  "bytes",
  "crc",
@@ -4781,7 +5071,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "byteorder",
  "crc",
  "dotenvy",
@@ -4894,7 +5184,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4916,9 +5206,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4942,7 +5232,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4953,12 +5243,12 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tempfile"
-version = "3.24.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -4993,7 +5283,7 @@ checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
  "base64",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "fancy-regex",
  "filedescriptor",
  "finl_unicode",
@@ -5053,7 +5343,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5064,7 +5354,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5132,9 +5422,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -5147,9 +5437,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -5157,20 +5447,20 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.2",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5233,18 +5523,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
+version = "0.25.9+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+checksum = "da053d28fe57e2c9d21b48261e14e7b4c8b670b54d2c684847b91feaf4c7dac5"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -5254,9 +5544,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+checksum = "39ca317ebc49f06bd748bfba29533eac9485569dc9bf80b849024b025e814fb9"
 dependencies = [
  "winnow",
 ]
@@ -5298,7 +5588,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bytes",
  "futures-util",
  "http",
@@ -5342,7 +5632,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5368,9 +5658,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -5410,9 +5700,9 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-normalization"
@@ -5431,9 +5721,9 @@ checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-truncate"
@@ -5507,12 +5797,12 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.20.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "atomic",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -5628,6 +5918,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wasite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5635,9 +5934,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5648,23 +5947,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.58"
+version = "0.4.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5672,24 +5967,46 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
 ]
 
 [[package]]
@@ -5706,10 +6023,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.85"
+name = "wasmparser"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5723,6 +6052,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -5906,7 +6244,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5917,7 +6255,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5937,6 +6275,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5952,6 +6301,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -5997,6 +6355,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -6058,6 +6431,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -6076,6 +6455,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -6091,6 +6476,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6124,6 +6515,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -6139,6 +6536,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6160,6 +6563,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -6175,6 +6584,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6196,21 +6611,11 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6218,12 +6623,94 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "wmi"
-version = "0.18.3"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "003e65f4934cf9449b9ce913ad822cd054a5af669d24f93db101fdb02856bb23"
+checksum = "7c81b85c57a57500e56669586496bf2abd5cf082b9d32995251185d105208b64"
 dependencies = [
  "chrono",
  "futures",
@@ -6293,7 +6780,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -6323,22 +6810,22 @@ checksum = "2164e798d9e3d84ee2c91139ace54638059a3b23e361f5c11781c2c6459bde0f"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.38"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57cf3aa6855b23711ee9852dfc97dfaa51c45feaba5b645d0c777414d494a961"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.38"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a616990af1a287837c4fe6596ad77ef57948f787e46ce28e166facc0cc1cb75"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6358,7 +6845,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -6379,7 +6866,7 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6412,11 +6899,11 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.19"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"


### PR DESCRIPTION
## Cargo Dependency Update

Monthly `cargo update` of `Cargo.lock` dependencies.

<details>
<summary>cargo update output</summary>

```
unpacking 'github:hercules-ci/flake-parts/57928607ea566b5db3ad13af0e57e921e6b12381?narHash=sha256-AnYjnFWgS49RlqX7LrC4uA%2BsCCDBj0Ry/WOJ5XWAsa0%3D' into the Git cache...
copying path '/nix/store/kzqqrhnhh9q3dnrj3x10cdihmj09yc8p-source' from 'https://cache.nixos.org'...
unpacking 'github:numtide/treefmt-nix/337a4fe074be1042a35086f15481d763b8ddc0e7?narHash=sha256-wQ6NJSuFqAEmIg2VMnLdCnUc0b7vslUohqqGGD%2BFyxk%3D' into the Git cache...
unpacking 'github:nix-community/fenix/e4c413b9546d6c9e6426b33b4d6de1a49a375024?narHash=sha256-8XbJXrhMFhLgoBrjFIJx5XJi%2BSD%2B7/gbvaIXCuqy9Z0%3D' into the Git cache...
unpacking 'github:ipetkov/crane/8525580bc0316c39dbfa18bd09a1331e98c9e463?narHash=sha256-84W9UNtSk9DNMh43WBkOjpkbfODlmg%2BRDi854PnNgLE%3D' into the Git cache...
copying path '/nix/store/g72v26axrr9x4cjgilk5gvq33l3ksq8f-iana-etc-20251215' from 'https://cache.nixos.org'...
copying path '/nix/store/frqc9w8q0dxsg7b8w3j0cv1lb9bd6xww-git-2.53.0-doc' from 'https://cache.nixos.org'...
copying path '/nix/store/8r1dl5avizg0qs395d0rgbnynxmn6ybg-mailcap-2.1.54' from 'https://cache.nixos.org'...
copying path '/nix/store/9qxw3hqlginyfzh622a3drpwqp3b95qs-perl5.42.0-Capture-Tiny-0.48' from 'https://cache.nixos.org'...
copying path '/nix/store/07i264gnk386s5bwlz6hm4ikimp5ngvw-perl5.42.0-Class-Data-Inheritable-0.09' from 'https://cache.nixos.org'...
copying path '/nix/store/bn66ssz5ia6jrslsq0pnhslkczkp362l-perl5.42.0-Class-Inspector-1.36' from 'https://cache.nixos.org'...
copying path '/nix/store/8dqf1bpn2qql7wgbrw9jy964blvq0afm-perl5.42.0-Class-Singleton-1.6' from 'https://cache.nixos.org'...
copying path '/nix/store/qgxi6cw748zcybf4a58pgq9gr0kzy8b5-perl5.42.0-Devel-StackTrace-2.04' from 'https://cache.nixos.org'...
copying path '/nix/store/cx6rkgzyiqyj73dhyqm673l3dy6d7syh-perl5.42.0-Digest-HMAC-1.05' from 'https://cache.nixos.org'...
copying path '/nix/store/3ia5765yl4xgyrfpc3xmaa7mphc481jl-perl5.42.0-Encode-Locale-1.05' from 'https://cache.nixos.org'...
copying path '/nix/store/iy8isjks7jqcw8cc16gwgsmvxr14wfn2-perl5.42.0-Eval-Closure-0.14' from 'https://cache.nixos.org'...
copying path '/nix/store/kfb54isrpdnbw5msz5cs120wr7nmff0h-perl5.42.0-FCGI-ProcManager-0.28' from 'https://cache.nixos.org'...
copying path '/nix/store/c7642m04gkq6frgf8c14y64s0qfmhiw0-perl5.42.0-HTML-TagCloud-0.38' from 'https://cache.nixos.org'...
copying path '/nix/store/j9vpn81nc1lq6dj655kdxykxjwvrl1bs-perl5.42.0-HTML-Tagset-3.20' from 'https://cache.nixos.org'...
copying path '/nix/store/fr16d7av36m5f934i32chs2d76zjm135-perl5.42.0-IO-HTML-1.004' from 'https://cache.nixos.org'...
copying path '/nix/store/3qxhjpkx1yb7aqyk3cqx0j2dy5zy9gdn-perl5.42.0-LWP-MediaTypes-6.04' from 'https://cache.nixos.org'...
copying path '/nix/store/wgl7ffkls6cf64ipzvp41als1bzjpi5b-busybox-1.37.0' from 'https://cache.nixos.org'...
copying path '/nix/store/0rpxs2xh6aqvlcq7n5z7yxjlmgpgphic-curl-8.18.0-man' from 'https://cache.nixos.org'...
copying path '/nix/store/l089jr1fx3pmhbywbn3asxwib5hqcnjr-find-xml-catalogs-hook' from 'https://cache.nixos.org'...
copying path '/nix/store/97rn2wpm09db8278qzjvbss9ybxhfsxf-gcc-15.2.0-libgcc' from 'https://cache.eidetica.dev'...
copying path '/nix/store/s0xj50a5awma0jwgsqws61014nxzxy19-gnu-config-2024-01-01' from 'https://cache.nixos.org'...
copying path '/nix/store/1xakvg5jqmaiawwk0n1sbhvsvrdya512-libunistring-1.4.1' from 'https://cache.eidetica.dev'...
copying path '/nix/store/25h01lplynxf9s0yh75brdhxzcjv4kzp-linux-headers-6.18.7' from 'https://cache.nixos.org'...
copying path '/nix/store/fijiiw6jrf1kzmzfbnhr18dxmrh6333f-d3-flame-graph-templates-4.1.3' from 'https://cache.nixos.org'...
copying path '/nix/store/9fik6jfandv189wklkbz99923jv45lcd-dejavu-fonts-minimal-2.37' from 'https://cache.nixos.org'...
copying path '/nix/store/kmshs6pbana0vwi81liv7hapr18nds42-nghttp2-1.67.1' from 'https://cache.nixos.org'...
copying path '/nix/store/z5xb6n6p88ipmrjh8znr6rwxf6r7awlc-perl5.42.0-CPAN-Meta-Check-0.018' from 'https://cache.nixos.org'...
copying path '/nix/store/vi1zyqnf080nvrp2cmnyr9kq1zqwqxln-perl5.42.0-Canary-Stability-2013' from 'https://cache.nixos.org'...
copying path '/nix/store/avdg12jmh3k8cn9rl0qdmrvbzbv8pflc-perl5.42.0-MRO-Compat-0.15' from 'https://cache.nixos.org'...
copying path '/nix/store/bpfsjwnk1ahnlcb72zmz3pyh4bbcg9iw-mirrors-list' from 'https://cache.nixos.org'...
copying path '/nix/store/ahx5hpih726wrrf763x9na9s0kvgbkcg-ncurses-6.6-man' from 'https://cache.nixos.org'...
copying path '/nix/store/radk0h4m33cfwh1p4cnv24qpylm3nc9x-perl5.42.0-Exception-Class-1.45' from 'https://cache.nixos.org'...
copying path '/nix/store/67v3l4sr26mvw3cc8jdjambbzigkk5rp-perl5.42.0-File-ShareDir-1.118' from 'https://cache.nixos.org'...
copying path '/nix/store/jmhg7841kwrdaambsxxf2a58kcbmd8mj-perl5.42.0-Module-Runtime-0.016' from 'https://cache.nixos.org'...
copying path '/nix/store/0xqajqmp5wkl1pjm6xvpryd7hq2jqx6f-perl5.42.0-Mozilla-CA-20230821' from 'https://cache.nixos.org'...
copying path '/nix/store/y5zs9cjn898kq9kwlfaq8yzwidppzl0c-perl5.42.0-Readonly-2.05' from 'https://cache.nixos.org'...
copying path '/nix/store/vccy333651ybgmmza0z3rzhkmhcj3jng-perl5.42.0-Role-Tiny-2.002004' from 'https://cache.nixos.org'...
copying path '/nix/store/as5fxanpg0bzrw0xgwq4ynjcpsf5hfmy-perl5.42.0-Sub-Exporter-Progressive-0.001013' from 'https://cache.nixos.org'...
copying path '/nix/store/0qpb5lsxqjcvnadwg4jcyb839ywji1gg-perl5.42.0-Sub-Quote-2.006008' from 'https://cache.nixos.org'...
copying path '/nix/store/2x1cp5cq2k71i5yk3gwijwzqgvp00m1v-perl5.42.0-Test-Needs-0.002010' from 'https://cache.nixos.org'...
copying path '/nix/store/rjm5as2ghzg3gls10vggg2n1vm6hzds6-perl5.42.0-Test-Requires-0.11' from 'https://cache.nixos.org'...
copying path '/nix/store/ygjrcj8viz09kcq8mspnlxd79n5kk303-perl5.42.0-Test-RequiresInternet-0.05' from 'https://cache.nixos.org'...
copying path '/nix/store/028s54dnz4rpvw8a2d6ba3v7di8h8gn2-fontconfig-2.17.1' from 'https://cache.nixos.org'...
copying path '/nix/store/s28xbwq6c0pl9vd74rfwyby4qxdha4mz-perl5.42.0-Try-Tiny-0.31' from 'https://cache.nixos.org'...
copying path '/nix/store/mkvhaz128287v2ncd7fa7w8a16sxb1nn-perl5.42.0-TimeDate-2.33' from 'https://cache.nixos.org'...
copying path '/nix/store/h2dp13b6a2n7rvyqnylwdg3w7kcc3p8p-perl5.42.0-URI-5.21' from 'https://cache.nixos.org'...
copying path '/nix/store/6cans7qvjxhvzvl15kk9asz7wcqk40fi-perl5.42.0-common-sense-3.75' from 'https://cache.nixos.org'...
copying path '/nix/store/51rv0qdzswfmb2nq5q305k947m71ivbs-perl5.42.0-Dist-CheckConflicts-0.11' from 'https://cache.nixos.org'...
copying path '/nix/store/85zrhzp2f9rb2kjax7p0d1r5m7pngi7f-postgresql-17.8-doc' from 'https://cache.nixos.org'...
copying path '/nix/store/r5iwbrdggixf71jm7bhy0j7xsdjyd6ji-postgresql-17.8-man' from 'https://cache.nixos.org'...
copying path '/nix/store/y7yfaxd7jsldgfvxpj3vlqcyidakp36y-publicsuffix-list-0-unstable-2026-01-25' from 'https://cache.nixos.org'...
copying path '/nix/store/shbd49l1zh3lhgnpdfvp77936x3mpnx9-reproducible-artifacts-stable-2026-02-12' from 'https://cache.eidetica.dev'...
copying path '/nix/store/97db2qpzcx9f0ab2ny8krfx59mcjrp21-perl5.42.0-libnet-3.15' from 'https://cache.nixos.org'...
copying path '/nix/store/bj3id8f0ffxlh9w5asz6phni3h3a33ri-rust-std-nightly-complete-2026-02-28' from 'https://cache.eidetica.dev'...
copying path '/nix/store/w1w0m55p5ry9cb5313h0v6542saacxmj-perl5.42.0-Params-ValidationCompiler-0.31' from 'https://cache.nixos.org'...
copying path '/nix/store/52n2kk31gcd44fahcbdrwccj6sq69z7y-perl5.42.0-Types-Serialiser-1.01' from 'https://cache.nixos.org'...
copying path '/nix/store/hk6p229s1q1f2qgm19pg5sn4q6na5188-perl5.42.0-Specio-0.48' from 'https://cache.nixos.org'...
copying path '/nix/store/86lz8v0555xpwjch4p7ahxsb2cviwg70-perl5.42.0-Module-Implementation-0.09' from 'https://cache.nixos.org'...
copying path '/nix/store/ir29xib753ljjfkq7m3sncj51pjzd2g0-perl5.42.0-Net-HTTP-6.23' from 'https://cache.nixos.org'...
copying path '/nix/store/pdga1fmcl0jk25vaxxa6s2lp9z7ri1kg-perl5.42.0-Test-Fatal-0.017' from 'https://cache.nixos.org'...
copying path '/nix/store/rgif5d5i5lwpy57scya0znq5bai9w5cd-perl5.42.0-HTTP-Date-6.06' from 'https://cache.nixos.org'...
copying path '/nix/store/096brbmyz3rbwi7rzlnmncd0n0bmf49s-perl5.42.0-WWW-RobotRules-6.02' from 'https://cache.nixos.org'...
copying path '/nix/store/2a0rc3lmmizlwy18drf07hw8hxvblnxq-rustc-docs-stable-2026-02-12' from 'https://cache.eidetica.dev'...
copying path '/nix/store/54wrxi0bgxyvqmyyfcvfm17qlf600yjs-tzdata-2025c' from 'https://cache.nixos.org'...
copying path '/nix/store/ylvn8sswwfdp6l71hmz9ic8m4w9996j5-libidn2-2.3.8' from 'https://cache.eidetica.dev'...
copying path '/nix/store/x2qs0sx1f5wr52w3dlz623s203m7d49b-perl5.42.0-B-Hooks-EndOfScope-0.26' from 'https://cache.nixos.org'...
copying path '/nix/store/gz3rknshr1ywis4mjaqrgj3z2shp3n3v-update-autotools-gnu-config-scripts-hook' from 'https://cache.nixos.org'...
copying path '/nix/store/lwgklcaz513gd6v4cxcq6xz7vk2hiza1-util-linux-minimal-2.41.3' from 'https://cache.nixos.org'...
copying path '/nix/store/5ciif1nws6k0maxdpw2rqryqsxdd0ams-perl5.42.0-File-Listing-6.16' from 'https://cache.nixos.org'...
copying path '/nix/store/7zgq0585s33nqhf05j4qh4iwzp7sk6rj-perl5.42.0-HTTP-CookieJar-0.014' from 'https://cache.nixos.org'...
copying path '/nix/store/r7vdyf8pwlqsgd5ydak9fmq3q1i5nm3m-xgcc-15.2.0-libgcc' from 'https://cache.eidetica.dev'...
copying path '/nix/store/njwanmygmqc5vdhx22mnipiihqp39ysr-zlib-1.3.1-static' from 'https://cache.nixos.org'...
copying path '/nix/store/l0l2ll1lmylczj1ihqn351af2kyp5x19-glibc-2.42-51' from 'https://cache.eidetica.dev'...
copying path '/nix/store/z063ds4yv84j3h769b5lc0hlf29qqwc6-act-0.2.84' from 'https://cache.nixos.org'...
copying path '/nix/store/svsqbc450wja17xgzqh0g56xxnigf5gw-aws-c-common-0.12.4' from 'https://cache.nixos.org'...
copying path '/nix/store/sb2rv4sivgmmgdwszyhjbsb51gs3dpai-brotli-1.2.0-lib' from 'https://cache.nixos.org'...
copying path '/nix/store/ydpw9xwv0j5v8swa6wlz1ag2p19635mi-bzip2-1.0.8' from 'https://cache.nixos.org'...
copying path '/nix/store/8c61qqsgvj8k8l0dw7ar6ni40az1vdg6-c-ares-1.34.6' from 'https://cache.nixos.org'...
copying path '/nix/store/9dkfjmalih6fgfq0cmjz4ihhykx9vmaq-c-ares-1.34.6' from 'https://cache.nixos.org'...
copying path '/nix/store/vp8xfrrhs2m4hvyyqy2z5jzb2rfk00m0-cargo-nightly-complete-2026-02-28' from 'https://cache.eidetica.dev'...
copying path '/nix/store/65b46g3r0785j9dsa61ayw4s4jzxs93l-cargo-stable-2026-02-12' from 'https://cache.eidetica.dev'...
copying path '/nix/store/36x9an7xv8mjl51zjbn08wcjkly8799d-clippy-preview-nightly-complete-2026-02-28' from 'https://cache.eidetica.dev'...
copying path '/nix/store/qd8y0dl3yxjbiy1dy2m1h4aqcafp3ghp-clippy-preview-stable-2026-02-12' from 'https://cache.eidetica.dev'...
copying path '/nix/store/mpjfg04q7cvi749zcfk8q5bayjhn1kc4-dav1d-1.5.3' from 'https://cache.nixos.org'...
copying path '/nix/store/7ssfvw8z4ylzjkw73z1y78svbhkdlkvb-attr-2.5.2' from 'https://cache.nixos.org'...
copying path '/nix/store/2hjsch59amjs3nbgh7ahcfzm2bfwl8zi-bash-5.3p9' from 'https://cache.eidetica.dev'...
copying path '/nix/store/nnhkhd6pj8zqd3m3yanpgky02ywrkhms-ed-1.22.4' from 'https://cache.nixos.org'...
copying path '/nix/store/x8l7qzpab2gpdrp89g48mxlrsiz4f0gm-bzip2-1.0.8-bin' from 'https://cache.nixos.org'...
copying path '/nix/store/vfa8fqz4k8dnlwivphif88qai54nxnqf-acl-2.3.2' from 'https://cache.nixos.org'...
copying path '/nix/store/vc7xk68lyq3d203rg429y2iia0pp70by-editline-1.17.1-unstable-2025-05-24' from 'https://cache.nixos.org'...
copying path '/nix/store/lcpv5jbr8inqqkkka9li5sh9ic5wd9mp-c-ares-1.34.6-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/bwqgrhq1dmi6b6xnjvhmrq54j8dzhzfr-aws-c-compression-0.3.1' from 'https://cache.nixos.org'...
copying path '/nix/store/wc3bnkdjca5gx2df5l1r3apw2mmqy0kc-aws-c-sdkutils-0.2.4' from 'https://cache.nixos.org'...
copying path '/nix/store/qrczva8vpjwms03i2m05jygn6hrr34iq-aws-checksums-0.2.7' from 'https://cache.nixos.org'...
copying path '/nix/store/3y8jfnbcv230kip514qh2wmfifihzvqp-brotli-1.2.0' from 'https://cache.nixos.org'...
copying path '/nix/store/5cp0vlc6kabxzk17q7jjwmwg6p7mjg3b-expand-response-params' from 'https://cache.nixos.org'...
copying path '/nix/store/harqqq4p37lpfj0h57xnwcag9ls0d2fs-expand-response-params' from 'https://cache.nixos.org'...
copying path '/nix/store/ans4y7j70iwwa1xvck2vjzzi2iknx4h1-expat-2.7.4' from 'https://cache.nixos.org'...
copying path '/nix/store/gf7b4yz4vhd0y2hnnrimhh875ghwzzzj-gawk-5.3.2' from 'https://cache.nixos.org'...
copying path '/nix/store/ihpdbhy4rfxaixiamyb588zfc3vj19al-gcc-15.2.0-lib' from 'https://cache.eidetica.dev'...
copying path '/nix/store/7qb2ak72cnd85rgjlsg2v7jkrf382s4y-gdbm-1.26-lib' from 'https://cache.nixos.org'...
copying path '/nix/store/mph4i5dxmkzbn3why9ccxan71dpcirlp-giflib-5.2.2' from 'https://cache.nixos.org'...
copying path '/nix/store/k0kf4ighsp04zb49lfhz2qlvdsv8d5f0-gitleaks-8.30.0' from 'https://cache.nixos.org'...
copying path '/nix/store/2c48s343k15i0cmwb9cp1vi6randmzcw-glibc-2.42-51-bin' from 'https://cache.nixos.org'...
copying path '/nix/store/m8x59ybbd4hycpswc27vj7hjyng7q7w6-brotli-1.2.0-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/njcs5bsgvn7qdzfr7kxjvn0fq8y6i4ys-gmp-6.3.0' from 'https://cache.nixos.org'...
copying path '/nix/store/0xw6y53ijaqwfd9c99wyaqiinychzv1f-gnumake-4.4.1' from 'https://cache.nixos.org'...
copying path '/nix/store/wv7qq5yb8plyhxji9x3r5gpkyfm2kf29-gnused-4.9' from 'https://cache.nixos.org'...
copying path '/nix/store/isva9q9zx3frx6hh6cnpihh1kd2bx6bk-gnutar-1.35' from 'https://cache.nixos.org'...
copying path '/nix/store/1vqg352fnsw1lsns082g73gkdn5cqc7c-gnum4-1.4.20' from 'https://cache.nixos.org'...
copying path '/nix/store/j8irrc0mpx029dw0rmadsjylg7h31ync-glibc-2.42-51-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/w1n7yp2vnldr395hbwbcaw9sflh413bm-gzip-1.14' from 'https://cache.nixos.org'...
copying path '/nix/store/v3j4fxhhv94i5zfmhyi95zd0ldvpin34-hwloc-2.12.2-lib' from 'https://cache.nixos.org'...
copying path '/nix/store/p69faj0lr3lqljvrnybmkpxw18skfqlf-isl-0.20' from 'https://cache.nixos.org'...
copying path '/nix/store/drsviq2sj4dvbq4c0s6dbfl13sdrlbxv-json-c-0.18' from 'https://cache.nixos.org'...
copying path '/nix/store/fw2d81ms5a8627ichs9a8fqc5dk9s5gc-keyutils-1.6.3-lib' from 'https://cache.nixos.org'...
copying path '/nix/store/678923hg4sq08b3i7kqgcw1ww2mj5mn3-bison-3.8.2' from 'https://cache.nixos.org'...
copying path '/nix/store/nvf3pymhlbl6dsdlswsrarp03d7b9dq0-flex-2.6.4' from 'https://cache.nixos.org'...
copying path '/nix/store/g1ppa090n8pkakfrf1311qx0n7vh888b-libcap-ng-0.9' from 'https://cache.nixos.org'...
copying path '/nix/store/x5ks2vq49yqrgz404y4x39dmxz4l8s98-libcpuid-0.8.1' from 'https://cache.nixos.org'...
copying path '/nix/store/rfqh6wnf9p6rl44zkw0v6bffgy65fvrn-libdeflate-1.25' from 'https://cache.nixos.org'...
copying path '/nix/store/qkykv5hi5zkkwqgvgyh91w3yy6rcg3nm-libev-4.33' from 'https://cache.nixos.org'...
copying path '/nix/store/pxb0lxw6w0d4c6npsg5828lam07q9m8n-audit-4.1.2-unstable-2025-09-06-lib' from 'https://cache.nixos.org'...
copying path '/nix/store/5mnq195cx3cagnpbbvf5ncbp4fjgy0sz-libffi-3.5.2' from 'https://cache.nixos.org'...
copying path '/nix/store/ydm8kg9fsvxbpz35jjwmg0bvcfsfl07c-libjpeg-turbo-3.1.3' from 'https://cache.nixos.org'...
copying path '/nix/store/ps2qpwzsn2wrf4p7hk8xg97qgpjl315f-libpfm-4.13.0' from 'https://cache.nixos.org'...
copying path '/nix/store/d945gymnx6pxcz5jiv0ii2w6vq88yk4y-libseccomp-2.6.0-lib' from 'https://cache.nixos.org'...
copying path '/nix/store/qvxaabi4w7isbp0vxqqsx4brl5n1qnjh-libpsl-0.21.5' from 'https://cache.nixos.org'...
copying path '/nix/store/wdjmrnmdi7cqflac3a5fhnm25xigw90x-libsodium-1.0.21-unstable-2026-01-22' from 'https://cache.nixos.org'...
copying path '/nix/store/25kllwapbbnjk0gqy5pmpdiz98r955gm-libtraceevent-1.8.7' from 'https://cache.nixos.org'...
copying path '/nix/store/84rbbk45fal6gqxmxh06ky2n42k6vqfp-libuv-1.51.0' from 'https://cache.nixos.org'...
copying path '/nix/store/68c9nshhpmv29p2wpb3yyjj2f48acaf5-libxau-1.0.12' from 'https://cache.nixos.org'...
copying path '/nix/store/g93whx8466047n5r84vd2cyaqxbx5i5i-libxcrypt-4.5.2' from 'https://cache.nixos.org'...
copying path '/nix/store/hzzhnxds6kxbbafh0nqlr18zncjq1pm9-libxdmcp-1.1.5' from 'https://cache.nixos.org'...
copying path '/nix/store/h8z5hxkx2j9dfnydpz89isjfs619f12q-llhttp-9.3.0' from 'https://cache.nixos.org'...
copying path '/nix/store/l3gqwj9zk4xgqv9kxfkvx9qc51m8j8x3-libxml2-2.15.1' from 'https://cache.nixos.org'...
copying path '/nix/store/j3m1hkyd8sdw19qzshaw6zj8y6djinyf-libyaml-0.2.5' from 'https://cache.nixos.org'...
copying path '/nix/store/i1bhjxlrci4j824srcihrm95rxbhkf7w-lndir-1.0.5' from 'https://cache.nixos.org'...
copying path '/nix/store/m5z0dbcz2y7r0f3rill6z02msz9b46if-libxcb-1.17.0' from 'https://cache.nixos.org'...
copying path '/nix/store/455a388x4ny03373s1wajannpflpj25r-libuv-1.51.0-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/abz8pmy2njd4jk7cfv1kzswr612kpi8l-lowdown-2.0.4-lib' from 'https://cache.nixos.org'...
copying path '/nix/store/vkspvcawsrvpg92a0y8c4anc50g3fwx0-lz4-1.10.0-lib' from 'https://cache.nixos.org'...
copying path '/nix/store/wcvrykaf90nmr0rikx6gy178ffvrxdj4-mpdecimal-4.0.1' from 'https://cache.nixos.org'...
copying path '/nix/store/24xvrgxnaxxhxrjp0sn9fld0nm51yyph-lz4-1.10.0' from 'https://cache.nixos.org'...
copying path '/nix/store/yfpwi6x8hs7b1958gcazm007cqc55ryv-llhttp-9.3.0-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/rcrlg39yb6g93v9lrb4x57v464li8y0h-ncompress-5.0' from 'https://cache.nixos.org'...
copying path '/nix/store/y9xh8dxxbi6ss7mawx5glgazslii4f63-mpfr-4.2.2' from 'https://cache.nixos.org'...
copying path '/nix/store/5qrvz1d1f813wcw6b752d4daaqxxbd1r-ncurses-6.6' from 'https://cache.nixos.org'...
copying path '/nix/store/4g2q10kbj49j0cpyal731ilca7d78z6z-nghttp2-1.67.1-lib' from 'https://cache.nixos.org'...
copying path '/nix/store/kg9dfz5scmck9hh3by219bxg9p25lqn1-nghttp2-1.67.1-lib' from 'https://cache.nixos.org'...
copying path '/nix/store/4krj3d6h2xpcdc6a2hphr2i4k6rab9kc-libxml2-2.15.1-bin' from 'https://cache.nixos.org'...
copying path '/nix/store/qb7y45nr8wzy7x5g8aky395ikr40ipzm-libxslt-1.1.45' from 'https://cache.nixos.org'...
copying path '/nix/store/m5c36y054r55dmc0mjvy81vcibfppn4w-alejandra-4.0.0' from 'https://cache.nixos.org'...
copying path '/nix/store/waar2jhcidhmcc0bzfrfh74d19k16fyy-boehm-gc-8.2.8' from 'https://cache.nixos.org'...
copying path '/nix/store/xydfz3abjfydsaz7ixfaka6ikdjjz1xk-cargo-careful-0.4.9' from 'https://cache.nixos.org'...
copying path '/nix/store/4gnq76nks0g1nddaggsw7v17agaacyh3-cargo-nextest-0.9.129' from 'https://cache.nixos.org'...
copying path '/nix/store/7d8f5hag8a3qzfwj5lixbcnai8skjsgy-compiler-rt-libc-21.1.8' from 'https://cache.nixos.org'...
copying path '/nix/store/4mk08faw9x5wkxsq72irj2zzhwsiih5l-db-4.8.30' from 'https://cache.nixos.org'...
copying path '/nix/store/mwlcc213jrh3lsj92yjbkgiiw605ip9i-deadnix-1.3.1' from 'https://cache.nixos.org'...
copying path '/nix/store/md592gfars4m9madyrpj9yrq5jhckgjf-gettext-0.26' from 'https://cache.nixos.org'...
copying path '/nix/store/3z4n8rmy4cfp0km5jaczz7f404j9sa64-gmp-with-cxx-6.3.0' from 'https://cache.nixos.org'...
copying path '/nix/store/wqikjqrnbynh44y0nfr16ynyq1g891wf-gmp-with-cxx-6.3.0' from 'https://cache.nixos.org'...
copying path '/nix/store/wcmcai1w6ww72hflq95k61fsx7kz0d2q-icu4c-76.1' from 'https://cache.nixos.org'...
copying path '/nix/store/x6bvf2yyik9jlp2bdsdh8hbzg4l9sd49-just-1.46.0' from 'https://cache.nixos.org'...
copying path '/nix/store/kwayg8d4hdr55hijsli5zh4h72slp3wa-lerc-4.0.0' from 'https://cache.nixos.org'...
copying path '/nix/store/r9kx65g5cjf1ifsrh6b02y8jsvjprk36-libmpc-1.3.1' from 'https://cache.nixos.org'...
copying path '/nix/store/8nlwlm79f2phsybyhy2dj0zpcfsjk5qy-libedit-20251016-3.1' from 'https://cache.nixos.org'...
copying path '/nix/store/hlxw2q9qansq7bn52xvlb5badw3z1v8s-coreutils-9.10' from 'https://cache.nixos.org'...
copying path '/nix/store/6pk6wr8gry5hqq9yfd59g7i63gc8l7qg-libvmaf-3.0.0' from 'https://cache.nixos.org'...
copying path '/nix/store/zdbhp4571kff54fwr71laia1p5yxw330-libx11-1.8.12' from 'https://cache.nixos.org'...
copying path '/nix/store/1f6917ky6w2gghw63myngxr2zq2zh8rm-libxml2-2.15.1-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/5akzak6yir5qanifyrxh4fazb8vwn85y-libxslt-1.1.45-bin' from 'https://cache.nixos.org'...
copying path '/nix/store/m4bcwyfwsykirmyyx8zgb6fhpvrw2si5-libyuv-1908' from 'https://cache.nixos.org'...
copying path '/nix/store/50k6na1w04vfcxqfkbdd08k9pqkdywsj-llvm-bitcode-linker-preview-stable-2026-02-12' from 'https://cache.eidetica.dev'...
copying path '/nix/store/f6scy031khvii6sz809g69vznjjk49z0-lz4-1.10.0-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/fahsap19aw4mgkflmv3xi6wzxx17anxp-libaom-3.12.1' from 'https://cache.nixos.org'...
copying path '/nix/store/b7b6khgymvp7nq0liixwxx0jjss06av3-mdbook-0.5.2' from 'https://cache.nixos.org'...
copying path '/nix/store/icrrz26xbyp293kagrlkab1bhc6gra0r-diffutils-3.12' from 'https://cache.nixos.org'...
copying path '/nix/store/b3rx5wac9hhfxn9120xkcvdwj51mc9z2-findutils-4.10.0' from 'https://cache.nixos.org'...
copying path '/nix/store/1llxqjy1r65cdhgrkjd6kghg0i6qgdmc-mdbook-mermaid-0.17.0' from 'https://cache.nixos.org'...
copying path '/nix/store/gc3jwy4sbrjygrp8n08bvscii4ksw4dn-libxpm-3.5.18' from 'https://cache.nixos.org'...
copying path '/nix/store/qr8dbyf89zzfcm76slsn0qavfalpng4f-mimalloc-3.1.5' from 'https://cache.nixos.org'...
copying path '/nix/store/f1ahhmizr4qi79k2hh0aaryrzzjivf0h-ncurses-6.6-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/kk735l9nyb970x8pfkkgawrpwx3kc2dr-nghttp2-1.67.1-lib' from 'https://cache.nixos.org'...
copying path '/nix/store/1pnbjd26bhdysyv4jdzmj17gryn7vxqn-nghttp2-1.67.1-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/5gmx4ls0l2jq468j179z0ncp6l4g9gjj-nghttp3-1.14.0' from 'https://cache.nixos.org'...
copying path '/nix/store/hddsa82i6slh4saws93hj7aaaym2ir1b-numactl-2.0.18' from 'https://cache.nixos.org'...
copying path '/nix/store/pi9dg0nb3qgx82340ksa8b8iasvx404p-onetbb-2022.3.0' from 'https://cache.nixos.org'...
copying path '/nix/store/p96a7p297gmia8zcy4i72qd45wzw8lh6-openssl-3.6.1' from 'https://cache.nixos.org'...
copying path '/nix/store/qnhjb19k7dc9kcldhx42l08xw1kcb4ir-oniguruma-6.9.10-lib' from 'https://cache.nixos.org'...
copying path '/nix/store/cp06sh2y41rfb0pcs71wxz654088cls1-nghttp3-1.14.0-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/vq971rqwp1qxfgqc6vnd8gjx828ffb3m-openssl-3.6.1' from 'https://cache.nixos.org'...
copying path '/nix/store/8y5jm97n4lyw80gh71yihghbhqc11fdz-patch-2.8' from 'https://cache.nixos.org'...
copying path '/nix/store/m2r8xywa2vqyvlv81w19pwayv0r1rixk-libblake3-1.8.3' from 'https://cache.nixos.org'...
copying path '/nix/store/70bwclvic12925zck7za5y9g761l9kkh-jq-1.8.1' from 'https://cache.nixos.org'...
copying path '/nix/store/590yx3aynyhs48jyk8ip37fk1mjqfhkb-patchelf-0.15.2' from 'https://cache.nixos.org'...
copying path '/nix/store/j3hs745klzarm7lrlpsyl8skx5czg0z0-pcre2-10.46' from 'https://cache.nixos.org'...
copying path '/nix/store/g41y5xaagglzx7wzqpi7yrilnirnigg2-perl5.42.0-Clone-0.46' from 'https://cache.nixos.org'...
copying path '/nix/store/jrvj1y7w8slim5xgbbly7hhpadsym63g-compiler-rt-libc-21.1.8-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/kc3p2klwb34i23y59scgdjxhp54dhxnr-perl5.42.0-Crypt-URandom-0.54' from 'https://cache.nixos.org'...
copying path '/nix/store/wcmkd6d74qycjhsnhy8nnkss2g74501i-perl5.42.0-FCGI-0.82' from 'https://cache.nixos.org'...
copying path '/nix/store/x4mz2jzaayv8q5wrprwl0xzgszg6wk7v-perl5.42.0-HTTP-Message-6.45' from 'https://cache.nixos.org'...
copying path '/nix/store/jyi1vkcbaihqbfbra4qd0107sj1jhdk4-jq-1.8.1-bin' from 'https://cache.nixos.org'...
copying path '/nix/store/gx71qyirw9ymwdyghim7x8l77v51rs2m-perl5.42.0-PathTools-3.75' from 'https://cache.nixos.org'...
copying path '/nix/store/9xwbcg5v6284f6yjqrp0kly9qj184n1x-perl5.42.0-Sub-Identify-0.14' from 'https://cache.nixos.org'...
copying path '/nix/store/ibzc4ndh24nnxzihs1ahvvyrr47yn1s8-perl5.42.0-TermReadKey-2.38' from 'https://cache.nixos.org'...
copying path '/nix/store/vlb2v7nwxw835ykkz0k43bjm6qknvv4x-perl5.42.0-Authen-SASL-2.1900' from 'https://cache.nixos.org'...
copying path '/nix/store/j5fz28pic24azmxkv183hk6fchfs7ag8-pkg-config-0.29.2' from 'https://cache.nixos.org'...
copying path '/nix/store/6k38kk69g0c627mk0jcz8dvgbvj461d6-perl5.42.0-HTML-Parser-3.81' from 'https://cache.nixos.org'...
copying path '/nix/store/bgm2mqsfhp32x2vhxr9rip78bi89z7cb-perl5.42.0-HTTP-Cookies-6.10' from 'https://cache.nixos.org'...
copying path '/nix/store/6ihhdz5frv36dasbabsihfv987ha2cpi-perl5.42.0-HTTP-Daemon-6.16' from 'https://cache.nixos.org'...
copying path '/nix/store/rx7f1i2jbignsr6qm3x65csidd2xqcq3-perl5.42.0-HTTP-Negotiate-6.01' from 'https://cache.nixos.org'...
copying path '/nix/store/97saa9h6919by58wbj13yjh07xk0xj88-popt-1.19' from 'https://cache.nixos.org'...
copying path '/nix/store/d2231a3r3fgc0a40fx8ym82k162bajhj-readline-8.3p3' from 'https://cache.nixos.org'...
copying path '/nix/store/1nv3i8mpypy3d516f4pd95m0w72r73jy-pkg-config-wrapper-0.29.2' from 'https://cache.nixos.org'...
copying path '/nix/store/hzg9fw59rl6r756y0577y6aw6075gja0-rust-src-nightly-complete-2026-02-28' from 'https://cache.eidetica.dev'...
copying path '/nix/store/y776kngi32014bh9qr7as6sj08x7mk9z-rust-src-stable-2026-02-12' from 'https://cache.eidetica.dev'...
copying path '/nix/store/8laf6k81j9ckylrigj3xsk76j69knhvl-gnugrep-3.12' from 'https://cache.nixos.org'...
copying path '/nix/store/lzpkdgqp7wj5b8w54x0iir6b07iscp28-simdjson-4.2.4' from 'https://cache.nixos.org'...
copying path '/nix/store/sglyhgkf0i17p9yrhnnmfg3691mzykrp-libselinux-3.8.1' from 'https://cache.nixos.org'...
copying path '/nix/store/gcd8gxs3dpz7i444x23yz9hjikmy6ij0-perl5.42.0-CGI-4.59' from 'https://cache.nixos.org'...
copying path '/nix/store/0nyjdyh436pva8b8268riqfszsnd28j5-simdutf-6.5.0' from 'https://cache.nixos.org'...
copying path '/nix/store/0550j0i8bmzxbcnzrg1g51zigj7y12ih-bash-interactive-5.3p9' from 'https://cache.nixos.org'...
copying path '/nix/store/sj57rqyvl28y67ivn0kgsq4br8l9i0if-readline-8.3p3-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/j4y4fm69wrv38jn319zl8ncz4hy34kx4-perl5.42.0-CGI-Fast-2.16' from 'https://cache.nixos.org'...
copying path '/nix/store/ifdxnnjqv87326c3h7ybhzvg96hck3qd-simdutf-8.0.0' from 'https://cache.nixos.org'...
copying path '/nix/store/hdlbanz4xxvr8dhavmslh4szvpr2ggbc-statix-0.5.8' from 'https://cache.nixos.org'...
copying path '/nix/store/jsjy1nxrpsxyp017pdv685hkl6fvcg06-tcl-8.6.16' from 'https://cache.nixos.org'...
copying path '/nix/store/qpsbxa2xi2cmk87c76agx9b414vmk5rd-typos-1.43.5' from 'https://cache.nixos.org'...
copying path '/nix/store/q8d0h2kvc0h3w6d5wrvipfp2kji7ph3c-util-linux-minimal-2.41.3-lib' from 'https://cache.nixos.org'...
copying path '/nix/store/6w6ri8gyxgvmsl2pcvp0p183ys07wrdm-ada-3.4.2' from 'https://cache.nixos.org'...
copying path '/nix/store/5cm706bg0pjq35bfpxr5qgx0qg94lpmi-util-linux-minimal-2.41.3-login' from 'https://cache.nixos.org'...
copying path '/nix/store/psnvdlvsgcjh4b9pdawd8n3xs0m4gf5a-uvwasi-0.0.23' from 'https://cache.nixos.org'...
copying path '/nix/store/4g5g1lslswjzsmm3k5cwcpp75vcrbvg3-aws-c-cal-0.9.2' from 'https://cache.nixos.org'...
copying path '/nix/store/n2kxkzwkska6mab5b7jwhhm66ph09n70-cargo-tarpaulin-0.35.2' from 'https://cache.nixos.org'...
copying path '/nix/store/6wvxajs4jcgx3agczzwy8b1mq6jfa0fx-cargo-udeps-0.1.60' from 'https://cache.nixos.org'...
copying path '/nix/store/xfjkn6pgqyd4h18fdbf5fshadqyzdklp-krb5-1.22.1-lib' from 'https://cache.nixos.org'...
copying path '/nix/store/qmi2lnjrj7njxapzirmh5m35ihzz3yp1-lychee-0.22.0-unstable-2025-12-05' from 'https://cache.nixos.org'...
copying path '/nix/store/yik8ksc75mrk44ax1rlwyslzqdkgqg0g-krb5-1.22.1-lib' from 'https://cache.nixos.org'...
copying path '/nix/store/v63pwwaj7y1c3zkm9jx09lzsdp0zh72v-nghttp2-1.67.1' from 'https://cache.nixos.org'...
copying path '/nix/store/y9085qj0nl9yr9px055n2mlnhx1pkfmw-ngtcp2-1.19.0' from 'https://cache.nixos.org'...
copying path '/nix/store/1qm74vf93ik1xjrr9kl6qvjrklljlcqh-glib-2.86.3' from 'https://cache.nixos.org'...
copying path '/nix/store/1znd05g5hidxwwzm7kpiykxqfrjg7wca-openssl-3.6.1-bin' from 'https://cache.nixos.org'...
copying path '/nix/store/9nww32bprhg1rr1qj423xdr5mwnqk93z-openssl-3.6.1-bin' from 'https://cache.nixos.org'...
copying path '/nix/store/02c66kqigmk1rn7dsnazd7f8i6kwjdip-ngtcp2-1.19.0-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/0j30s2yjgcvss2qxzgbr13i5q7pan60l-nghttp2-1.67.1-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/aaa7ja0i8hjmgvx6c435h5bm5l8d2jyj-krb5-1.22.1' from 'https://cache.nixos.org'...
copying path '/nix/store/blkfyhhv9bfhspgka84r9c9fqc8dsy0g-openssl-3.6.1-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/xkwhw6gvya1k5imjy49bsr8229lg28fv-perl5.42.0-Net-SSLeay-1.92' from 'https://cache.nixos.org'...
copying path '/nix/store/rjzzxaj940qidr3gf31kr2sankgxm1yv-postgresql-17.8-lib' from 'https://cache.nixos.org'...
copying path '/nix/store/n1j3yzp78k2ijahflyxw5z7y8pqanzwh-krb5-1.22.1' from 'https://cache.nixos.org'...
copying path '/nix/store/jaz8s02ga49df3c33200jvcn5nkxq0ff-s2n-tls-1.6.4' from 'https://cache.nixos.org'...
copying path '/nix/store/1p14m1hrdkykyxs0l6wg7y29ahppcnsr-openssl-3.6.1-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/1mv4y8dsjsb0bw2rs7c2xpaxp5sdz282-systemd-minimal-libs-259' from 'https://cache.nixos.org'...
copying path '/nix/store/i3cgrdgd32m0x4hwhdm080hqsplhmmgy-perl5.42.0-IO-Socket-SSL-2.083' from 'https://cache.nixos.org'...
copying path '/nix/store/jm9ll6kf568khpax6fmp6pycnjsvr932-util-linux-minimal-2.41.3-mount' from 'https://cache.nixos.org'...
copying path '/nix/store/jmbxnc0r2blyjpivvg3gabz6flyzy3bn-krb5-1.22.1-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/bmvr90ryzab7kjrmiv90ykkj6g5wvmyq-aws-c-io-0.22.0' from 'https://cache.nixos.org'...
copying path '/nix/store/jkn83dsc7ylklwmggrnb3k9vqzb2c1h0-util-linux-minimal-2.41.3-swap' from 'https://cache.nixos.org'...
copying path '/nix/store/qqvwkik5wn2d6lgq5a3ipdbqxxr63klj-krb5-1.22.1-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/wz6zrlcl24d7xygzgp460f92icn8zlhj-xxHash-0.8.3' from 'https://cache.nixos.org'...
copying path '/nix/store/ad630z5lkrrirwjrz8z8ymrzgklqjqdl-perl5.42.0-Net-SMTP-SSL-1.04' from 'https://cache.nixos.org'...
copying path '/nix/store/khd9yb8b0npl5x98y7d5l102v0wp600l-xz-5.8.2' from 'https://cache.nixos.org'...
copying path '/nix/store/vl8jkqpr0l3fac3cxiy4nwc5paiww1lv-zlib-1.3.1' from 'https://cache.eidetica.dev'...
copying path '/nix/store/v37y2wqh86akn9wr5f9fr6n6hzdw6ric-zlib-ng-2.3.3' from 'https://cache.nixos.org'...
copying path '/nix/store/kyk7xxwwx9gjpr3g2cc4ii2dh3r8y2ya-aws-c-event-stream-0.5.7' from 'https://cache.nixos.org'...
copying path '/nix/store/0rmvw2h9694qj9aqikrvjhvkbm9nw553-aws-c-http-0.10.4' from 'https://cache.nixos.org'...
copying path '/nix/store/m27kji8vcm9hn8jyn3dxixxkgbs6p0kp-zstd-1.5.7' from 'https://cache.nixos.org'...
copying path '/nix/store/q151vxaxv1l4hmf7kccgs45h0xcngagp-icu4c-76.1-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/27fx8p4k6098wan3zahdbyj79ndcn03z-xz-5.8.2-bin' from 'https://cache.nixos.org'...
copying path '/nix/store/p3j7lphwlci13f9w2v4rav6rbvpi80li-file-5.45' from 'https://cache.nixos.org'...
copying path '/nix/store/3nlzlnpqa7fsbx4f0sdd642cjw4rysa6-binutils-2.44-lib' from 'https://cache.nixos.org'...
copying path '/nix/store/sca0pf46jmxva40qahkcwys5c1lvk6n2-gcc-15.2.0' from 'https://cache.nixos.org'...
copying path '/nix/store/bm62iznvisqil197w8g9kmivra2fv7iv-libpng-apng-1.6.55' from 'https://cache.nixos.org'...
copying path '/nix/store/38bhsc4kzxd47z36mmzr2410mq1zc5i4-libssh2-1.11.1' from 'https://cache.nixos.org'...
copying path '/nix/store/drvn5cdabrybdirxbb9z11ra78r3is2b-libssh2-1.11.1' from 'https://cache.nixos.org'...
copying path '/nix/store/wrwzn9h21jzg24dilb15wsh0010idkk6-boost-1.89.0' from 'https://cache.nixos.org'...
copying path '/nix/store/fgk4aqaccjhd5f8b9w6linnfmpfl5sw9-aws-c-auth-0.9.1' from 'https://cache.nixos.org'...
copying path '/nix/store/z4svsyvl3kabvqdd9dj0z7w36jc2a5m2-aws-c-mqtt-0.13.3' from 'https://cache.nixos.org'...
copying path '/nix/store/jld7vprd8kf2cgchdmkw2bb6d48hw30i-cargo-deny-0.19.0' from 'https://cache.nixos.org'...
copying path '/nix/store/n9jq6ks3q2kkzw3davzgpsvmpb8v6siy-freetype-2.13.3' from 'https://cache.nixos.org'...
copying path '/nix/store/6myhsg4shn6wvqbh0dznqr5y39sm16a9-libarchive-3.8.4-lib' from 'https://cache.nixos.org'...
copying path '/nix/store/9nmzd62x45ayp4vmswvn6z45h6bzrsla-binutils-2.44' from 'https://cache.nixos.org'...
copying path '/nix/store/2gy9y4qvsb4s1s4ihmb6rfx3awp7yyrr-curl-8.18.0' from 'https://cache.nixos.org'...
copying path '/nix/store/i59cbsr9zwy57hp41pa3wg1cbzm0yjpr-curl-8.18.0' from 'https://cache.nixos.org'...
copying path '/nix/store/l5y2shwzmmi5f56nk75aip4zm6j2izrv-aws-c-s3-0.8.7' from 'https://cache.nixos.org'...
copying path '/nix/store/s0wxpgw0dgcsjdzg90h4xvghbnwwjabi-libgit2-1.9.2-lib' from 'https://cache.nixos.org'...
copying path '/nix/store/xv8izh58wi09ph641k190hp7ah0kdy9i-libssh2-1.11.1-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/nqx5zb6fl85lvz2mbs2rryjf8p8bhi43-fontconfig-2.17.1-lib' from 'https://cache.nixos.org'...
copying path '/nix/store/2lam1r026ls2avdkdc532fa3hc0imc0n-libwebp-1.6.0' from 'https://cache.nixos.org'...
copying path '/nix/store/i3b5ghdwkbmgy14m0prdvn47chqvh2an-curl-8.18.0-bin' from 'https://cache.nixos.org'...
copying path '/nix/store/154c6p5dz2askmsf1mj09g7x47qqy792-aws-crt-cpp-0.34.3' from 'https://cache.nixos.org'...
copying path '/nix/store/2hp2kc85zapzjaj9y22jf9xgwqmlsk6m-linux-pam-1.7.1' from 'https://cache.nixos.org'...
copying path '/nix/store/588hnj4f64i2bbdjk1mjzif778dk4zp4-elfutils-0.194' from 'https://cache.nixos.org'...
copying path '/nix/store/s6v0k4cvllyp5cy03ngxz0snj7z23ljm-llvm-21.1.8-lib' from 'https://cache.nixos.org'...
copying path '/nix/store/bg1v0d02jx4sfqj1brns277jmdbprq1g-llvm-tools-preview-stable-2026-02-12' from 'https://cache.eidetica.dev'...
copying path '/nix/store/mh3xdda8siz8g0g5lhhmvp80gzm87msn-mold-unwrapped-2.40.4' from 'https://cache.nixos.org'...
copying path '/nix/store/9r03s7bgriqd4qhcsqi0bmwi7b1a8qda-libtiff-4.7.1' from 'https://cache.nixos.org'...
copying path '/nix/store/4pfrhja4j3j5g4iwssn9w43sgihdf4wl-perl-5.42.0' from 'https://cache.nixos.org'...
copying path '/nix/store/3x58811xjcgx11iagqhp8dsnn1qm1b03-rsync-3.4.1' from 'https://cache.nixos.org'...
copying path '/nix/store/fqf4p9bz36gl558z9bf1ml2xbq7ic939-nix-util-2.33.3' from 'https://cache.nixos.org'...
copying path '/nix/store/f8f11x06gi8ycykwb2yyhv5jgjj5b8fv-gdk-pixbuf-2.44.5' from 'https://cache.nixos.org'...
copying path '/nix/store/n86g9yx78hab19mi1f71rklba5c4fx7a-libwebp-1.6.0' from 'https://cache.nixos.org'...
copying path '/nix/store/y7dxkimrcga2y8hhyn4p11g4124ar5ly-postgresql-17.8' from 'https://cache.nixos.org'...
copying path '/nix/store/v790zwqwiybhlsls2sfkz5b4zn1fjvzj-babeltrace-1.5.11' from 'https://cache.nixos.org'...
copying path '/nix/store/71gpd7fhizmg6bn2jn005p4gp8p4s510-hadolint-2.14.0' from 'https://cache.nixos.org'...
copying path '/nix/store/f77qaqf4xzahrc81rp6bri52ma49lpyh-nix-output-monitor-2.1.8' from 'https://cache.nixos.org'...
copying path '/nix/store/mx074pqc80mhvcphb6kv93h7qyrlgxnr-rust-stable-2026-02-12' from 'https://cache.eidetica.dev'...
copying path '/nix/store/r5wyb2a3c0sa5b6bqwkzcabp30nvdy4d-rustc-nightly-complete-2026-02-28' from 'https://cache.eidetica.dev'...
copying path '/nix/store/i5kmqg3q40a7n5v0ax06rh22l9qp3xhm-shellcheck-0.11.0-bin' from 'https://cache.nixos.org'...
copying path '/nix/store/kpb8v9gmim23l94g7rsh91dn75q32d9a-libavif-1.3.0' from 'https://cache.nixos.org'...
copying path '/nix/store/iiaxpnv28vngxacp66k96qg7nnsg254h-slang-2.3.3' from 'https://cache.nixos.org'...
copying path '/nix/store/whs07fdxlw22fi8b3jzd2z871dh41qx6-sqlite-3.51.2' from 'https://cache.nixos.org'...
copying path '/nix/store/9jpblv3gg5kcki914i6cgr9icpqn2w14-gd-2.3.3' from 'https://cache.nixos.org'...
copying path '/nix/store/k87a0gv4hg1zmm8j5d3ffmxyvhr13i41-sqlite-3.51.2-bin' from 'https://cache.nixos.org'...
copying path '/nix/store/9lmh68dxfi83ip9al0dpjjlmclb3gq1x-shellcheck-0.11.0' from 'https://cache.nixos.org'...
copying path '/nix/store/q2014afk6bp02x3hfz2c94ai251mwzjj-stdenv-linux' from 'https://cache.nixos.org'...
copying path '/nix/store/4yi6jj75bb5hhdzpzlxfyf69d35wsf2x-binutils-wrapper-2.44' from 'https://cache.nixos.org'...
copying path '/nix/store/4w19rmimq1i2pljwbw8qw5jh406ald4l-systemd-minimal-libs-259-dev' from 'https://cache.nixos.org'...
building '/nix/store/ra8g0vncd3slqc5cxizfjlh3dnrppcrk-cargoHelperFunctionsHook.drv'...
building '/nix/store/9gyr3c5c6k3fihgwpqaar1bg3bkqrz7c-configureCargoCommonVarsHook.drv'...
copying path '/nix/store/fvrgm2qclcbl2fp1gj6x43llbkcbq9b1-util-linux-minimal-2.41.3-bin' from 'https://cache.nixos.org'...
building '/nix/store/4arj38yvg3bhfc2z2s9669c7ks40l250-configureCargoVendoredDepsHook.drv'...
copying path '/nix/store/xks3v41w0rqp27a17kwkybcvr39rxpl8-zstd-1.5.7-bin' from 'https://cache.nixos.org'...
copying path '/nix/store/87y9237m9c9m9mxk9ajwdfmn78vz6w2y-zlib-1.3.1-dev' from 'https://cache.nixos.org'...
building '/nix/store/vlibinkl01vk64a09qs0k997fwxvl3vg-inheritCargoArtifactsHook.drv'...
copying path '/nix/store/dsvli94p5s006zga0z6yawxhdk7vqzrx-nix-store-2.33.3' from 'https://cache.nixos.org'...
building '/nix/store/cq6w9k1mcfrsj4bv5xkg2hwksvd7b51r-installCargoArtifactsHook.drv'...
copying path '/nix/store/m1fw8l8y9ycxh5dzispbb7cwl6rra14l-python3-3.13.12' from 'https://cache.nixos.org'...
copying path '/nix/store/5j4mx4vckmmms2spy8x8kqjxcb12kpf5-sqlite-3.51.2-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/q2vpbpf8vqzizz6836vlw3n83cjr8bma-mold-unwrapped-wrapper-2.40.4' from 'https://cache.nixos.org'...
building '/nix/store/fd80d0nmf72ipiw96xcj701naa78jjxf-installFromCargoBuildLogHook.drv'...
copying path '/nix/store/lf619qllm0iaqilas3wq2vc1k76dk7pg-curl-8.18.0-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/dszpfwzkz14xd19bwm2yhs3cbvkpw88s-zstd-1.5.7-dev' from 'https://cache.nixos.org'...
building '/nix/store/rxn5ig6g8yiwjbmdkvrlsnimhd733rzb-removeReferencesToRustToolchainHook.drv'...
building '/nix/store/0p0mkxz1f3hsxv3sh6pnc1338nqbsrys-removeReferencesToVendoredSourcesHook.drv'...
building '/nix/store/nr1z19qwzyd7cmkfqwbyjpsld97la2a3-replaceCargoLockHook.drv'...
building '/nix/store/jc3cpzz9f5zblsadk548i2245i5qx7si-llvm-tools-nightly-x86_64-unknown-linux-gnu.tar.gz.drv'...
building '/nix/store/p0gqvy5msrsxdx52wvgadjrj1fx5ba0c-miri-nightly-x86_64-unknown-linux-gnu.tar.gz.drv'...
copying path '/nix/store/h4apbnz8p5fmjwcmzlaxcjm5vr70d97x-nodejs-slim-24.13.0' from 'https://cache.nixos.org'...
copying path '/nix/store/hkfzfl5crrwyc572kmzhvwj7c6lrz2i0-nix-fetchers-2.33.3' from 'https://cache.nixos.org'...
copying path '/nix/store/kgbiv7mn5w9vg6iy5jk1jx2wa3wchl09-nix-main-2.33.3' from 'https://cache.nixos.org'...
copying path '/nix/store/sghf8qk47wbfj0lisj5kw3h2pw1mny8w-util-linux-minimal-2.41.3-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/syiw15mnd7pshmxcbrqxl53zbh5dm1jz-nix-expr-2.33.3' from 'https://cache.nixos.org'...
copying path '/nix/store/ry4myrsmhjhn1xkw8v8yhjpx3ilhf2wh-nix-flake-2.33.3' from 'https://cache.nixos.org'...
copying path '/nix/store/iz8hs7sbhr97ijyy7phh03qy4qwl0hbs-nix-cmd-2.33.3' from 'https://cache.nixos.org'...
copying path '/nix/store/m8llbls90bg5d79l07jd7gcgrc8d87dn-perl5.42.0-Devel-Cover-1.44' from 'https://cache.nixos.org'...
copying path '/nix/store/5v3pw4ihihy9fvn1xkl93id564h76fpa-perl5.42.0-GD-2.78' from 'https://cache.nixos.org'...
copying path '/nix/store/id94vaa9927psjvcbg7fcdcmg487rcjq-perl5.42.0-JSON-XS-4.03' from 'https://cache.nixos.org'...
copying path '/nix/store/qjzvm6lzzdpmbw622mhjb0p0nia6y0hh-perl5.42.0-Memory-Usage-0.201' from 'https://cache.nixos.org'...
copying path '/nix/store/2c4kkrrlgzaiijd8g0wv01wxgn4657ha-perl5.42.0-Package-Stash-0.40' from 'https://cache.nixos.org'...
copying path '/nix/store/xxxiiqjcir30wgyr24cx9s1a135flfhw-perl5.42.0-libwww-perl-6.72' from 'https://cache.nixos.org'...
copying path '/nix/store/smczcks9wp95w6jzaj8y3n6525axkcr5-perl5.42.0-namespace-clean-0.27' from 'https://cache.nixos.org'...
copying path '/nix/store/6fy75w25xlhrmpv7ngms0yf3blp2b2yk-perl5.42.0-Memory-Process-0.06' from 'https://cache.nixos.org'...
copying path '/nix/store/k8bq1akp35ambbf855b4943m030bbvq2-perl5.42.0-namespace-autoclean-0.29' from 'https://cache.nixos.org'...
copying path '/nix/store/b6wjw1hx342f33a4xjf7h2l95npm4x2z-nix-2.33.3' from 'https://cache.nixos.org'...
copying path '/nix/store/ha8q0vf8z1hi1xpqk55a5k765xg8z6fy-nix-eval-jobs-2.33.1' from 'https://cache.nixos.org'...
copying path '/nix/store/237v56bwn7wn2vxybh3shgc1zf72zgkw-perl5.42.0-DateTime-TimeZone-2.60' from 'https://cache.nixos.org'...
copying path '/nix/store/x2ryh54fy3z3309pi4d5ji81mx77p2yx-perl5.42.0-DateTime-Locale-1.39' from 'https://cache.nixos.org'...
copying path '/nix/store/fq3wd7q7b351yilk246qms11qyh4dy4j-perl5.42.0-DateTime-1.59' from 'https://cache.nixos.org'...
copying path '/nix/store/pfkrik20c35kysksmsh31jwmni1dfjmx-perl5.42.0-DateTime-Format-W3CDTF-0.08' from 'https://cache.nixos.org'...
copying path '/nix/store/rwkg6mdhrv2j9471kqmck3i4cn6z5g1x-nodejs-slim-24.13.0-corepack' from 'https://cache.nixos.org'...
copying path '/nix/store/84a9a50f29spa8s45bpamq658srndhdf-nodejs-slim-24.13.0-npm' from 'https://cache.nixos.org'...
copying path '/nix/store/ap0rgwkaxk7rvzb0j2kignfraafnkg4b-perf-linux-6.19.3' from 'https://cache.nixos.org'...
copying path '/nix/store/x3asbshpzyxws7jldywcp8923s45j8qc-python3.13-pyflakes-3.4.0' from 'https://cache.nixos.org'...
copying path '/nix/store/imindlm08wk8n5d0yhmm0ap3gcymqxdk-python3.13-pyyaml-6.0.3' from 'https://cache.nixos.org'...
copying path '/nix/store/k5g9niar56yl1sk0qzhn2mkmmh5nrpwg-nix-fast-build-1.3.0' from 'https://cache.nixos.org'...
copying path '/nix/store/xqggqw0avfnhmdvy7mn2f97a6w3g0sqa-lcov-2.4' from 'https://cache.nixos.org'...
copying path '/nix/store/8x49w8i0vafv34rlc6h4a0f7z0z2qpb5-git-2.53.0' from 'https://cache.nixos.org'...
copying path '/nix/store/n2k9fic5mf7j8sw59vr4vf4fx5lzkq7z-python3.13-pathspec-0.12.1' from 'https://cache.nixos.org'...
copying path '/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0' from 'https://cache.nixos.org'...
copying path '/nix/store/a6k0l2naclakdmypd5frw9bgzyawnlmi-python3.13-yamllint-1.37.1' from 'https://cache.nixos.org'...
copying path '/nix/store/pafy6lli47c2fhrnxanz4wdmcy9932ix-actionlint-1.7.11' from 'https://cache.nixos.org'...
copying path '/nix/store/d2r4prwfc5vp3v1w70vxhv0fvhgrz7m8-markdownlint-cli-0.47.0' from 'https://cache.nixos.org'...
copying path '/nix/store/xdfb5f50gczga54xyaz79v4wj9hz21d3-prettier-3.6.2' from 'https://cache.nixos.org'...
copying path '/nix/store/4y0izjzly25ip9y086n1c37767qracci-cargo-flamegraph-0.6.11' from 'https://cache.nixos.org'...
copying path '/nix/store/kbw2j1vag664b3sj3rjwz9v53cqx87sb-gcc-wrapper-15.2.0' from 'https://cache.nixos.org'...
copying path '/nix/store/i2wjlac66sas7r3hv2r0jqpb45r8lhgx-release-plz-0.3.156' from 'https://cache.nixos.org'...
copying path '/nix/store/zkiy4zv8wz3v95bj6fdmkqwql8x1vnhb-stdenv-linux' from 'https://cache.nixos.org'...
building '/nix/store/8aw478va9rph8njr2w84xl749jg0kjbl-llvm-tools-preview-nightly-complete-2026-02-28.drv'...
building '/nix/store/6yg2237ashi36bq4asddq4pxvyz762nc-rust-nightly-complete-with-components-2026-02-28.drv'...
copying path '/nix/store/i209l2gb220326l7p3fk1b5bhd09x63a-rustfmt-preview-nightly-complete-2026-02-28' from 'https://cache.eidetica.dev'...
building '/nix/store/2sq7d5h5kpv9xka4dgw69haa3v99f95z-miri-preview-nightly-complete-2026-02-28.drv'...
copying path '/nix/store/62249whr4b2bhp13b3mxkkn08n7w8piw-rust-nightly-complete-with-components-2026-02-28' from 'https://cache.eidetica.dev'...
building '/nix/store/a2r654mlkb31gjfnschvplhckchw7a0x-clippy-nightly-complete-with-src-2026-02-28.drv'...
copying path '/nix/store/f160pmgwc710rrc5c2vjgach0xfxa4nm-clang-21.1.8-lib' from 'https://cache.nixos.org'...
copying path '/nix/store/8pkfxq43pva8va7izw27pjb3qzd00rgb-lld-21.1.8' from 'https://cache.nixos.org'...
copying path '/nix/store/344zmxispaqv91c7wlsfqyf7gvpv3wj2-llvm-21.1.8' from 'https://cache.nixos.org'...
building '/nix/store/3gml06hrjsbwb1121zm49w0g7akmimy2-rust-nightly-complete-with-components-2026-02-28.drv'...
copying path '/nix/store/g8r229mkcdkkgfg5h90dp51a9rakvhfg-llvm-21.1.8-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/nw2ba6r7i00mld1p8da9y8hpxai4swrf-llvm-binutils-21.1.8' from 'https://cache.nixos.org'...
copying path '/nix/store/0kh0x0a3ajkzxyy6v8yjvnfh6dnkbxic-llvm-binutils-wrapper-21.1.8' from 'https://cache.nixos.org'...
building '/nix/store/01ag8hjpypvgcs9w6k6xm8pr8xpap05x-cargo-nightly.drv'...
copying path '/nix/store/482i7k840pk0cmv6qhf4rf5gyah1lq8l-clang-21.1.8' from 'https://cache.nixos.org'...
copying path '/nix/store/97vplpbajnr7x03fqh9biz5v6960sv22-clang-wrapper-21.1.8' from 'https://cache.nixos.org'...
copying path '/nix/store/xydgaqq7mhh4mz8yl02ymbmqs06392p6-postgresql-17.8-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/g45h5d91vlz9lsxwa10znr4ys37vzh6l-rust-stable-2026-02-12' from 'https://cache.eidetica.dev'...
building '/nix/store/grvxav3c9159vrsnz48lljyxw77pym5j-eidetica-env.drv'...
this path will be fetched (107.5 KiB download, 107.4 KiB unpacked):
  /nix/store/5vmwpgmif2wa2hw5ip3ab6q40wvyfw2w-bash-interactive-5.3p9-man
copying path '/nix/store/5vmwpgmif2wa2hw5ip3ab6q40wvyfw2w-bash-interactive-5.3p9-man' from 'https://cache.nixos.org'...
Eidetica Development Shell

Run 'just' to see available commands

    Updating crates.io index
     Locking 140 packages to latest compatible versions
    Updating anstream v0.6.21 -> v1.0.0
    Updating anstyle v1.0.13 -> v1.0.14
    Updating anstyle-parse v0.2.7 -> v1.0.0
    Updating anyhow v1.0.100 -> v1.0.102
    Updating arc-swap v1.8.1 -> v1.9.0
      Adding aws-lc-rs v1.16.2
      Adding aws-lc-sys v0.39.1
    Updating bitflags v2.10.0 -> v2.11.0
    Updating blake3 v1.8.3 -> v1.8.4
    Updating bumpalo v3.19.1 -> v3.20.2
    Updating cc v1.2.55 -> v1.2.58
      Adding cesu8 v1.1.0
    Updating chrono v0.4.43 -> v0.4.44
    Updating clap v4.5.57 -> v4.6.0
    Updating clap_builder v4.5.57 -> v4.6.0
    Updating clap_derive v4.5.55 -> v4.6.0
    Updating clap_lex v0.7.7 -> v1.1.0
      Adding cmake v0.1.58
    Updating colorchoice v1.0.4 -> v1.0.5
      Adding combine v4.6.7
      Adding core-foundation v0.10.1
      Adding cpufeatures v0.3.0
    Updating der v0.8.0-rc.10 -> v0.8.0
    Updating deranged v0.5.5 -> v0.5.8
      Adding dunce v1.0.5
    Updating euclid v0.22.13 -> v0.22.14
      Adding fs_extra v1.3.0
    Updating futures v0.3.31 -> v0.3.32
    Updating futures-buffered v0.2.12 -> v0.2.13
    Updating futures-channel v0.3.31 -> v0.3.32
    Updating futures-core v0.3.31 -> v0.3.32
    Updating futures-executor v0.3.31 -> v0.3.32
    Updating futures-io v0.3.31 -> v0.3.32
    Updating futures-macro v0.3.31 -> v0.3.32
    Updating futures-sink v0.3.31 -> v0.3.32
    Updating futures-task v0.3.31 -> v0.3.32
    Updating futures-util v0.3.31 -> v0.3.32
      Adding getrandom v0.4.2
    Updating hybrid-array v0.4.7 -> v0.4.10
    Updating hyper v1.8.1 -> v1.9.0
      Adding id-arena v2.3.0
    Updating instability v0.3.11 -> v0.3.12
    Updating ipconfig v0.3.2 -> v0.3.4
    Updating ipnet v2.11.0 -> v2.12.0
    Updating iri-string v0.7.10 -> v0.7.12
    Updating iroh-metrics v0.38.2 -> v0.38.3
    Updating itoa v1.0.17 -> v1.0.18
      Adding jni v0.21.1
      Adding jni-sys v0.3.1
      Adding jni-sys v0.4.1
      Adding jni-sys-macros v0.4.1
      Adding jobserver v0.1.34
    Updating js-sys v0.3.85 -> v0.3.94
    Updating kasuari v0.4.11 -> v0.4.12
      Adding leb128fmt v0.1.0
    Updating libc v0.2.180 -> v0.2.183
    Updating libredox v0.1.12 -> v0.1.15
    Updating line-clipping v0.3.5 -> v0.3.7
    Updating linux-raw-sys v0.11.0 -> v0.12.1
    Updating memchr v2.7.6 -> v2.8.0
    Updating mio v1.1.1 -> v1.2.0
    Updating moka v0.12.13 -> v0.12.15
    Updating netdev v0.40.0 -> v0.40.1
    Updating netlink-packet-route v0.25.1 -> v0.29.0
    Updating num-conv v0.2.0 -> v0.2.1
    Updating num_enum v0.7.5 -> v0.7.6
    Updating num_enum_derive v0.7.5 -> v0.7.6
    Updating once_cell v1.21.3 -> v1.21.4
      Adding openssl-probe v0.2.1
    Updating papaya v0.2.3 -> v0.2.4
    Updating pin-project v1.1.10 -> v1.1.11
    Updating pin-project-internal v1.1.10 -> v1.1.11
    Updating pin-project-lite v0.2.16 -> v0.2.17
    Removing pin-utils v0.1.0
    Updating pkarr v5.0.2 -> v5.0.4
    Updating pkcs8 v0.11.0-rc.10 -> v0.11.0-rc.11
      Adding plain v0.2.3
      Adding prettyplease v0.2.37
    Updating proc-macro-crate v3.4.0 -> v3.5.0
    Updating quinn-proto v0.11.13 -> v0.11.14
    Updating quote v1.0.44 -> v1.0.45
      Adding r-efi v6.0.0
    Updating redox_syscall v0.7.0 -> v0.7.3
    Updating regex-syntax v0.8.9 -> v0.8.10
      Adding reqwest v0.13.2
    Updating rustc-hash v2.1.1 -> v2.1.2
    Updating rustix v1.1.3 -> v1.1.4
    Updating rustls v0.23.36 -> v0.23.37
      Adding rustls-native-certs v0.8.3
      Adding rustls-platform-verifier v0.6.2
      Adding rustls-platform-verifier-android v0.1.1
    Updating rustls-webpki v0.103.9 -> v0.103.10
    Updating ryu v1.0.22 -> v1.0.23
      Adding schannel v0.1.29
      Adding security-framework v3.7.0
      Adding security-framework-sys v2.17.0
    Updating simple-dns v0.9.3 -> v0.11.2
    Removing socket2 v0.5.10
    Removing socket2 v0.6.2
      Adding socket2 v0.6.3
    Updating syn v2.0.114 -> v2.0.117
    Updating tempfile v3.24.0 -> v3.27.0
    Updating tinyvec v1.10.0 -> v1.11.0
    Updating tokio v1.49.0 -> v1.50.0
    Updating tokio-macros v2.6.0 -> v2.6.1
    Updating toml_datetime v0.7.5+spec-1.1.0 -> v1.1.1+spec-1.1.0
    Updating toml_edit v0.23.10+spec-1.0.0 -> v0.25.9+spec-1.1.0
    Updating toml_parser v1.0.6+spec-1.1.0 -> v1.1.1+spec-1.1.0
    Updating tracing-subscriber v0.3.22 -> v0.3.23
    Updating unicode-ident v1.0.22 -> v1.0.24
    Updating unicode-segmentation v1.12.0 -> v1.13.2
    Updating uuid v1.20.0 -> v1.23.0
      Adding wasip3 v0.4.0+wasi-0.3.0-rc-2026-01-06
    Updating wasm-bindgen v0.2.108 -> v0.2.117
    Updating wasm-bindgen-futures v0.4.58 -> v0.4.67
    Updating wasm-bindgen-macro v0.2.108 -> v0.2.117
    Updating wasm-bindgen-macro-support v0.2.108 -> v0.2.117
    Updating wasm-bindgen-shared v0.2.108 -> v0.2.117
      Adding wasm-encoder v0.244.0
      Adding wasm-metadata v0.244.0
      Adding wasmparser v0.244.0
    Updating web-sys v0.3.85 -> v0.3.94
      Adding webpki-root-certs v1.0.6
      Adding windows-registry v0.6.1
      Adding windows-sys v0.45.0
      Adding windows-targets v0.42.2
      Adding windows_aarch64_gnullvm v0.42.2
      Adding windows_aarch64_msvc v0.42.2
      Adding windows_i686_gnu v0.42.2
      Adding windows_i686_msvc v0.42.2
      Adding windows_x86_64_gnu v0.42.2
      Adding windows_x86_64_gnullvm v0.42.2
      Adding windows_x86_64_msvc v0.42.2
    Updating winnow v0.7.14 -> v1.0.1
    Removing winreg v0.50.0
      Adding wit-bindgen-core v0.51.0
      Adding wit-bindgen-rust v0.51.0
      Adding wit-bindgen-rust-macro v0.51.0
      Adding wit-component v0.244.0
      Adding wit-parser v0.244.0
    Updating wmi v0.18.3 -> v0.18.4
    Updating zerocopy v0.8.38 -> v0.8.48
    Updating zerocopy-derive v0.8.38 -> v0.8.48
    Updating zmij v1.0.19 -> v1.0.21
note: pass `--verbose` to see 11 unchanged dependencies behind latest
```

</details>

<details>
<summary>Diff stats</summary>

```
 Cargo.lock | 1121 +++++++++++++++++++++++++++++++++++++++++++-----------------
 1 file changed, 804 insertions(+), 317 deletions(-)
```

</details>

### Hold

This PR is on hold until **2026-04-08** (7-day waiting period).
The `on-hold` label will be automatically removed after the hold expires.

<!-- hold-until: 2026-04-08 -->