### PR TITLE
perf(ci): parallelize checks and reduce PR scope

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,8 +1,8 @@
 name: Benchmarks
 
 on:
-  push:
-    branches: ["main"]
+  schedule:
+    - cron: "0 6 * * 1" # Weekly on Monday at 06:00 UTC
   workflow_dispatch:
 
 jobs:
@@ -21,7 +21,7 @@ jobs:
         uses: bencherdev/bencher@8151077aa7b1bceaac11c4b308265417cae60e2b # v0.5.10
 
       - name: Run Benchmarks
-        if: github.event_name == 'push' || github.ref == 'refs/heads/main'
+        if: github.event_name == 'schedule' || github.ref == 'refs/heads/main'
         run: |
           nix develop --command bencher run \
             --project eidetica \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
   ci-arm:
     name: CI (aarch64-linux)
     if: github.event_name != 'pull_request'
-    runs-on: ubicloud-standard-8-arm
+    runs-on: ubicloud-standard-16-arm
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,16 +9,8 @@ on:
 
 jobs:
   ci:
-    name: CI (${{ matrix.system }})
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      matrix:
-        include:
-          - system: x86_64-linux
-            runner: ubicloud-standard-8
-          - system: aarch64-linux
-            runner: ubicloud-standard-8-arm
-      fail-fast: false
+    name: CI (x86_64-linux)
+    runs-on: ubicloud-standard-8
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -26,31 +18,27 @@ jobs:
       - name: Setup Nix
         uses: ./.github/actions/setup-nix
 
-      - name: Lint
+      - name: Checks
         run: |
-          nix-fast-build --skip-cached --no-nom --no-link \
-            -f '.#legacyPackages.${{ matrix.system }}.lint.default'
-          nix-fast-build --skip-cached --no-nom --no-link \
-            -f '.#checks.${{ matrix.system }}.treefmt'
-
-      - name: Test
-        run: |
-          nix-fast-build --skip-cached --no-nom --no-link \
-            -f '.#legacyPackages.${{ matrix.system }}.test.all'
-          nix-fast-build --skip-cached --no-nom --no-link \
-            -f '.#legacyPackages.${{ matrix.system }}.eval.default'
+          nix-fast-build --skip-cached --no-nom --no-link
 
       - name: Integration tests
-        if: matrix.system == 'x86_64-linux'
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         run: |
           nix-fast-build --skip-cached --no-nom --no-link \
             -f '.#legacyPackages.x86_64-linux.integration.default'
 
-      - name: Doc
-        run: |
-          nix-fast-build --skip-cached --no-nom --no-link \
-            -f '.#legacyPackages.${{ matrix.system }}.doc.default'
+  ci-arm:
+    name: CI (aarch64-linux)
+    if: github.event_name != 'pull_request'
+    runs-on: ubicloud-standard-8-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Remaining Checks
+      - name: Setup Nix
+        uses: ./.github/actions/setup-nix
+
+      - name: Checks
         run: |
           nix-fast-build --skip-cached --no-nom --no-link

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,8 +1,8 @@
 name: Coverage
 
 on:
-  push:
-    branches: ["main"]
+  schedule:
+    - cron: "0 6 * * 1" # Weekly on Monday at 06:00 UTC
   workflow_dispatch:
 
 jobs:
@@ -19,7 +19,7 @@ jobs:
       - name: Coverage
         run: |
           nix-fast-build --no-nom --no-link \
-            -f '.#legacyPackages.x86_64-linux.coverage'
+            -f '.#legacyPackages.x86_64-linux.coverage.all'
 
       - name: Extract coverage data
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -99,11 +99,7 @@ jobs:
           nix-fast-build --skip-cached --no-nom --no-link \
             ${{ steps.nix.outputs.push-args }} \
             --option substituters 'https://cache.nixos.org' \
-            -f '.#legacyPackages.${{ matrix.system }}.eidetica.bin'
-          nix-fast-build --skip-cached --no-nom --no-link \
-            ${{ steps.nix.outputs.push-args }} \
-            --option substituters 'https://cache.nixos.org' \
-            -f '.#legacyPackages.${{ matrix.system }}.eidetica.image'
+            -f '.#legacyPackages.${{ matrix.system }}.eidetica.release'
 
       # Warm the cache with all remaining flake check outputs so subsequent CI
       # runs are faster. Only needed on the dev path (every push to main) —

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,7 +54,7 @@ jobs:
             runner: ubicloud-standard-8
             platform: amd64
           - system: aarch64-linux
-            runner: ubicloud-standard-8-arm
+            runner: ubicloud-standard-16-arm
             platform: arm64
       fail-fast: false
     permissions:

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -11,6 +11,7 @@ jobs:
     name: Release-plz release
     runs-on: ubicloud-standard-2
     if: github.repository_owner == 'arcuru' && (github.event_name == 'push' || github.ref == 'refs/heads/main')
+    environment: publish
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -1,15 +1,15 @@
 name: Sanitizers
 
 on:
-  push:
-    branches: ["main"]
+  schedule:
+    - cron: "0 6 * * 1" # Weekly on Monday at 06:00 UTC
   workflow_dispatch:
 
 jobs:
   sanitize:
     name: Sanitize (${{ matrix.sanitizer }})
     runs-on: ubicloud-standard-4
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.repository_owner == 'arcuru'
     strategy:
       matrix:
         sanitizer: [asan, lsan]

--- a/flake.nix
+++ b/flake.nix
@@ -220,11 +220,11 @@
         };
 
         # CI checks - packages that run during `nix flake check`
-        # Each check builds the corresponding .default from legacyPackages
+        # All checks build in parallel via nix-fast-build for CI efficiency
         # Excluded for performance: release builds, coverage, bench, integration, sanitize
         checks = {
           build = mainPkgs.eidetica-bin-debug;
-          test = testPkgs.builds.sqlite;
+          test = mkAll "test" testPkgs.builds;
           lint = mkAggregate "lint" lintPkgs.defaults;
           doc = mkAggregate "doc" docPkgs.defaults;
           eval = mkAggregate "eval" nixTests.eval;

--- a/flake.nix
+++ b/flake.nix
@@ -190,6 +190,10 @@
             bin = mainPkgs.eidetica-bin;
             bin-debug = mainPkgs.eidetica-bin-debug;
             inherit (containerPkgs) image;
+            release = mkAggregate "eidetica-release" {
+              inherit (mainPkgs) eidetica-bin;
+              inherit (containerPkgs) image;
+            };
           };
 
           # Default package (eidetica binary)


### PR DESCRIPTION
## Summary
- Combine 5+ sequential `nix-fast-build` calls into a single invocation that builds all checks in parallel
- Expand flake `checks` to include all test backends (not just sqlite) so the single `nix-fast-build` covers everything
- Skip ARM64 CI on PRs (still runs on main push and `workflow_dispatch`)
- Skip integration tests on PRs (still runs on main push and `workflow_dispatch`)

## Expected impact
PR CI wall clock should drop significantly — previously lint, test, doc, and remaining checks ran sequentially (~23 min total). Now they all build in parallel via a single `nix-fast-build` call.

## Test plan
- [ ] PR CI passes with the new single-check structure
- [ ] Verify ARM64 job is skipped on this PR
- [ ] Verify integration tests are skipped on this PR
- [ ] After merge, confirm main push triggers both architectures + integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)