### PR TITLE
fix(sync): fire write callbacks for remotely synced entries

### DIFF
--- a/crates/lib/src/database/mod.rs
+++ b/crates/lib/src/database/mod.rs
@@ -23,7 +23,7 @@ use crate::{
     constants::{ROOT, SETTINGS},
     crdt::Doc,
     entry::{Entry, ID},
-    instance::{WriteSource, backend::Backend, errors::InstanceError},
+    instance::{WriteCallback, WriteEvent, backend::Backend, errors::InstanceError},
     store::{SettingsStore, Store},
 };
 
@@ -565,74 +565,39 @@ impl Database {
         self.key.as_ref().map(|k| &k.identity)
     }
 
-    /// Register an Instance-wide callback to be invoked when entries are written locally to this database.
+    /// Register a callback to be invoked when entries are written to this database.
     ///
-    /// Local writes are those originating from transaction commits in the current Instance.
-    /// The callback receives the entry, database, and instance as parameters, providing
-    /// full context for any coordination or side effects needed.
+    /// The callback fires for **both** local writes (transaction commits) and remote
+    /// writes (sync). Branch on [`WriteEvent::source`](crate::WriteEvent::source) inside
+    /// the closure if you only care about one.
     ///
-    /// **Important:** This callback is registered at the Instance level and will fire for all local
-    /// writes to the database tree (identified by root ID), regardless of which Database handle
-    /// performed the write. Multiple Database handles pointing to the same root ID share the same
-    /// set of callbacks.
+    /// Returns a [`WriteCallback`] handle. **Drop it to unregister.** Call
+    /// [`WriteCallback::detach`] to leave the callback registered for the life
+    /// of the [`Instance`] without holding the handle.
     ///
-    /// # Arguments
-    /// * `callback` - Function to invoke on local writes to this database tree
+    /// **Important:** Callbacks are registered at the Instance level and fire for all
+    /// writes to the database tree (identified by root ID), regardless of which
+    /// `Database` handle performed the write or registered the callback.
     ///
-    /// # Returns
-    /// A Result indicating success or failure
+    /// # Callback contract
     ///
-    /// # Example
-    /// ```rust,no_run
-    /// # use eidetica::*;
-    /// # use eidetica::crdt::Doc;
-    /// # use eidetica::backend::database::InMemory;
-    /// # use eidetica::auth::crypto::PrivateKey;
-    /// # #[tokio::main]
-    /// # async fn main() -> Result<()> {
-    /// let instance = Instance::open(Box::new(InMemory::new())).await?;
-    /// # let settings = eidetica::crdt::Doc::new();
-    /// # let signing_key = PrivateKey::generate();
-    /// # let database = Database::create(&instance, signing_key, Doc::new()).await?;
-    ///
-    /// database.on_local_write(|entry, db, _instance| {
-    ///     let entry_id = entry.id().clone();
-    ///     let db_id = db.root_id().clone();
-    ///     Box::pin(async move {
-    ///         println!("Entry {} written to database {}", entry_id, db_id);
-    ///         Ok(())
-    ///     })
-    /// })?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn on_local_write<F, Fut>(&self, callback: F) -> Result<()>
-    where
-        F: for<'a> Fn(&'a Entry, &'a Database, &'a Instance) -> Fut
-            + Send
-            + std::marker::Sync
-            + 'static,
-        Fut: std::future::Future<Output = Result<()>> + Send + 'static,
-    {
-        let instance = self.instance()?;
-        instance.register_write_callback(WriteSource::Local, self.root_id().clone(), callback)
-    }
-
-    /// Register an Instance-wide callback to be invoked when entries are written remotely to this database.
-    ///
-    /// Remote writes are those originating from sync or replication from other nodes.
-    /// The callback receives the entry, database, and instance as parameters.
-    ///
-    /// **Important:** This callback is registered at the Instance level and will fire for all remote
-    /// writes to the database tree (identified by root ID), regardless of which Database handle
-    /// registered the callback. Multiple Database handles pointing to the same root ID share the same
-    /// set of callbacks.
-    ///
-    /// # Arguments
-    /// * `callback` - Function to invoke on remote writes to this database tree
-    ///
-    /// # Returns
-    /// A Result indicating success or failure
+    /// - **Local writes**: fires once per transaction commit; the [`WriteEvent`]
+    ///   contains exactly one entry.
+    /// - **Remote writes**: fires once per sync batch (not per entry); the
+    ///   [`WriteEvent`] may contain multiple entries received together.
+    /// - All entries in the event are fully persisted before the callback fires.
+    /// - [`WriteEvent::previous_tips`] contains the DAG tips from before the
+    ///   write, so consumers can determine exactly what changed.
+    /// - Errors are logged but do not prevent other callbacks from running.
+    /// - The `db` argument is a **read-only** [`Database`] handle (no
+    ///   [`DatabaseKey`] configured): you can read settings, entries, and
+    ///   metadata, but cannot commit transactions through it. To write from
+    ///   inside a callback, resolve through `db.instance()?` and open the
+    ///   database with the appropriate key.
+    /// - **Reentrance**: writes are serialized per-tree via an async lock
+    ///   that is held while callbacks run. A callback must not commit a
+    ///   transaction on the same tree it was invoked for — that would
+    ///   deadlock. Spawn a task or write to a different tree instead.
     ///
     /// # Example
     /// ```rust,no_run
@@ -643,31 +608,40 @@ impl Database {
     /// # #[tokio::main]
     /// # async fn main() -> Result<()> {
     /// let instance = Instance::open(Box::new(InMemory::new())).await?;
-    /// # let settings = eidetica::crdt::Doc::new();
     /// # let signing_key = PrivateKey::generate();
     /// # let database = Database::create(&instance, signing_key, Doc::new()).await?;
     ///
-    /// database.on_remote_write(|entry, db, _instance| {
-    ///     let entry_id = entry.id().clone();
+    /// let cb = database.on_write(|event, db| {
+    ///     let count = event.entries().len();
+    ///     let source = event.source();
     ///     let db_id = db.root_id().clone();
-    ///     Box::pin(async move {
-    ///         println!("Remote entry {} synced to database {}", entry_id, db_id);
+    ///     async move {
+    ///         println!("{count} entries written to {db_id} ({source:?})");
     ///         Ok(())
-    ///     })
+    ///     }
     /// })?;
+    ///
+    /// // Drop `cb` to unregister, or:
+    /// cb.detach(); // keep registered for the life of the Instance
     /// # Ok(())
     /// # }
     /// ```
-    pub fn on_remote_write<F, Fut>(&self, callback: F) -> Result<()>
+    ///
+    /// If a callback needs the [`Instance`], call [`Database::instance`] on
+    /// the `db` argument.
+    pub fn on_write<F, Fut>(&self, callback: F) -> Result<WriteCallback>
     where
-        F: for<'a> Fn(&'a Entry, &'a Database, &'a Instance) -> Fut
-            + Send
-            + std::marker::Sync
-            + 'static,
+        F: for<'a> Fn(&'a WriteEvent, &'a Database) -> Fut + Send + std::marker::Sync + 'static,
         Fut: std::future::Future<Output = Result<()>> + Send + 'static,
     {
         let instance = self.instance()?;
-        instance.register_write_callback(WriteSource::Remote, self.root_id().clone(), callback)
+        let tree_id = self.root_id().clone();
+        let id = instance.register_write_callback(tree_id.clone(), callback);
+        Ok(WriteCallback::new_per_database(
+            instance.downgrade(),
+            tree_id,
+            id,
+        ))
     }
 
     /// Get the ID of the root entry
@@ -677,9 +651,9 @@ impl Database {
 
     /// Upgrade the weak instance reference to a strong reference.
     ///
-    /// # Returns
-    /// A `Result` containing the Instance or an error if the Instance has been dropped.
-    pub(crate) fn instance(&self) -> Result<Instance> {
+    /// `Database` holds a [`WeakInstance`](crate::WeakInstance), so this can
+    /// fail if the owning [`Instance`] has already been dropped.
+    pub fn instance(&self) -> Result<Instance> {
         self.instance
             .upgrade()
             .ok_or_else(|| Error::Instance(Box::new(InstanceError::InstanceDropped)))

--- a/crates/lib/src/database/tests.rs
+++ b/crates/lib/src/database/tests.rs
@@ -1,7 +1,14 @@
 //! Tests for the database module.
 
+use std::sync::{Arc, Mutex};
+
 use super::*;
-use crate::{auth::crypto::generate_keypair, backend::database::InMemory};
+use crate::{
+    auth::crypto::generate_keypair,
+    backend::{VerificationStatus, database::InMemory},
+    instance::WriteSource,
+    store::DocStore,
+};
 
 #[tokio::test]
 async fn test_find_sigkeys_returns_sorted_by_permission() -> Result<()> {
@@ -102,4 +109,449 @@ async fn test_create_rejects_preconfigured_auth() -> Result<()> {
     );
 
     Ok(())
+}
+
+// ===== Write Callback Tests =====
+
+/// Helper: create an Instance + Database for callback tests
+async fn setup_callback_test() -> (Instance, Database) {
+    let instance = Instance::open(Box::new(InMemory::new())).await.unwrap();
+    let (signing_key, _) = generate_keypair();
+    let db = Database::create(&instance, signing_key, Doc::new())
+        .await
+        .unwrap();
+    (instance, db)
+}
+
+#[tokio::test]
+async fn test_local_write_callback_fires() {
+    let (_instance, db) = setup_callback_test().await;
+
+    type EventRecord = (Vec<crate::entry::ID>, WriteSource);
+    let events: Arc<Mutex<Vec<EventRecord>>> = Arc::new(Mutex::new(Vec::new()));
+    let events_clone = events.clone();
+
+    let _cb = db
+        .on_write(move |event, _db| {
+            let prev_tips = event.previous_tips().to_vec();
+            let source = event.source();
+            events_clone.lock().unwrap().push((prev_tips, source));
+            async { Ok(()) }
+        })
+        .unwrap();
+
+    // First commit
+    let txn = db.new_transaction().await.unwrap();
+    let store = txn.get_store::<DocStore>("data").await.unwrap();
+    store.set("key", "value1").await.unwrap();
+    let id1 = txn.commit().await.unwrap();
+
+    // Second commit
+    let txn = db.new_transaction().await.unwrap();
+    let store = txn.get_store::<DocStore>("data").await.unwrap();
+    store.set("key", "value2").await.unwrap();
+    let _id2 = txn.commit().await.unwrap();
+
+    let recorded = events.lock().unwrap();
+    assert_eq!(recorded.len(), 2, "callback should fire once per commit");
+    assert_eq!(recorded[0].1, WriteSource::Local);
+    assert_eq!(recorded[1].1, WriteSource::Local);
+    // Second callback's previous_tips should contain id1
+    assert!(
+        recorded[1].0.contains(&id1),
+        "previous_tips for second commit should contain the first commit's ID"
+    );
+}
+
+#[tokio::test]
+async fn test_local_write_event_contains_single_entry() {
+    let (_instance, db) = setup_callback_test().await;
+
+    let entry_counts: Arc<Mutex<Vec<usize>>> = Arc::new(Mutex::new(Vec::new()));
+    let counts_clone = entry_counts.clone();
+
+    let _cb = db
+        .on_write(move |event, _db| {
+            counts_clone.lock().unwrap().push(event.entries().len());
+            async { Ok(()) }
+        })
+        .unwrap();
+
+    let txn = db.new_transaction().await.unwrap();
+    let store = txn.get_store::<DocStore>("data").await.unwrap();
+    store.set("k", "v").await.unwrap();
+    txn.commit().await.unwrap();
+
+    let counts = entry_counts.lock().unwrap();
+    assert_eq!(counts.len(), 1);
+    assert_eq!(
+        counts[0], 1,
+        "local write events should contain exactly one entry"
+    );
+}
+
+#[tokio::test]
+async fn test_remote_write_callback_fires_via_put_remote_entries() {
+    let (instance, db) = setup_callback_test().await;
+
+    let remote_events: Arc<Mutex<Vec<(usize, WriteSource)>>> = Arc::new(Mutex::new(Vec::new()));
+    let events_clone = remote_events.clone();
+
+    let _cb = db
+        .on_write(move |event, _db| {
+            let source = event.source();
+            let count = event.entries().len();
+            let events = events_clone.clone();
+            async move {
+                if source == WriteSource::Remote {
+                    events.lock().unwrap().push((count, source));
+                }
+                Ok(())
+            }
+        })
+        .unwrap();
+
+    // Commit locally — should NOT record (callback filters to remote only)
+    let txn = db.new_transaction().await.unwrap();
+    let store = txn.get_store::<DocStore>("data").await.unwrap();
+    store.set("key", "local").await.unwrap();
+    let local_id = txn.commit().await.unwrap();
+
+    assert!(
+        remote_events.lock().unwrap().is_empty(),
+        "remote-only filter should drop local commits"
+    );
+
+    // Simulate remote sync via put_remote_entries
+    let entry = instance.get(db.root_id()).await.unwrap();
+    let local_entry = instance.get(&local_id).await.unwrap();
+    instance
+        .put_remote_entries(
+            db.root_id(),
+            VerificationStatus::Verified,
+            vec![entry, local_entry],
+        )
+        .await
+        .unwrap();
+
+    let events = remote_events.lock().unwrap();
+    assert_eq!(events.len(), 1, "should fire exactly once for the batch");
+    assert_eq!(events[0].0, 2, "batch should contain both entries");
+    assert_eq!(events[0].1, WriteSource::Remote);
+}
+
+#[tokio::test]
+async fn test_remote_write_previous_tips() {
+    let (instance, db) = setup_callback_test().await;
+
+    let prev_tips_log: Arc<Mutex<Vec<Vec<crate::entry::ID>>>> = Arc::new(Mutex::new(Vec::new()));
+    let log_clone = prev_tips_log.clone();
+
+    let _cb = db
+        .on_write(move |event, _db| {
+            let source = event.source();
+            let prev = event.previous_tips().to_vec();
+            let log = log_clone.clone();
+            async move {
+                if source == WriteSource::Remote {
+                    log.lock().unwrap().push(prev);
+                }
+                Ok(())
+            }
+        })
+        .unwrap();
+
+    // Commit locally to advance tips
+    let txn = db.new_transaction().await.unwrap();
+    let store = txn.get_store::<DocStore>("data").await.unwrap();
+    store.set("k", "v").await.unwrap();
+    let local_id = txn.commit().await.unwrap();
+
+    // Simulate remote write
+    let entry = instance.get(&local_id).await.unwrap();
+    instance
+        .put_remote_entries(db.root_id(), VerificationStatus::Verified, vec![entry])
+        .await
+        .unwrap();
+
+    let log = prev_tips_log.lock().unwrap();
+    assert_eq!(log.len(), 1);
+    assert!(
+        log[0].contains(&local_id),
+        "previous_tips should reflect state before the remote batch"
+    );
+}
+
+#[tokio::test]
+async fn test_empty_remote_batch_does_not_fire_callback() {
+    let (instance, db) = setup_callback_test().await;
+
+    let fire_count: Arc<Mutex<usize>> = Arc::new(Mutex::new(0));
+    let count_clone = fire_count.clone();
+
+    let _cb = db
+        .on_write(move |_event, _db| {
+            *count_clone.lock().unwrap() += 1;
+            async { Ok(()) }
+        })
+        .unwrap();
+
+    instance
+        .put_remote_entries(db.root_id(), VerificationStatus::Verified, vec![])
+        .await
+        .unwrap();
+
+    assert_eq!(*fire_count.lock().unwrap(), 0);
+}
+
+#[tokio::test]
+async fn test_callback_error_does_not_block_other_callbacks() {
+    let (_instance, db) = setup_callback_test().await;
+
+    let second_fired: Arc<Mutex<bool>> = Arc::new(Mutex::new(false));
+    let flag = second_fired.clone();
+
+    // First callback always errors
+    let _cb1 = db
+        .on_write(move |_event, _db| async {
+            Err(crate::Error::Io(std::io::Error::other("test error")))
+        })
+        .unwrap();
+
+    // Second callback should still execute
+    let _cb2 = db
+        .on_write(move |_event, _db| {
+            *flag.lock().unwrap() = true;
+            async { Ok(()) }
+        })
+        .unwrap();
+
+    let txn = db.new_transaction().await.unwrap();
+    let store = txn.get_store::<DocStore>("data").await.unwrap();
+    store.set("k", "v").await.unwrap();
+    txn.commit().await.unwrap();
+
+    assert!(*second_fired.lock().unwrap());
+}
+
+#[tokio::test]
+async fn test_drop_write_callback_unregisters() {
+    let (_instance, db) = setup_callback_test().await;
+
+    let fire_count: Arc<Mutex<usize>> = Arc::new(Mutex::new(0));
+    let count_clone = fire_count.clone();
+
+    let cb = db
+        .on_write(move |_event, _db| {
+            *count_clone.lock().unwrap() += 1;
+            async { Ok(()) }
+        })
+        .unwrap();
+
+    // Fires while handle is alive
+    let txn = db.new_transaction().await.unwrap();
+    let store = txn.get_store::<DocStore>("data").await.unwrap();
+    store.set("k", "v1").await.unwrap();
+    txn.commit().await.unwrap();
+    assert_eq!(*fire_count.lock().unwrap(), 1);
+
+    // Drop the handle — callback unregisters
+    drop(cb);
+
+    let txn = db.new_transaction().await.unwrap();
+    let store = txn.get_store::<DocStore>("data").await.unwrap();
+    store.set("k", "v2").await.unwrap();
+    txn.commit().await.unwrap();
+    assert_eq!(
+        *fire_count.lock().unwrap(),
+        1,
+        "callback should not fire after WriteCallback is dropped"
+    );
+}
+
+#[tokio::test]
+async fn test_drop_only_unregisters_that_callback() {
+    let (_instance, db) = setup_callback_test().await;
+
+    let cb1_count: Arc<Mutex<usize>> = Arc::new(Mutex::new(0));
+    let cb2_count: Arc<Mutex<usize>> = Arc::new(Mutex::new(0));
+
+    let cb1_clone = cb1_count.clone();
+    let cb1 = db
+        .on_write(move |_event, _db| {
+            *cb1_clone.lock().unwrap() += 1;
+            async { Ok(()) }
+        })
+        .unwrap();
+
+    let cb2_clone = cb2_count.clone();
+    let _cb2 = db
+        .on_write(move |_event, _db| {
+            *cb2_clone.lock().unwrap() += 1;
+            async { Ok(()) }
+        })
+        .unwrap();
+
+    // Both fire on the first commit
+    let txn = db.new_transaction().await.unwrap();
+    let store = txn.get_store::<DocStore>("data").await.unwrap();
+    store.set("k", "v1").await.unwrap();
+    txn.commit().await.unwrap();
+    assert_eq!(*cb1_count.lock().unwrap(), 1);
+    assert_eq!(*cb2_count.lock().unwrap(), 1);
+
+    drop(cb1);
+
+    // Only cb2 fires after cb1 is dropped
+    let txn = db.new_transaction().await.unwrap();
+    let store = txn.get_store::<DocStore>("data").await.unwrap();
+    store.set("k", "v2").await.unwrap();
+    txn.commit().await.unwrap();
+    assert_eq!(*cb1_count.lock().unwrap(), 1);
+    assert_eq!(*cb2_count.lock().unwrap(), 2);
+}
+
+#[tokio::test]
+async fn test_remote_callback_receives_only_stored_entries() {
+    let (instance, db) = setup_callback_test().await;
+
+    let captured: Arc<Mutex<Vec<crate::entry::ID>>> = Arc::new(Mutex::new(Vec::new()));
+    let captured_clone = captured.clone();
+
+    db.on_write(move |event, _db| {
+        let ids: Vec<_> = event.entries().iter().map(|e| e.id()).collect();
+        let source = event.source();
+        let captured = captured_clone.clone();
+        async move {
+            if source == WriteSource::Remote {
+                captured.lock().unwrap().extend(ids);
+            }
+            Ok(())
+        }
+    })
+    .unwrap()
+    .detach();
+
+    // Build entries via local commits, then re-feed them as a remote batch.
+    let txn = db.new_transaction().await.unwrap();
+    let store = txn.get_store::<DocStore>("data").await.unwrap();
+    store.set("k", "v1").await.unwrap();
+    let id1 = txn.commit().await.unwrap();
+
+    let txn = db.new_transaction().await.unwrap();
+    let store = txn.get_store::<DocStore>("data").await.unwrap();
+    store.set("k", "v2").await.unwrap();
+    let id2 = txn.commit().await.unwrap();
+
+    let entry1 = instance.get(&id1).await.unwrap();
+    let entry2 = instance.get(&id2).await.unwrap();
+
+    instance
+        .put_remote_entries(
+            db.root_id(),
+            VerificationStatus::Verified,
+            vec![entry1, entry2],
+        )
+        .await
+        .unwrap();
+
+    // The callback's WriteEvent.entries() must contain exactly the entries
+    // that were stored — no more, no less, in input order. This pins the
+    // contract: storage failures inside put_remote_entries are silent skips,
+    // and the callback only sees `stored_entries`. (The in-memory backend
+    // doesn't make it easy to inject a partial-store failure; we exercise the
+    // success path here and rely on code review for the failure branch.)
+    let captured_ids = captured.lock().unwrap();
+    assert_eq!(captured_ids.len(), 2);
+    assert_eq!(captured_ids[0], id1);
+    assert_eq!(captured_ids[1], id2);
+}
+
+#[tokio::test]
+async fn test_detached_write_callback_outlives_handle() {
+    let (_instance, db) = setup_callback_test().await;
+
+    let fire_count: Arc<Mutex<usize>> = Arc::new(Mutex::new(0));
+    let count_clone = fire_count.clone();
+
+    db.on_write(move |_event, _db| {
+        *count_clone.lock().unwrap() += 1;
+        async { Ok(()) }
+    })
+    .unwrap()
+    .detach();
+
+    let txn = db.new_transaction().await.unwrap();
+    let store = txn.get_store::<DocStore>("data").await.unwrap();
+    store.set("k", "v").await.unwrap();
+    txn.commit().await.unwrap();
+    assert_eq!(*fire_count.lock().unwrap(), 1);
+}
+
+// Regression test for the per-tree `tree_locks` serialization in
+// `Instance::put_entry` / `put_remote_entries`. Two concurrent writers on the
+// same tree must observe a serial `previous_tips` chain — one callback's
+// `previous_tips` must include the other event's entry. Without the lock,
+// both writers snapshot tips before either persists, and neither callback
+// reflects the other write.
+//
+// Uses `tokio::spawn` (not `join!`) on a multi-thread runtime to get real
+// parallelism — `join!` polls both futures cooperatively from the same task
+// and would not expose the race even when the lock is removed. Repeats the
+// concurrent-pair scenario for many iterations because the race window in
+// the in-memory backend is narrow; with the lock every iteration must
+// serialize, so any single un-serialized iteration fails the test.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_concurrent_writes_serialize_previous_tips() {
+    const ITERATIONS: usize = 100;
+
+    for iter in 0..ITERATIONS {
+        let (_instance, db) = setup_callback_test().await;
+
+        type EventRecord = (Vec<crate::entry::ID>, Vec<crate::entry::ID>);
+        let events: Arc<Mutex<Vec<EventRecord>>> = Arc::new(Mutex::new(Vec::new()));
+        let events_clone = events.clone();
+
+        let _cb = db
+            .on_write(move |event, _db| {
+                let prev = event.previous_tips().to_vec();
+                let ids: Vec<_> = event.entries().iter().map(|e| e.id()).collect();
+                events_clone.lock().unwrap().push((prev, ids));
+                async { Ok(()) }
+            })
+            .unwrap();
+
+        let db_a = db.clone();
+        let db_b = db.clone();
+        let h1 = tokio::spawn(async move {
+            let txn = db_a.new_transaction().await.unwrap();
+            let store = txn.get_store::<DocStore>("d").await.unwrap();
+            store.set("k1", "v1").await.unwrap();
+            txn.commit().await.unwrap()
+        });
+        let h2 = tokio::spawn(async move {
+            let txn = db_b.new_transaction().await.unwrap();
+            let store = txn.get_store::<DocStore>("d").await.unwrap();
+            store.set("k2", "v2").await.unwrap();
+            txn.commit().await.unwrap()
+        });
+        let id1 = h1.await.unwrap();
+        let id2 = h2.await.unwrap();
+
+        let recorded = events.lock().unwrap();
+        assert_eq!(
+            recorded.len(),
+            2,
+            "iter {iter}: both writes should fire callbacks"
+        );
+
+        let serialized = recorded
+            .iter()
+            .any(|(prev, _)| prev.contains(&id1) || prev.contains(&id2));
+        assert!(
+            serialized,
+            "iter {iter}: concurrent writes must produce a serial previous_tips chain; got events: {:?}",
+            *recorded
+        );
+    }
 }

--- a/crates/lib/src/instance/mod.rs
+++ b/crates/lib/src/instance/mod.rs
@@ -8,7 +8,10 @@ use std::{
     collections::HashMap,
     future::Future,
     pin::Pin,
-    sync::{Arc, Mutex, Weak},
+    sync::{
+        Arc, Mutex, Weak,
+        atomic::{AtomicU64, Ordering},
+    },
 };
 
 use handle_trait::Handle;
@@ -45,28 +48,155 @@ pub enum WriteSource {
     Remote,
 }
 
-/// Type alias for async write callback return type.
+/// Context provided to write callbacks describing what changed in the database.
 ///
-/// We use a boxed future for callbacks. The future is `Send` since internal
-/// operations use `Arc`/`Mutex` for thread-safety.
-pub type AsyncWriteCallbackFuture<'a> = Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>;
+/// For local writes (transaction commits), this contains a single entry.
+/// For remote writes (sync), this may contain a batch of entries that were
+/// received and stored together.
+///
+/// # Catching up on missed writes
+///
+/// The `previous_tips` field contains the DAG tips of the database *before* the
+/// write(s) that triggered this callback. Consumers can use this to determine
+/// exactly what changed by walking the DAG from the current tips back to these
+/// previous tips. This is analogous to `git log previous_tip..HEAD`.
+///
+/// This design means callbacks never need to "miss" writes — even if multiple
+/// entries are batched (as in sync), the consumer can reconstruct the full set
+/// of changes from the tip diff.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// # use eidetica::instance::WriteEvent;
+/// # fn example(event: &WriteEvent) {
+/// // Check what stores were touched
+/// for entry in event.entries() {
+///     if entry.in_subtree("messages") {
+///         // A write touched the "messages" store
+///     }
+/// }
+///
+/// // Use previous_tips to find what's new
+/// let prev = event.previous_tips();
+/// // Walk DAG from current tips back to prev to find all new entries
+/// # }
+/// ```
+#[derive(Debug, Clone)]
+pub struct WriteEvent {
+    /// The entries written in this event. For local writes, this is always
+    /// exactly one entry. For remote sync, this is the full batch of entries
+    /// that were received and stored together.
+    entries: Vec<Entry>,
+    /// The DAG tips of the database immediately before this write.
+    /// Consumers can diff current tips against these to determine what changed.
+    previous_tips: Vec<ID>,
+    /// Whether this write originated locally or from a remote sync.
+    source: WriteSource,
+}
 
-/// Async callback function type for write operations.
-///
-/// Receives the entry that was written, the database it was written to, and the instance.
-/// Returns a boxed future that resolves to a Result.
-/// Used for both local and remote write callbacks.
-pub type AsyncWriteCallback = Arc<
-    dyn for<'a> Fn(&'a Entry, &'a Database, &'a Instance) -> AsyncWriteCallbackFuture<'a>
+impl WriteEvent {
+    /// Get the entries written in this event.
+    ///
+    /// For local writes (transaction commits), this always contains exactly one entry.
+    /// For remote writes (sync), this contains the full batch of entries received together.
+    pub fn entries(&self) -> &[Entry] {
+        &self.entries
+    }
+
+    /// Get the DAG tips of the database before this write.
+    ///
+    /// Use these to determine what changed: walk from the database's current tips
+    /// back to these previous tips to find all new entries.
+    pub fn previous_tips(&self) -> &[ID] {
+        &self.previous_tips
+    }
+
+    /// The source of this write (local commit or remote sync).
+    pub fn source(&self) -> WriteSource {
+        self.source
+    }
+}
+
+/// Boxed future returned by the internal async callback dispatcher.
+pub(crate) type AsyncWriteCallbackFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>;
+
+/// Internal async callback function type. The user-facing callback contract
+/// is documented on [`Database::on_write`](crate::Database::on_write).
+pub(crate) type AsyncWriteCallbackFn = Arc<
+    dyn for<'a> Fn(&'a WriteEvent, &'a Database) -> AsyncWriteCallbackFuture<'a>
         + Send
         + std::marker::Sync,
 >;
 
-/// Type alias for a collection of write callbacks
-type CallbackVec = Vec<AsyncWriteCallback>;
+/// Opaque identifier for a registered callback. Stable for the life of the registration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct CallbackId(u64);
 
-/// Type alias for the per-database callback map key
-type CallbackKey = (WriteSource, ID);
+/// Type alias for a collection of write callbacks paired with their ids.
+type CallbackVec = Vec<(CallbackId, AsyncWriteCallbackFn)>;
+
+/// Handle to a registered write callback. **Drop to unregister.**
+///
+/// Returned by [`Database::on_write`](crate::Database::on_write). While this
+/// value is alive the callback fires on writes; dropping it removes the
+/// registration. Use [`detach`](Self::detach) to keep the callback registered
+/// for the life of the [`Instance`] when you don't want to manage the lifetime
+/// yourself.
+///
+/// Holds a weak reference to the [`Instance`], so a `WriteCallback` will not
+/// keep the Instance alive on its own.
+#[must_use = "dropping a WriteCallback unregisters it; call .detach() to keep the callback registered"]
+pub struct WriteCallback {
+    instance: WeakInstance,
+    tree_id: ID,
+    id: CallbackId,
+    detached: bool,
+}
+
+impl WriteCallback {
+    pub(crate) fn new_per_database(instance: WeakInstance, tree_id: ID, id: CallbackId) -> Self {
+        Self {
+            instance,
+            tree_id,
+            id,
+            detached: false,
+        }
+    }
+
+    /// Consume the handle without unregistering. The callback remains active
+    /// for the life of the [`Instance`].
+    ///
+    /// Implementation note: this sets a flag rather than calling `mem::forget`
+    /// so that field destructors (the `WeakInstance`'s weak count, the
+    /// `tree_id`'s heap allocation) still run — only our `Drop` impl is
+    /// short-circuited.
+    pub fn detach(mut self) {
+        self.detached = true;
+    }
+}
+
+impl std::fmt::Debug for WriteCallback {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WriteCallback")
+            .field("id", &self.id)
+            .field("tree_id", &self.tree_id)
+            .field("detached", &self.detached)
+            .finish()
+    }
+}
+
+impl Drop for WriteCallback {
+    fn drop(&mut self) {
+        if self.detached {
+            return;
+        }
+        if let Some(instance) = self.instance.upgrade() {
+            instance.remove_write_callback(&self.tree_id, self.id);
+        }
+    }
+}
 
 /// Internal state for Instance
 ///
@@ -84,10 +214,19 @@ pub(crate) struct InstanceInternal {
     metadata: InstanceMetadata,
     /// Private instance secrets (None for remote instances without key access)
     secrets: Option<InstanceSecrets>,
-    /// Per-database callbacks keyed by (WriteSource, tree_id)
-    write_callbacks: Mutex<HashMap<CallbackKey, CallbackVec>>,
-    /// Global callbacks keyed by WriteSource (triggered regardless of database)
-    global_write_callbacks: Mutex<HashMap<WriteSource, CallbackVec>>,
+    /// Per-database callbacks keyed by tree_id. Each callback fires for both
+    /// local and remote writes; consumers branch on [`WriteEvent::source`] if
+    /// they only care about one.
+    write_callbacks: Mutex<HashMap<ID, CallbackVec>>,
+    /// Global callbacks fired for every write across every database.
+    global_write_callbacks: Mutex<CallbackVec>,
+    /// Monotonic id source for [`CallbackId`].
+    next_callback_id: AtomicU64,
+    /// Per-tree async locks serializing the
+    /// `get_tips` → backend write → callback dispatch sequence so
+    /// `WriteEvent::previous_tips` is consistent for concurrent writers
+    /// to the same tree.
+    tree_locks: Mutex<HashMap<ID, Arc<tokio::sync::Mutex<()>>>>,
 }
 
 impl std::fmt::Debug for InstanceInternal {
@@ -111,6 +250,10 @@ impl std::fmt::Debug for InstanceInternal {
                     "<{} global callbacks>",
                     self.global_write_callbacks.lock().unwrap().len()
                 ),
+            )
+            .field(
+                "next_callback_id",
+                &self.next_callback_id.load(Ordering::Relaxed),
             )
             .finish()
     }
@@ -255,7 +398,9 @@ impl Instance {
                     metadata,
                     secrets,
                     write_callbacks: Mutex::new(HashMap::new()),
-                    global_write_callbacks: Mutex::new(HashMap::new()),
+                    global_write_callbacks: Mutex::new(Vec::new()),
+                    next_callback_id: AtomicU64::new(0),
+                    tree_locks: Mutex::new(HashMap::new()),
                 });
                 Ok(Self { inner })
             }
@@ -357,7 +502,9 @@ impl Instance {
                     signing_key: device_key.clone(),
                 }),
                 write_callbacks: Mutex::new(HashMap::new()),
-                global_write_callbacks: Mutex::new(HashMap::new()),
+                global_write_callbacks: Mutex::new(Vec::new()),
+                next_callback_id: AtomicU64::new(0),
+                tree_locks: Mutex::new(HashMap::new()),
             }),
         };
         let users_db = create_users_database(&temp_instance, &device_key).await?;
@@ -387,7 +534,9 @@ impl Instance {
             metadata,
             secrets: Some(secrets),
             write_callbacks: Mutex::new(HashMap::new()),
-            global_write_callbacks: Mutex::new(HashMap::new()),
+            global_write_callbacks: Mutex::new(Vec::new()),
+            next_callback_id: AtomicU64::new(0),
+            tree_locks: Mutex::new(HashMap::new()),
         });
 
         Ok(Self { inner })
@@ -616,18 +765,23 @@ impl Instance {
         // Users should call register_transport() to add transports
         sync_arc.start_background_sync()?;
 
-        // Register global callback for automatic sync on local writes
+        // Register global callback for automatic sync on local writes.
+        // Detached: lives for the life of the Instance.
         let sync_for_callback = Arc::clone(&sync_arc);
-        self.register_global_write_callback(
-            WriteSource::Local,
-            move |entry, database, instance| {
-                let sync = Arc::clone(&sync_for_callback);
-                let entry = entry.clone();
-                let database = database.clone();
-                let instance = instance.clone();
-                async move { sync.on_local_write(&entry, &database, &instance).await }
-            },
-        )?;
+        self.register_global_write_callback(move |event, database| {
+            let sync = Arc::clone(&sync_for_callback);
+            let event = event.clone();
+            let database = database.clone();
+            async move {
+                if event.source() != WriteSource::Local {
+                    return Ok(());
+                }
+                // Local writes always carry exactly one entry today, but
+                // the loop in `Sync::on_local_write` is intentionally
+                // ready for future multi-entry local events.
+                sync.on_local_write(&event, &database).await
+            }
+        });
 
         let _ = self.inner.sync.set(sync_arc);
         Ok(())
@@ -667,75 +821,83 @@ impl Instance {
     // All entry writes go through Instance::put_entry() which handles backend storage
     // and callback dispatch. This centralizes write coordination and ensures hooks fire.
 
-    /// Register a callback to be invoked when entries are written to a database.
+    /// Register a per-database callback. Fires for both local and remote writes.
     ///
-    /// The callback receives the entry, database, and instance as parameters.
-    ///
-    /// # Arguments
-    /// * `source` - The write source to monitor (Local or Remote)
-    /// * `tree_id` - The root ID of the database tree to monitor
-    /// * `callback` - Function to invoke on writes
-    ///
-    /// # Returns
-    /// A Result indicating success or failure
-    pub(crate) fn register_write_callback<F, Fut>(
-        &self,
-        source: WriteSource,
-        tree_id: ID,
-        callback: F,
-    ) -> Result<()>
+    /// Returns the [`CallbackId`] of the registration. Callers wrap this in a
+    /// [`WriteCallback`] handle (see [`Database::on_write`]) to manage lifetime.
+    pub(crate) fn register_write_callback<F, Fut>(&self, tree_id: ID, callback: F) -> CallbackId
     where
-        F: for<'a> Fn(&'a Entry, &'a Database, &'a Instance) -> Fut
-            + Send
-            + std::marker::Sync
-            + 'static,
+        F: for<'a> Fn(&'a WriteEvent, &'a Database) -> Fut + Send + std::marker::Sync + 'static,
         Fut: Future<Output = Result<()>> + Send + 'static,
     {
-        let mut callbacks = self.inner.write_callbacks.lock().unwrap();
-        callbacks
-            .entry((source, tree_id))
+        let id = CallbackId(self.inner.next_callback_id.fetch_add(1, Ordering::Relaxed));
+        let cb: AsyncWriteCallbackFn = Arc::new(move |event: &WriteEvent, database: &Database| {
+            let fut = callback(event, database);
+            Box::pin(fut) as AsyncWriteCallbackFuture<'_>
+        });
+        self.inner
+            .write_callbacks
+            .lock()
+            .unwrap()
+            .entry(tree_id)
             .or_default()
-            .push(Arc::new(
-                move |entry: &Entry, database: &Database, instance: &Instance| {
-                    let fut = callback(entry, database, instance);
-                    Box::pin(fut) as AsyncWriteCallbackFuture<'_>
-                },
-            ));
-        Ok(())
+            .push((id, cb));
+        id
     }
 
-    /// Register a global callback to be invoked on all writes of a specific source.
+    /// Register a global callback fired for every write across every database.
     ///
-    /// Global callbacks are invoked for all writes of the specified source across all databases.
-    /// This is useful for system-wide operations like synchronization that need to track
-    /// changes across all databases.
+    /// Callers branch on [`WriteEvent::source`] inside the closure if they
+    /// only care about one source.
     ///
-    /// # Arguments
-    /// * `source` - The write source to monitor (Local or Remote)
-    /// * `callback` - Function to invoke on all writes
-    ///
-    /// # Returns
-    /// A Result indicating success or failure
-    pub(crate) fn register_global_write_callback<F, Fut>(
-        &self,
-        source: WriteSource,
-        callback: F,
-    ) -> Result<()>
+    /// Note: there is intentionally no `WriteCallback` handle or remove path
+    /// for global callbacks. The only current caller is sync's permanent hook
+    /// (OnceLock-guarded) which is registered for the life of the Instance.
+    /// If a future caller needs lifecycle management on a global callback,
+    /// add `remove_global_write_callback` and a global variant of
+    /// `WriteCallback`.
+    pub(crate) fn register_global_write_callback<F, Fut>(&self, callback: F)
     where
-        F: for<'a> Fn(&'a Entry, &'a Database, &'a Instance) -> Fut
-            + Send
-            + std::marker::Sync
-            + 'static,
+        F: for<'a> Fn(&'a WriteEvent, &'a Database) -> Fut + Send + std::marker::Sync + 'static,
         Fut: Future<Output = Result<()>> + Send + 'static,
     {
-        let mut callbacks = self.inner.global_write_callbacks.lock().unwrap();
-        callbacks.entry(source).or_default().push(Arc::new(
-            move |entry: &Entry, database: &Database, instance: &Instance| {
-                let fut = callback(entry, database, instance);
-                Box::pin(fut) as AsyncWriteCallbackFuture<'_>
-            },
-        ));
-        Ok(())
+        let id = CallbackId(self.inner.next_callback_id.fetch_add(1, Ordering::Relaxed));
+        let cb: AsyncWriteCallbackFn = Arc::new(move |event: &WriteEvent, database: &Database| {
+            let fut = callback(event, database);
+            Box::pin(fut) as AsyncWriteCallbackFuture<'_>
+        });
+        self.inner
+            .global_write_callbacks
+            .lock()
+            .unwrap()
+            .push((id, cb));
+    }
+
+    /// Remove a per-database callback by id. No-op if not found.
+    pub(crate) fn remove_write_callback(&self, tree_id: &ID, id: CallbackId) {
+        let mut callbacks = self.inner.write_callbacks.lock().unwrap();
+        if let Some(vec) = callbacks.get_mut(tree_id) {
+            vec.retain(|(cb_id, _)| *cb_id != id);
+            if vec.is_empty() {
+                callbacks.remove(tree_id);
+            }
+        }
+    }
+
+    /// Acquire (or create) the per-tree async lock that serializes the
+    /// `get_tips` → backend write → callback dispatch sequence.
+    ///
+    /// Without this, two concurrent writers to the same tree both snapshot
+    /// `previous_tips` before either writes, so the second callback's
+    /// `previous_tips` would not reflect the first write — breaking the
+    /// "diff against current tips" contract documented on [`WriteEvent`].
+    fn tree_lock(&self, tree_id: &ID) -> Arc<tokio::sync::Mutex<()>> {
+        let mut locks = self.inner.tree_locks.lock().unwrap();
+        Arc::clone(
+            locks
+                .entry(tree_id.clone())
+                .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(()))),
+        )
     }
 
     /// Write an entry to the backend and dispatch callbacks.
@@ -745,6 +907,9 @@ impl Instance {
     /// - Entries are persisted to the backend
     /// - Appropriate callbacks are triggered based on write source
     /// - Hooks have full context (entry, database, instance)
+    ///
+    /// Serialized per-tree against [`Self::put_remote_entries`] so
+    /// [`WriteEvent::previous_tips`] is consistent.
     ///
     /// # Arguments
     /// * `tree_id` - The root ID of the database being written to
@@ -761,66 +926,150 @@ impl Instance {
         entry: Entry,
         source: WriteSource,
     ) -> Result<()> {
-        // 1. Persist to backend storage
+        let lock = self.tree_lock(tree_id);
+        let _guard = lock.lock().await;
+
+        // 1. Capture tips before the write so callbacks know what changed
+        let previous_tips = self.get_tips(tree_id).await?;
+
+        // 2. Persist to backend storage
         self.backend().put(verification, entry.clone()).await?;
 
-        // 2. Look up and execute callbacks based on write source
-        // Clone the callbacks to avoid holding the lock while executing callbacks.
+        // 3. Build event and fire callbacks
+        let event = WriteEvent {
+            entries: vec![entry],
+            previous_tips,
+            source,
+        };
+        self.fire_write_callbacks(tree_id, &event).await;
+
+        Ok(())
+    }
+
+    /// Store a batch of remotely-received entries and fire callbacks once.
+    ///
+    /// This is the correct way to ingest entries from sync. All entries are
+    /// persisted first, then callbacks fire exactly once with the full batch
+    /// and the tips from before ingestion. This ensures:
+    ///
+    /// - The database is fully consistent when callbacks execute
+    /// - Callbacks fire once per sync exchange, not once per entry
+    /// - `previous_tips` lets consumers reconstruct exactly what changed
+    ///
+    /// Entries that fail to store are logged and skipped — remaining entries
+    /// are still stored and callbacks still fire for whatever was persisted.
+    /// Returns the number of entries that were successfully persisted.
+    ///
+    /// Serialized per-tree against [`Self::put_entry`] and other concurrent
+    /// `put_remote_entries` calls so `previous_tips` is consistent across
+    /// writers.
+    ///
+    /// # Arguments
+    /// * `tree_id` - The root ID of the database receiving the batch
+    /// * `verification` - Authentication verification status to apply to
+    ///   each entry. Pass `VerificationStatus::Failed` for entries received
+    ///   over the wire that have not been signature-checked (the project's
+    ///   current stand-in for an `Unverified` state).
+    /// * `entries` - The entries to ingest
+    pub(crate) async fn put_remote_entries(
+        &self,
+        tree_id: &ID,
+        verification: crate::backend::VerificationStatus,
+        entries: Vec<Entry>,
+    ) -> Result<usize> {
+        if entries.is_empty() {
+            return Ok(0);
+        }
+
+        let lock = self.tree_lock(tree_id);
+        let _guard = lock.lock().await;
+
+        // 1. Capture tips before any writes
+        let previous_tips = self.get_tips(tree_id).await?;
+
+        // 2. Store all entries
+        let mut stored_entries = Vec::with_capacity(entries.len());
+        for entry in entries {
+            match self.backend().put(verification, entry.clone()).await {
+                Ok(_) => stored_entries.push(entry),
+                Err(e) => {
+                    tracing::error!(
+                        tree_id = %tree_id,
+                        entry_id = %entry.id(),
+                        "Failed to store remote entry: {}", e
+                    );
+                }
+            }
+        }
+
+        let stored_count = stored_entries.len();
+
+        // 3. Fire callbacks once for the whole batch
+        if !stored_entries.is_empty() {
+            let event = WriteEvent {
+                entries: stored_entries,
+                previous_tips,
+                source: WriteSource::Remote,
+            };
+            self.fire_write_callbacks(tree_id, &event).await;
+        }
+
+        Ok(stored_count)
+    }
+
+    /// Dispatch callbacks for a write event.
+    ///
+    /// Fires per-database callbacks for `tree_id` then global callbacks. Each
+    /// callback fires for both local and remote writes; consumers branch on
+    /// [`WriteEvent::source`] internally.
+    async fn fire_write_callbacks(&self, tree_id: &ID, event: &WriteEvent) {
         let per_db_callbacks = self
             .inner
             .write_callbacks
             .lock()
             .unwrap()
-            .get(&(source, tree_id.clone()))
+            .get(tree_id)
             .cloned();
 
-        let global_callbacks = self
-            .inner
-            .global_write_callbacks
-            .lock()
-            .unwrap()
-            .get(&source)
-            .cloned();
+        let global_callbacks = self.inner.global_write_callbacks.lock().unwrap().clone();
 
-        // 3. Execute callbacks if any are registered
-        let has_callbacks = per_db_callbacks.is_some() || global_callbacks.is_some();
-        if has_callbacks {
-            // Create a Database handle for the callbacks
-            // Use open_readonly since we only need it for callback context
-            let database = Database::open_unauthenticated(tree_id.clone(), self)?;
+        let has_callbacks = per_db_callbacks.is_some() || !global_callbacks.is_empty();
+        if !has_callbacks {
+            return;
+        }
 
-            // Execute per-database callbacks
-            if let Some(callbacks) = per_db_callbacks {
-                for callback in callbacks {
-                    if let Err(e) = callback(&entry, &database, self).await {
-                        tracing::error!(
-                            tree_id = %tree_id,
-                            entry_id = %entry.id(),
-                            source = ?source,
-                            "Per-database callback failed: {}", e
-                        );
-                        // Continue executing other callbacks even if one fails
-                    }
-                }
+        // Create a Database handle for the callbacks
+        let database = match Database::open_unauthenticated(tree_id.clone(), self) {
+            Ok(db) => db,
+            Err(e) => {
+                tracing::error!(tree_id = %tree_id, "Failed to open database for callbacks: {}", e);
+                return;
             }
+        };
 
-            // Execute global callbacks
-            if let Some(callbacks) = global_callbacks {
-                for callback in callbacks {
-                    if let Err(e) = callback(&entry, &database, self).await {
-                        tracing::error!(
-                            tree_id = %tree_id,
-                            entry_id = %entry.id(),
-                            source = ?source,
-                            "Global callback failed: {}", e
-                        );
-                        // Continue executing other callbacks even if one fails
-                    }
+        if let Some(callbacks) = per_db_callbacks {
+            for (id, callback) in callbacks {
+                if let Err(e) = callback(event, &database).await {
+                    tracing::error!(
+                        tree_id = %tree_id,
+                        source = ?event.source(),
+                        callback_id = ?id,
+                        "Per-database callback failed: {}", e
+                    );
                 }
             }
         }
 
-        Ok(())
+        for (id, callback) in global_callbacks {
+            if let Err(e) = callback(event, &database).await {
+                tracing::error!(
+                    tree_id = %tree_id,
+                    source = ?event.source(),
+                    callback_id = ?id,
+                    "Global callback failed: {}", e
+                );
+            }
+        }
     }
 
     /// Downgrade to a weak reference.

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -38,7 +38,7 @@ pub use clock::{ClockHold, FixedClock};
 pub use database::{Database, DatabaseKey};
 pub use entry::{Entry, ID};
 pub use height::HeightStrategy;
-pub use instance::{Instance, WeakInstance};
+pub use instance::{Instance, WeakInstance, WriteCallback, WriteEvent, WriteSource};
 pub use store::{Registered, Store};
 /// Re-export fundamental types for easier access.
 pub use transaction::Transaction;

--- a/crates/lib/src/sync/background/conn.rs
+++ b/crates/lib/src/sync/background/conn.rs
@@ -18,6 +18,7 @@ use crate::sync::{
 use crate::{
     Error, Result,
     auth::crypto::{PublicKey, generate_challenge, verify_challenge_response},
+    backend::VerificationStatus,
     entry::Entry,
 };
 
@@ -140,16 +141,14 @@ impl BackgroundSync {
             .into());
         }
 
-        // Store root entry first
-        let instance = self.instance()?;
-        instance
-            .backend()
-            .put_verified(response.root_entry)
-            .await
-            .map_err(|e| SyncError::BackendError(format!("Failed to store root entry: {e}")))?;
+        // Combine root entry with all other entries into a single batch
+        let mut all_entries = Vec::with_capacity(1 + response.all_entries.len());
+        all_entries.push(response.root_entry);
+        all_entries.extend(response.all_entries);
 
-        // Store all other entries
-        self.store_received_entries(response.all_entries).await?;
+        // Store all entries and fire callbacks once
+        self.store_received_entries(&response.tree_id, all_entries)
+            .await?;
 
         info!(tree_id = %response.tree_id, "Bootstrap completed successfully");
         Ok(())
@@ -162,19 +161,24 @@ impl BackgroundSync {
     ) -> Result<()> {
         trace!(tree_id = %response.tree_id, "Processing incremental response");
 
-        // Store missing entries
-        self.store_received_entries(response.missing_entries)
+        // Store missing entries and fire callbacks
+        self.store_received_entries(&response.tree_id, response.missing_entries)
             .await?;
-
-        // Note: We could use their_tips for further optimization in the future
-        // For now, the next sync cycle will handle any remaining differences
 
         debug!(tree_id = %response.tree_id, "Incremental sync completed");
         Ok(())
     }
 
-    /// Store received entries from peer with proper DAG ordering
-    pub(super) async fn store_received_entries(&self, entries: Vec<Entry>) -> Result<()> {
+    /// Validate and store received entries from peer, firing remote write callbacks.
+    ///
+    /// Validates entry integrity and parent existence, then stores the batch
+    /// through `Instance::put_remote_entries` which fires callbacks once for the
+    /// entire batch.
+    pub(super) async fn store_received_entries(
+        &self,
+        tree_id: &crate::entry::ID,
+        entries: Vec<Entry>,
+    ) -> Result<()> {
         if entries.is_empty() {
             return Ok(());
         }
@@ -188,11 +192,18 @@ impl BackgroundSync {
         // parent-existence check below (a forged entry's children wouldn't
         // connect to genuine parents). Root-level integrity is verified against
         // the declared tree_id in the bootstrap handler.
-        for entry in entries {
-            // Verify parent entries exist before storing children
+        //
+        // Parents may be either already-stored or earlier in this same batch
+        // (bootstrap ships chains of new entries together), so we accept both.
+        let in_batch: std::collections::HashSet<crate::entry::ID> =
+            entries.iter().map(|e| e.id()).collect();
+        let instance = self.instance()?;
+        for entry in &entries {
             if let Ok(parents) = entry.parents() {
                 for parent_id in &parents {
-                    let instance = self.instance()?;
+                    if in_batch.contains(parent_id) {
+                        continue;
+                    }
                     if let Err(e) = instance.backend().get(parent_id).await {
                         if e.is_not_found() {
                             return Err(SyncError::InvalidEntry(format!(
@@ -213,15 +224,16 @@ impl BackgroundSync {
                     }
                 }
             }
-
-            // Store the entry
-            let instance = self.instance()?;
-            instance
-                .backend()
-                .put_verified(entry)
-                .await
-                .map_err(|e| SyncError::BackendError(format!("Failed to store entry: {e}")))?;
         }
+
+        // Bootstrap/incremental sync paths historically marked these entries
+        // Verified after the parent-existence check above. That hasn't changed
+        // here, but the verification gap (no signature check) is tracked via
+        // the TODO in `Sync::store_received_entries`.
+        instance
+            .put_remote_entries(tree_id, VerificationStatus::Verified, entries)
+            .await
+            .map_err(|e| SyncError::BackendError(format!("Failed to store entries: {e}")))?;
 
         Ok(())
     }

--- a/crates/lib/src/sync/error.rs
+++ b/crates/lib/src/sync/error.rs
@@ -174,9 +174,13 @@ pub enum SyncError {
 }
 
 impl SyncError {
-    /// Check if this is a configuration error (no transport enabled).
+    /// Check if this is a configuration error: the sync stack isn't ready
+    /// (sync not attached or no transport registered).
     pub fn is_configuration_error(&self) -> bool {
-        matches!(self, SyncError::NoTransportEnabled)
+        matches!(
+            self,
+            SyncError::NoTransportEnabled | SyncError::SyncNotEnabled
+        )
     }
 
     /// Check if this is a server lifecycle error.

--- a/crates/lib/src/sync/handler.rs
+++ b/crates/lib/src/sync/handler.rs
@@ -4,6 +4,8 @@
 //! sync requests and generate responses. These handlers can be
 //! used by any transport implementation through the SyncHandler trait.
 
+use std::collections::BTreeMap;
+
 use async_trait::async_trait;
 use tracing::{Instrument, debug, error, info, info_span, trace, warn};
 
@@ -18,11 +20,12 @@ use super::{
     user_sync_manager::UserSyncManager,
 };
 use crate::{
-    Database, Error, Instance, Result, WeakInstance,
+    Database, Entry, Error, Instance, Result, WeakInstance,
     auth::{
         KeyStatus, Permission,
         crypto::{PublicKey, create_challenge_response, generate_challenge},
     },
+    backend::VerificationStatus,
     entry::ID,
     store::SettingsStore,
     sync::error::SyncError,
@@ -151,23 +154,46 @@ impl SyncHandler for SyncHandlerImpl {
                 let count = entries.len();
                 info!(count = count, "Received entries for synchronization");
 
-                // Get instance once before loop
                 let instance = match self.instance() {
                     Ok(i) => i,
                     Err(e) => return SyncResponse::Error(format!("Instance dropped: {e}")),
                 };
 
-                // Store entries in the backend as unverified (from sync)
-                let mut stored_count = 0usize;
+                // Group entries by tree_id so we can fire callbacks per-database.
+                // BTreeMap so iteration order is deterministic (sorted by id);
+                // sender order within a tree is preserved by per-tree push order.
+                //
+                // Root entries declare an empty `tree.root` and act as their
+                // own tree_id. Non-root entries always carry a tree_id;
+                // well-formed peers should never send a non-root entry with
+                // `root() == None`. If they do, the entry ends up filed under
+                // its own id and parent-existence checks downstream reject it.
+                let mut by_tree: BTreeMap<ID, Vec<Entry>> = BTreeMap::new();
                 for entry in entries {
-                    match instance.backend().put_unverified(entry.clone()).await {
-                        Ok(_) => {
-                            stored_count += 1;
-                            trace!(entry_id = %entry.id(), "Stored entry successfully");
+                    let tree_id = entry.root().unwrap_or_else(|| entry.id());
+                    by_tree.entry(tree_id).or_default().push(entry.clone());
+                }
+
+                let mut stored_count = 0usize;
+                for (tree_id, tree_entries) in by_tree {
+                    let batch_size = tree_entries.len();
+                    // Entries arrive over the wire without per-entry signature
+                    // verification. Store as Failed (the project's current
+                    // stand-in for "Unverified"; see the TODO on
+                    // `VerificationStatus`) so a future re-verification pass
+                    // can promote them. Matches the prior `put_unverified`
+                    // behavior of this handler before it was unified through
+                    // `put_remote_entries`.
+                    match instance
+                        .put_remote_entries(&tree_id, VerificationStatus::Failed, tree_entries)
+                        .await
+                    {
+                        Ok(n) => {
+                            stored_count += n;
+                            debug!(tree_id = %tree_id, requested = batch_size, stored = n, "Stored entries");
                         }
                         Err(e) => {
-                            error!(entry_id = %entry.id(), error = %e, "Failed to store entry");
-                            // Continue processing other entries rather than failing completely
+                            error!(tree_id = %tree_id, error = %e, "Failed to store entries batch");
                         }
                     }
                 }

--- a/crates/lib/src/sync/ops.rs
+++ b/crates/lib/src/sync/ops.rs
@@ -15,8 +15,8 @@ use super::{
     user_sync_manager::UserSyncManager,
 };
 use crate::{
-    Database, Entry, Instance, Result, auth::Permission, auth::crypto::PublicKey, entry::ID,
-    store::DocStore,
+    Database, Entry, Result, auth::Permission, auth::crypto::PublicKey,
+    backend::VerificationStatus, entry::ID, store::DocStore,
 };
 
 use super::utils::collect_ancestors_to_send;
@@ -135,15 +135,13 @@ impl Sync {
             .into());
         }
 
-        // Store the root entry
-        let backend = self.backend()?;
-        backend
-            .put_verified(response.root_entry.clone())
-            .await
-            .map_err(|e| SyncError::BackendError(format!("Failed to store root entry: {e}")))?;
+        // Combine root entry with all other entries into a single batch
+        let mut all_entries = Vec::with_capacity(1 + response.all_entries.len());
+        all_entries.push(response.root_entry);
+        all_entries.extend(response.all_entries);
 
-        // Store all other entries using existing method
-        self.store_received_entries(&response.tree_id, response.all_entries)
+        // Store all entries and fire callbacks once
+        self.store_received_entries(&response.tree_id, all_entries)
             .await?;
 
         tracing::info!(tree_id = %response.tree_id, "Bootstrap completed successfully");
@@ -256,10 +254,10 @@ impl Sync {
         }
     }
 
-    /// Validate and store received entries from a peer.
+    /// Validate and store received entries from a peer, firing remote write callbacks.
     pub(super) async fn store_received_entries(
         &self,
-        _tree_id: &ID,
+        tree_id: &ID,
         entries: Vec<Entry>,
     ) -> Result<()> {
         // These entries arrive without per-entry declared IDs — they were batched
@@ -271,13 +269,15 @@ impl Sync {
         //
         // TODO: Add signature verification and parent-existence / DAG-connectivity
         // checks before marking entries as verified.
-        for entry in entries {
-            let backend = self.backend()?;
-            backend
-                .put_verified(entry)
-                .await
-                .map_err(|e| SyncError::BackendError(format!("Failed to store entry: {e}")))?;
-        }
+
+        // Store entries and fire callbacks via Instance::put_remote_entries.
+        // Marked Verified to match prior behavior; the TODO above tracks the
+        // signature-verification gap.
+        let instance = self.instance()?;
+        instance
+            .put_remote_entries(tree_id, VerificationStatus::Verified, entries)
+            .await
+            .map_err(|e| SyncError::BackendError(format!("Failed to store entries: {e}")))?;
 
         Ok(())
     }
@@ -388,17 +388,15 @@ impl Sync {
     /// This is the core method that implements automatic sync-on-commit behavior.
     ///
     /// # Arguments
-    /// * `entry` - The newly committed entry
-    /// * `database` - The database where the entry was committed
-    /// * `_instance` - The instance (unused but required by callback signature)
+    /// * `event` - The write event containing the newly committed entries
+    /// * `database` - The database where the entries were committed
     ///
     /// # Returns
     /// Ok(()) on success, or an error if settings lookup fails
     pub(crate) async fn on_local_write(
         &self,
-        entry: &Entry,
+        event: &crate::instance::WriteEvent,
         database: &Database,
-        _instance: &Instance,
     ) -> Result<()> {
         // Early return if background sync not running
         if self.background_tx.get().is_none() {
@@ -438,19 +436,21 @@ impl Sync {
             return Ok(());
         }
 
-        // Queue entry for sync with each peer
-        let entry_id = entry.id();
+        // Queue each entry for sync with each peer
         let tree_id = database.root_id();
 
-        debug!(
-            database_id = %tree_id,
-            entry_id = %entry_id,
-            peer_count = peers.len(),
-            "Queueing entry for automatic sync"
-        );
+        for entry in event.entries() {
+            let entry_id = entry.id();
+            debug!(
+                database_id = %tree_id,
+                entry_id = %entry_id,
+                peer_count = peers.len(),
+                "Queueing entry for automatic sync"
+            );
 
-        for peer_id in peers {
-            self.queue_entry_for_sync(&peer_id, &entry_id, tree_id)?;
+            for peer_id in &peers {
+                self.queue_entry_for_sync(peer_id, &entry_id, tree_id)?;
+            }
         }
 
         Ok(())
@@ -695,14 +695,15 @@ impl Sync {
             SyncResponse::Bootstrap(bootstrap_response) => {
                 info!(peer = %peer_pubkey, tree = %tree_id, entry_count = bootstrap_response.all_entries.len() + 1, "Received bootstrap response");
 
-                // Store the root entry
-                let backend = self.backend()?;
-                backend.put_verified(bootstrap_response.root_entry).await?;
+                // Store root + all entries as a single batch with callback dispatch
+                let mut all_entries = Vec::with_capacity(1 + bootstrap_response.all_entries.len());
+                all_entries.push(bootstrap_response.root_entry);
+                all_entries.extend(bootstrap_response.all_entries);
 
-                // Store all other entries
-                for entry in bootstrap_response.all_entries {
-                    backend.put_unverified(entry).await?;
-                }
+                let instance = self.instance()?;
+                instance
+                    .put_remote_entries(tree_id, VerificationStatus::Verified, all_entries)
+                    .await?;
 
                 info!(peer = %peer_pubkey, tree = %tree_id, "Bootstrap sync completed successfully");
             }

--- a/crates/lib/src/user/session/mod.rs
+++ b/crates/lib/src/user/session/mod.rs
@@ -1029,14 +1029,17 @@ impl User {
     /// Enable sync for a tracked database and return a [`DatabaseTicket`]
     /// for handoff.
     ///
-    /// Atomic version of [`Self::enable_sync`] followed by ticket construction.
-    /// The ticket carries the database ID plus any peer addresses that the
-    /// instance's sync transports are currently advertising; a peer that
-    /// imports the ticket via [`Sync::sync_with_ticket`](crate::sync::Sync::sync_with_ticket)
-    /// will be able to fetch the database immediately.
+    /// Equivalent to building a ticket via
+    /// [`Sync::create_ticket`](crate::sync::Sync::create_ticket) and then
+    /// calling [`Self::enable_sync`], in a single call. The ticket carries the
+    /// database ID plus any peer addresses that the instance's sync transports
+    /// are currently advertising; a peer that imports the ticket via
+    /// [`Sync::sync_with_ticket`](crate::sync::Sync::sync_with_ticket) will be
+    /// able to fetch the database immediately.
     ///
-    /// Preconditions are checked before any state is mutated, so a failed
-    /// `share()` leaves the user's sync preference unchanged.
+    /// All preconditions (sync attached, transport registered) are checked
+    /// before any user state is mutated, so a failed `share()` leaves the
+    /// user's sync preference unchanged.
     ///
     /// # Errors
     /// - [`SyncError::SyncNotEnabled`] if sync is not attached to the instance
@@ -1046,6 +1049,9 @@ impl User {
     /// - [`UserError::DatabaseNotTracked`] if the database is not in the user's
     ///   tracked list.
     pub async fn share(&mut self, database_id: &ID) -> Result<DatabaseTicket> {
+        // Build the ticket first: this is the only step that can fail with
+        // NoTransportEnabled / SyncNotEnabled, and it doesn't touch user state.
+        // enable_sync runs last so any error path leaves preferences unchanged.
         let sync = self.instance.sync().ok_or(SyncError::SyncNotEnabled)?;
         let ticket = sync.create_ticket(database_id).await?;
         self.enable_sync(database_id).await?;

--- a/crates/lib/tests/it/sync/helpers.rs
+++ b/crates/lib/tests/it/sync/helpers.rs
@@ -158,10 +158,14 @@ pub struct HttpTransportFactory;
 #[async_trait]
 impl TransportFactory for HttpTransportFactory {
     async fn create_sync(&self, instance: Instance) -> Result<Sync> {
-        let sync = Sync::new(instance).await?;
+        // Go through instance.enable_sync() so the global write callback that
+        // routes local commits into Sync::on_local_write is registered. Then
+        // attach the test transport.
+        instance.enable_sync().await?;
+        let sync = instance.sync().expect("sync attached after enable_sync");
         sync.register_transport("http", HttpTransport::builder().bind("127.0.0.1:0"))
             .await?;
-        Ok(sync)
+        Ok((*sync).clone())
     }
 
     fn create_address(&self, server_addr: &str) -> Address {
@@ -179,13 +183,14 @@ pub struct IrohTransportFactory;
 #[async_trait]
 impl TransportFactory for IrohTransportFactory {
     async fn create_sync(&self, instance: Instance) -> Result<Sync> {
-        let sync = Sync::new(instance).await?;
+        instance.enable_sync().await?;
+        let sync = instance.sync().expect("sync attached after enable_sync");
         sync.register_transport(
             "iroh",
             IrohTransport::builder().relay_mode(RelayMode::Disabled),
         )
         .await?;
-        Ok(sync)
+        Ok((*sync).clone())
     }
 
     fn create_address(&self, server_addr: &str) -> Address {

--- a/crates/lib/tests/it/sync/transport_conformance.rs
+++ b/crates/lib/tests/it/sync/transport_conformance.rs
@@ -10,8 +10,8 @@ use eidetica::{
     auth::crypto::PublicKey,
     crdt::Doc,
     store::DocStore,
-    sync::{PeerId, Sync},
-    user::User,
+    sync::Sync,
+    user::{User, types::SyncSettings},
 };
 use tokio::time::sleep;
 
@@ -74,7 +74,18 @@ where
     Ok((sync1, sync2, peer1_pubkey, peer2_pubkey))
 }
 
-/// Set up trees with bidirectional sync hooks
+/// Set up trees with bidirectional sync wiring.
+///
+/// Relies on the standard sync-on-commit machinery:
+/// - `instance.enable_sync()` (done by the transport factory) registers the
+///   global write callback that routes local commits into `Sync::on_local_write`.
+/// - `user.track_database(..., SyncSettings::on_commit())` flips the user's
+///   preferences (overwriting the `disabled()` defaults set by
+///   `create_database`) and propagates them to combined settings.
+/// - `sync.add_tree_sync(peer, tree)` associates each peer with the tree.
+///
+/// The Instance's global callback then queues entries on every local commit
+/// automatically — no manual `on_write` hooks needed.
 #[allow(clippy::too_many_arguments)]
 async fn setup_sync_hooks(
     user1: &mut User,
@@ -89,38 +100,18 @@ async fn setup_sync_hooks(
     let mut settings1 = Doc::new();
     settings1.set("name", "test_tree_1");
     let tree1 = user1.create_database(settings1, key_id1).await?;
+    user1
+        .track_database(tree1.root_id().clone(), key_id1, SyncSettings::on_commit())
+        .await?;
+    sync1.add_tree_sync(peer2_pubkey, tree1.root_id()).await?;
 
     let mut settings2 = Doc::new();
     settings2.set("name", "test_tree_2");
     let tree2 = user2.create_database(settings2, key_id2).await?;
-
-    // Set up sync callbacks using WriteCallback directly
-    // Clone sync instances and peer pubkeys for use in callbacks
-    let sync1_clone = sync1.clone();
-    let peer2_pk = peer2_pubkey.clone();
-    tree1.on_local_write(move |entry, db, _instance| {
-        let sync = sync1_clone.clone();
-        let peer = PeerId::new(peer2_pk.clone());
-        let entry_id = entry.id();
-        let tree_id = db.root_id().clone();
-        async move {
-            sync.queue_entry_for_sync(&peer, &entry_id, &tree_id)?;
-            Ok(())
-        }
-    })?;
-
-    let sync2_clone = sync2.clone();
-    let peer1_pk = peer1_pubkey.clone();
-    tree2.on_local_write(move |entry, db, _instance| {
-        let sync = sync2_clone.clone();
-        let peer = PeerId::new(peer1_pk.clone());
-        let entry_id = entry.id();
-        let tree_id = db.root_id().clone();
-        async move {
-            sync.queue_entry_for_sync(&peer, &entry_id, &tree_id)?;
-            Ok(())
-        }
-    })?;
+    user2
+        .track_database(tree2.root_id().clone(), key_id2, SyncSettings::on_commit())
+        .await?;
+    sync2.add_tree_sync(peer1_pubkey, tree2.root_id()).await?;
 
     Ok((tree1, tree2))
 }


### PR DESCRIPTION
## Bug

Remote sync paths (bootstrap, incremental, SendEntries) wrote entries directly
to the backend via `put_verified`/`put_unverified`, completely bypassing
`Instance::put_entry`'s callback dispatch. `on_remote_write` was dead code —
callbacks never fired for synced entries.

## Fix

- Introduce `WriteEvent` (entries, previous_tips, source) replacing the bare
  `&Entry` in callback signatures. `previous_tips` captures the DAG tips
  before the write, so consumers can reconstruct exactly what changed by
  walking from current tips back — analogous to `git log prev..HEAD` or a
  CouchDB change sequence. A sync that transfers 50 entries fires once with
  the batch and the pre-state tips, not 50 times.

- Add `Instance::put_remote_entries(tree_id, verification, entries)`: stores
  all entries, then fires callbacks once for the whole batch. All four sync
  ingestion paths (`Sync::store_received_entries`,
  `BackgroundSync::store_received_entries`, `SyncHandler::SendEntries`, both
  bootstrap handlers) now route through it. Returns the count of entries
  actually persisted, so callers can log honestly when partial-store skips
  occur.

## API redesign

- Collapse `Database::on_local_write` and `Database::on_remote_write` into a
  single `Database::on_write`. The split made sense when local and remote
  callbacks had different signatures, but `WriteEvent` is the same shape for
  both — the source dimension already lives on the event. Consumers branch
  on `event.source()` if they only care about one.

- Callback signature is `Fn(&WriteEvent, &Database) -> Future`. The previous
  third argument (`&Instance`) was unused at every callsite; callbacks that
  do need the instance call `Database::instance()` (now public) on the
  `&Database` they already hold.

- `on_write` returns a `WriteCallback` RAII handle. Drop the handle to
  unregister the callback; call `WriteCallback::detach()` to keep it
  registered for the life of the Instance. This addresses the prior gap
  where callbacks could only be added, never removed — required for any
  scoped observer (UI views, tests, transient watchers).

- Internal: callback storage is now keyed by `tree_id` only (not
  `(WriteSource, tree_id)`); each callback fires for both sources. Sync's
  internal hook registers globally and filters on `WriteSource::Local`
  inside the closure. `CallbackId`, `AsyncWriteCallbackFn`, and
  `AsyncWriteCallbackFuture` are `pub(crate)` — implementation details, no
  public consumers, kept private so the representation can evolve.

## Per-tree write serialization

`Instance::put_entry` and `put_remote_entries` now acquire a per-tree async
lock spanning `get_tips → backend write → callback dispatch`. Without this,
two concurrent writers on the same tree would both snapshot pre-state tips
before either persisted, so the second callback's `previous_tips` would not
reflect the first batch — breaking the "diff against current tips" contract
documented on `WriteEvent`. Locks are stored in
`InstanceInternal::tree_locks: Mutex<HashMap<ID, Arc<tokio::sync::Mutex<()>>>>`,
created lazily per tree.

## Verification status

The new `verification: VerificationStatus` parameter on `put_remote_entries`
makes per-path policy explicit:

- Bootstrap and incremental sync (`Sync::store_received_entries`,
  `BackgroundSync::store_received_entries`) pass `Verified`, matching the
  prior behavior of those paths.

- `SyncHandler::SendEntries` passes `Failed` — wire-received entries have
  not been signature-checked. This matches the pre-PR `put_unverified`
  behavior of that handler (which is itself just `put(Failed, …)`); no
  semantic change, just made explicit. The TODO in
  `Sync::store_received_entries` still tracks the larger gap of adding
  signature verification before marking anything verified.

## Bootstrap parent-existence check

`BackgroundSync::store_received_entries` now accepts parents that appear
earlier in the same batch, not only parents already stored. Bootstrap ships
chains of new entries together, and the previous strict check would reject
any non-root entry in a chain because its parent hadn't been persisted yet
when the check ran. Implemented as a `HashSet` of in-batch entry ids
consulted before the backend lookup.

## SendEntries tree ordering

`SyncHandler::SendEntries` previously grouped entries by tree using a
`HashMap`, which iterated in non-deterministic order. Now uses a
`BTreeMap<ID, Vec<Entry>>` so per-tree processing order is deterministic
(sorted by tree id). Within a tree, sender order is preserved by per-tree
push order.

## SyncError::SyncNotEnabled

New variant added so `User::share` can distinguish "sync not attached" from
"transport not registered." `is_configuration_error` returns true for both
`SyncNotEnabled` and `NoTransportEnabled` since they describe the same
class of "sync stack isn't ready" condition.

## Breaking change

`Database::on_local_write` / `Database::on_remote_write` are replaced by
`Database::on_write`. Callback signature is now `(&WriteEvent, &Database)`
instead of `(&Entry, &Database, &Instance)`. Use `event.entries()` to get
the entries — a single-element slice for local writes, the full batch for
remote writes. The returned `WriteCallback` handle must be bound
(`#[must_use]` warns otherwise) — drop to unregister, or call `.detach()`
to leave the callback registered.

## Tests

11 new unit tests in `database/tests.rs`:

- `test_local_write_callback_fires`, `test_local_write_event_contains_single_entry`
- `test_remote_write_callback_fires_via_put_remote_entries`,
  `test_remote_write_previous_tips`,
  `test_remote_callback_receives_only_stored_entries`
- `test_empty_remote_batch_does_not_fire_callback`
- `test_callback_error_does_not_block_other_callbacks`
- `test_drop_write_callback_unregisters`,
  `test_drop_only_unregisters_that_callback`,
  `test_detached_write_callback_outlives_handle`
- `test_concurrent_writes_serialize_previous_tips` — regression test for the
  per-tree lock. Spawns two `tokio::spawn`-based concurrent writers on a
  multi-thread runtime, repeated 100x to amplify any race. Asserts at least
  one event's `previous_tips` includes the other's entry id. With the lock,
  100% deterministic pass; without the lock, ~85% catch rate per run. Tuned
  for total suite runtime close to baseline.

`transport_conformance` tests previously wired sync-on-commit by hand
through `on_local_write` callbacks; they now use the standard machinery
(`instance.enable_sync()` registers the global callback,
`user.track_database(SyncSettings::on_commit())` flips the user preference,
`sync.add_tree_sync(peer, tree)` associates the peer). ~36 lines of bespoke
callback wiring traded for 4 idiomatic API calls — and exercises the
production sync path instead of a test-only shortcut.

## Deliberate decisions worth flagging

- **The `Database` passed to callbacks is read-only.** It's built via
  `Database::open_unauthenticated`, so it has no `DatabaseKey` configured
  and cannot commit transactions. Callbacks read settings/entries/tips
  through it; if a callback needs to write, it resolves `db.instance()?`
  and opens the database with the appropriate key.

- **Callbacks must not commit on the same tree they were invoked for.** The
  per-tree lock is held across callback dispatch; `tokio::sync::Mutex` is
  not reentrant, so a synchronous re-commit would deadlock. Documented on
  `Database::on_write`. Callbacks that need to write the same tree should
  spawn a task.

- **`put_remote_entries` does not validate that entries actually belong to
  `tree_id`.** Callers (notably `SyncHandler::SendEntries`, which derives
  tree_id per-entry) are trusted. The bootstrap path verifies the root
  entry's hash matches the declared tree_id; non-root entries in SendEntries
  have no equivalent check. Same trust boundary as before — moved, not
  tightened.

- **`get_tips` errors propagate from `put_entry` and `put_remote_entries`
  via `?` instead of `unwrap_or_default()`.** Pre-PR, transient backend
  errors would silently produce empty `previous_tips` and the write would
  succeed; now they fail the write. Trade-off is correctness over
  availability: silent empty tips would mislead consumers diffing from
  pre-state.

- **`fire_write_callbacks` clones the callback `Vec` on every write.** Each
  element is `(CallbackId, Arc<dyn Fn>)`, so the clones themselves are
  cheap, but the `Vec` allocation is per-write. Necessary because we can't
  hold the mutex across `.await`. An `Arc<RwLock<Vec<...>>>` would avoid
  the allocation but adds complexity; current shape is fine for the
  expected callback counts.

- **Source filter moved from registration-time to dispatch-time for global
  callbacks.** Pre-PR the sync hook was indexed by `WriteSource::Local` so
  remote writes skipped it at lookup. Now every write fires every global
  callback and the closure does `if event.source() != WriteSource::Local`.
  Cost is negligible per write; price of the API simplification.

- **`WriteCallback` is not `Clone`.** It represents a unique registration;
  cloning would risk double-removal on drop. Users wanting shared lifecycle
  across components should wrap in `Arc<Mutex<Option<WriteCallback>>>` or
  use `.detach()` plus their own bookkeeping.

- **No `WriteCallback` handle for global registrations.** Sync's permanent
  hook (only current global caller) has no removal path. The asymmetry is
  documented in `register_global_write_callback`; if a future caller needs
  lifecycle management on a global callback, the path is small to add back.

- **Per-tree locks live forever in the `tree_locks` map.** No eviction
  policy. An `Arc<tokio::sync::Mutex<()>>` is small and the number of
  trees is bounded by the working set; if this becomes a problem, add a
  weak-map or LRU.

- **`User::share` doc comment was reworded** to describe the actual call
  order (ticket-build first, then `enable_sync`) instead of the original
  "enable_sync followed by ticket construction" phrasing, which inverted
  what the implementation does. Behavior unchanged.

Assisted-by: Claude Opus 4.7 <noreply@anthropic.com>