### PR TITLE
fix(deps): update rustls-webpki to fix security advisories

### DIFF
--- a/.config/deny.toml
+++ b/.config/deny.toml
@@ -4,7 +4,6 @@ ignore = [
     # Ignore these unmaintained crates that come from iroh dependencies
     "RUSTSEC-2023-0089", # atomic-polyfill unmaintained (via iroh)
     "RUSTSEC-2024-0436", # paste unmaintained (via iroh)
-    "RUSTSEC-2026-0049", # rustls-webpki CRL matching bug, fixed in >=0.103.10 (via iroh)
 ]
 
 [bans]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1156,7 +1156,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4540,9 +4540,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary
- Update `rustls-webpki` 0.103.10 → 0.103.12 to fix RUSTSEC-2026-0098 and RUSTSEC-2026-0099 (name constraint validation bugs)
- Remove now-unnecessary `RUSTSEC-2026-0049` ignore entry from deny.toml

Closes #30

## Test plan
- [x] `cargo check` passes
- [x] `cargo deny check --config .config/deny.toml advisories` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)