### PR TITLE
refactor(docs): replace mdbook test with cargo-based book testing

### DIFF
--- a/.config/deny.toml
+++ b/.config/deny.toml
@@ -36,6 +36,7 @@ exceptions = [
     # Eidetica's own libraries
     { allow = ["AGPL-3.0-or-later"], crate = "eidetica" },
     { allow = ["AGPL-3.0-or-later"], crate = "eidetica-bin" },
+    { allow = ["AGPL-3.0-or-later"], crate = "eidetica-book-tests" },
     { allow = ["AGPL-3.0-or-later"], crate = "example-chat" },
     { allow = ["AGPL-3.0-or-later"], crate = "example-todo" },
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1468,6 +1468,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "eidetica-book-tests"
+version = "0.2.0"
+dependencies = [
+ "chrono",
+ "eidetica",
+ "iroh",
+ "serde",
+ "tokio",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/lib", "crates/bin", "examples/*"]
+members = ["crates/lib", "crates/bin", "crates/book-tests", "examples/*"]
 resolver = "2"
 
 [workspace.package]

--- a/crates/book-tests/Cargo.toml
+++ b/crates/book-tests/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "eidetica-book-tests"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+publish = false
+description = "Doctests for the eidetica mdbook documentation"
+
+# build.rs auto-discovers markdown files in docs/src/
+build = "build.rs"
+
+[dependencies]
+eidetica = { path = "../lib", features = ["full"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+serde = { workspace = true }
+chrono = { workspace = true }
+iroh = { workspace = true }
+tracing-subscriber = { workspace = true }
+uuid = { workspace = true }

--- a/crates/book-tests/build.rs
+++ b/crates/book-tests/build.rs
@@ -1,0 +1,46 @@
+use std::io::Write;
+use std::{env, fs, path::PathBuf};
+
+fn main() {
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    let docs_dir = manifest_dir.join("../../docs/src");
+
+    println!("cargo::rerun-if-changed={}", docs_dir.display());
+
+    let mut generated = fs::File::create(out_dir.join("book_doctests.rs")).unwrap();
+
+    discover_md_files(&docs_dir, &docs_dir, &mut generated);
+}
+
+fn discover_md_files(base: &PathBuf, dir: &PathBuf, out: &mut fs::File) {
+    let mut entries: Vec<_> = fs::read_dir(dir).unwrap().filter_map(|e| e.ok()).collect();
+    entries.sort_by_key(|e| e.path());
+
+    for entry in entries {
+        let path = entry.path();
+        if path.is_dir() {
+            // Skip generated/copied directories that aren't book source
+            let name = entry.file_name();
+            if name == "rustdoc" {
+                continue;
+            }
+            discover_md_files(base, &path, out);
+        } else if path.extension().is_some_and(|e| e == "md") {
+            let rel = path.strip_prefix(base).unwrap();
+            // Create a valid Rust module name from the path
+            let mod_name: String = rel
+                .to_string_lossy()
+                .replace('/', "__")
+                .replace(".md", "")
+                .replace('-', "_");
+
+            // Use the canonicalized absolute path so include_str! works
+            // regardless of where OUT_DIR is located.
+            let abs_path = path.canonicalize().unwrap();
+
+            writeln!(out, "#[doc = include_str!(\"{}\")]", abs_path.display(),).unwrap();
+            writeln!(out, "mod {mod_name} {{}}\n").unwrap();
+        }
+    }
+}

--- a/crates/book-tests/src/lib.rs
+++ b/crates/book-tests/src/lib.rs
@@ -1,0 +1,10 @@
+#![allow(non_snake_case)]
+// This crate exists solely to test code examples in the mdbook documentation.
+//
+// The build.rs auto-discovers all .md files under docs/src/ and generates
+// modules with `#[doc = include_str!("...")]` for each one. Running
+// `cargo test --doc -p eidetica-book-tests` compiles and runs every
+// fenced Rust code block through cargo's normal dependency resolution,
+// avoiding the rlib collision issues that plague `mdbook test -L`.
+
+include!(concat!(env!("OUT_DIR"), "/book_doctests.rs"));

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,20 +22,19 @@ The documentation includes compilable examples using the actual Eidetica API. Th
 
 ### How It Works
 
-The documentation testing system works as follows:
+The `eidetica-book-tests` crate (`crates/book-tests/`) auto-discovers all markdown
+files in `docs/src/` via a build script and includes them as doc comments using
+`#[doc = include_str!()]`. This lets `cargo test --doc` compile and run every
+fenced Rust code block through cargo's normal dependency resolution.
 
-1. Examples use `extern crate eidetica;` to access the real library
-2. `just doc test` builds eidetica with all features enabled
-3. mdbook uses `-L target/debug/deps` to find compiled dependencies
-4. Build process ensures only one eidetica configuration exists
-
-### Build Process
+This approach avoids the E0464 "multiple rlib candidates" errors that occur with
+`mdbook test -L`, which breaks when cargo builds dependencies with different
+feature sets (common in workspaces with complex dependency trees).
 
 ```bash
 just doc test
-├── rm -f target/debug/deps/libeidetica-*.rlib target/debug/deps/libeidetica-*.rmeta
-├── cargo build -p eidetica                    # Builds single eidetica configuration
-└── mdbook test docs -L target/debug/deps      # Tests examples against built library
+├── just doc links                              # Check documentation links
+└── cargo test --doc -p eidetica-book-tests     # Test all book examples
 ```
 
 ### Testing Strategy
@@ -149,8 +148,7 @@ Document the current architecture, APIs, and behavior patterns without historica
 If book tests fail:
 
 1. Check imports use valid module paths from the eidetica crate
-2. Verify examples have proper `extern crate` declarations
-3. Run `just doc test` separately to isolate issues
-4. Some features may require specific feature flags
+2. Run `just doc test` separately to isolate issues
+3. New markdown files in `docs/src/` are auto-discovered; no manual registration needed
 
 Tested examples use the real API directly, ensuring documentation stays accurate as the codebase evolves.

--- a/docs/src/design/bootstrap.md
+++ b/docs/src/design/bootstrap.md
@@ -34,7 +34,7 @@ A database can grant universal permissions by setting a global permission in its
 
 <!-- Code block ignored: Simplified view of AuthSettings structure -->
 
-```rust,ignore
+```text
 // AuthSettings stores data in a Doc with three sub-objects:
 //   "keys"        - per-key auth entries (SigKey → AuthKey)
 //   "delegations" - delegated tree references

--- a/flake.nix
+++ b/flake.nix
@@ -169,7 +169,7 @@
               all = mkAll "sanitize" sanitizePkgs.builds;
             };
 
-          # Documentation group - nix build .#doc.default (fast), .#doc.api, .#doc.book, .#doc.booktest
+          # Documentation group - nix build .#doc.default (fast), .#doc.api, .#doc.book, .#doc.test
           doc =
             docPkgs.builds
             // {

--- a/justfile
+++ b/justfile
@@ -345,9 +345,7 @@ doc action='api':
             ;;
         test)
             just doc links
-            rm --force target/debug/deps/libeidetica-*.rlib target/debug/deps/libeidetica-*.rmeta
-            cargo build --package eidetica
-            RUST_LOG=error mdbook test docs --library-path target/debug/deps
+            cargo test --doc -p eidetica-book-tests
             ;;
         clean)
             mdbook clean docs

--- a/nix/packages/doc.nix
+++ b/nix/packages/doc.nix
@@ -85,33 +85,15 @@
       mdbook build docs -d $out
     '';
 
-  doc-book-test = craneLib.mkCargoDerivation (debugArgs
-    // {
-      pname = "book-test";
-      src = docSrc;
-      nativeBuildInputs = debugArgs.nativeBuildInputs ++ [pkgs.mdbook];
-      buildPhaseCargoCommand = ''
-        rm -f target/debug/deps/libeidetica-*.rlib target/debug/deps/libeidetica-*.rmeta
-        cargo build -p eidetica
-      '';
-      doCheck = true;
-      checkPhase = ''
-        runHook preCheck
-        cd docs
-        mdbook test . -L ../target/debug/deps
-        runHook postCheck
-      '';
-      doInstallCargoArtifacts = false;
-      installPhase = ''
-        runHook preInstall
-        mkdir -p $out
-        echo "Documentation examples tested successfully" > $out/result
-        runHook postInstall
-      '';
-    });
-
+  # All doc tests: both Rust doc comments and mdbook code examples.
+  # Uses docSrc (includes docs/ directory) so the book-tests crate can
+  # find the markdown files. The book-tests crate auto-discovers all
+  # markdown files in docs/src/ and tests their fenced code blocks through
+  # cargo's dependency resolution, avoiding E0464 "multiple rlib candidates"
+  # errors that plague `mdbook test -L`.
   doc-test = craneLib.cargoTest (debugArgs
     // {
+      src = docSrc;
       cargoTestExtraArgs = "--doc --workspace --all-features";
     });
 in {
@@ -124,7 +106,6 @@ in {
     links = doc-links;
     test = doc-test;
     book = doc-book;
-    booktest = doc-book-test;
   };
 
   runners = {
@@ -135,7 +116,6 @@ in {
   defaults = {
     api = doc-api;
     test = doc-test;
-    booktest = doc-book-test;
     links = doc-links;
   };
 }


### PR DESCRIPTION
## Summary

- Replace `mdbook test -L target/debug/deps` with a `eidetica-book-tests` crate that tests book examples via `cargo test --doc`
- `mdbook test` invokes rustdoc with a flat `-L` search path, which breaks when cargo builds dependencies with different feature sets (62 crates in this workspace have feature divergence, producing multiple rlib files per crate and triggering E0464 "multiple candidates for rlib dependency")
- This was masked in CI by nix build caching — the old derivation hash was cached as passing, so the bug only surfaced when flake input updates changed the hash (see #28)
- The `book-tests` crate auto-discovers `docs/src/**/*.md` via `build.rs` and includes them as doc comments, so new docs are tested automatically
- Simplifies nix build: removes custom `doc-book-test` derivation, merges into existing `doc-test`, reuses crane's shared dependency cache

## Test plan

- [x] `cargo test --doc -p eidetica-book-tests` — 55 passed, 0 failed
- [x] `nix build .#doc.test` — builds successfully using shared dep cache
- [x] `nix build .#doc.default` — full doc pipeline (api + test + links) passes
- [x] `nix flake check` — all checks pass (build, test, lint, doc, eval, treefmt)
- [ ] CI passes on both x86_64-linux and aarch64-linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)