### PR TITLE
chore(deps): update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1772080396,
-        "narHash": "sha256-84W9UNtSk9DNMh43WBkOjpkbfODlmg+RDi854PnNgLE=",
+        "lastModified": 1774313767,
+        "narHash": "sha256-hy0XTQND6avzGEUFrJtYBBpFa/POiiaGBr2vpU6Y9tY=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "8525580bc0316c39dbfa18bd09a1331e98c9e463",
+        "rev": "3d9df76e29656c679c744968b17fbaf28f0e923d",
         "type": "github"
       },
       "original": {
@@ -23,11 +23,11 @@
         "rust-analyzer-src": []
       },
       "locked": {
-        "lastModified": 1772261909,
-        "narHash": "sha256-8XbJXrhMFhLgoBrjFIJx5XJi+SD+7/gbvaIXCuqy9Z0=",
+        "lastModified": 1774942139,
+        "narHash": "sha256-Wib0RDVsptJWQd2ldBgFpMF0kRjQKHejQq9an+ActYo=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "e4c413b9546d6c9e6426b33b4d6de1a49a375024",
+        "rev": "0beafd2252f80385610e2f12cbecfdb9d2dfb0a0",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769996383,
-        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
+        "lastModified": 1772408722,
+        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
+        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772198003,
-        "narHash": "sha256-I45esRSssFtJ8p/gLHUZ1OUaaTaVLluNkABkk6arQwE=",
+        "lastModified": 1774709303,
+        "narHash": "sha256-D3Q07BbIA2KnTcSXIqqu9P586uWxN74zNoCH3h2ESHg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "dd9b079222d43e1943b6ebd802f04fd959dc8e61",
+        "rev": "8110df5ad7abf5d4c0f6fb0f8f978390e77f9685",
         "type": "github"
       },
       "original": {
@@ -88,11 +88,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770228511,
-        "narHash": "sha256-wQ6NJSuFqAEmIg2VMnLdCnUc0b7vslUohqqGGD+Fyxk=",
+        "lastModified": 1773297127,
+        "narHash": "sha256-6E/yhXP7Oy/NbXtf1ktzmU8SdVqJQ09HC/48ebEGBpk=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "337a4fe074be1042a35086f15481d763b8ddc0e7",
+        "rev": "71b125cd05fbfd78cab3e070b73544abe24c5016",
         "type": "github"
       },
       "original": {

--- a/nix/packages/doc.nix
+++ b/nix/packages/doc.nix
@@ -61,7 +61,7 @@
 
   doc-links =
     pkgs.runCommand "doc-links" {
-      nativeBuildInputs = [pkgs.lychee];
+      nativeBuildInputs = [pkgs.lychee pkgs.cacert];
     } ''
       lychee --offline ${lycheeArgs} ${doc-site}
       mkdir -p $out


### PR DESCRIPTION
## Flake Input Update

Monthly `nix flake update` of Nix dependencies.

### Input Changes

- **crane**: [`8525580` → `3d9df76`](https://github.com/ipetkov/crane/compare/8525580bc0316c39dbfa18bd09a1331e98c9e463...3d9df76e29656c679c744968b17fbaf28f0e923d)
- **fenix**: [`e4c413b` → `0beafd2`](https://github.com/nix-community/fenix/compare/e4c413b9546d6c9e6426b33b4d6de1a49a375024...0beafd2252f80385610e2f12cbecfdb9d2dfb0a0)
- **flake-parts**: [`5792860` → `f20dc5d`](https://github.com/hercules-ci/flake-parts/compare/57928607ea566b5db3ad13af0e57e921e6b12381...f20dc5d9b8027381c474144ecabc9034d6a839a3)
- **nixpkgs**: [`dd9b079` → `8110df5`](https://github.com/nixos/nixpkgs/compare/dd9b079222d43e1943b6ebd802f04fd959dc8e61...8110df5ad7abf5d4c0f6fb0f8f978390e77f9685)
- **treefmt-nix**: [`337a4fe` → `71b125c`](https://github.com/numtide/treefmt-nix/compare/337a4fe074be1042a35086f15481d763b8ddc0e7...71b125cd05fbfd78cab3e070b73544abe24c5016)


<details>
<summary>nix flake update output</summary>

```
unpacking 'github:ipetkov/crane/3d9df76e29656c679c744968b17fbaf28f0e923d' into the Git cache...
unpacking 'github:nix-community/fenix/0beafd2252f80385610e2f12cbecfdb9d2dfb0a0' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/f20dc5d9b8027381c474144ecabc9034d6a839a3' into the Git cache...
unpacking 'github:nixos/nixpkgs/8110df5ad7abf5d4c0f6fb0f8f978390e77f9685' into the Git cache...
unpacking 'github:numtide/treefmt-nix/71b125cd05fbfd78cab3e070b73544abe24c5016' into the Git cache...
warning: updating lock file "/home/runner/work/eidetica/eidetica/flake.lock":
• Updated input 'crane':
    'github:ipetkov/crane/8525580' (2026-02-26)
  → 'github:ipetkov/crane/3d9df76' (2026-03-24)
• Updated input 'fenix':
    'github:nix-community/fenix/e4c413b' (2026-02-28)
  → 'github:nix-community/fenix/0beafd2' (2026-03-31)
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/5792860' (2026-02-02)
  → 'github:hercules-ci/flake-parts/f20dc5d' (2026-03-01)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/dd9b079' (2026-02-27)
  → 'github:nixos/nixpkgs/8110df5' (2026-03-28)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/337a4fe' (2026-02-04)
  → 'github:numtide/treefmt-nix/71b125c' (2026-03-12)
```

</details>

### Hold

This PR is on hold until **2026-04-08** (7-day waiting period).
The `on-hold` label will be automatically removed after the hold expires.

<!-- hold-until: 2026-04-08 -->