### PR TITLE
Fix publish workflow: release aggregate build failure

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -190,10 +190,11 @@
             bin = mainPkgs.eidetica-bin;
             bin-debug = mainPkgs.eidetica-bin-debug;
             inherit (containerPkgs) image;
-            release = mkAggregate "eidetica-release" {
-              inherit (mainPkgs) eidetica-bin;
-              inherit (containerPkgs) image;
-            };
+            release = pkgs.runCommand "eidetica-release" {} ''
+              mkdir -p $out/bin $out/image
+              ln -s ${mainPkgs.eidetica-bin}/bin/* $out/bin/
+              ln -s ${containerPkgs.image} $out/image/eidetica-image.tar.gz
+            '';
           };
 
           # Default package (eidetica binary)


### PR DESCRIPTION
## Summary
- Fix the `eidetica.release` Nix target that fails with "Not a directory" during publish
- `mkAggregate` uses `symlinkJoin` which can only merge directory derivations, but `dockerTools.buildImage` produces a `.tar.gz` file
- Replace with `runCommand` that creates a proper directory structure with symlinks to both the binary and the container image

## Test plan
- [x] `nix build .#eidetica.release` succeeds locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)