### PR TITLE
feat(user): add enable_sync/disable_sync/is_sync_enabled on User

### DIFF
--- a/crates/lib/src/user/session/mod.rs
+++ b/crates/lib/src/user/session/mod.rs
@@ -20,6 +20,8 @@
 //! - **`database()`** - Get a specific tracked database
 //! - **`track_database()`** - Add or update a tracked database (upsert)
 //! - **`untrack_database()`** - Remove a database from your tracked list
+//! - **`enable_sync()` / `disable_sync()`** - Toggle this user's sync preference for a tracked database
+//! - **`is_sync_enabled()`** - Check this user's sync preference for a database
 //!
 //! ## Key-Database Mappings
 //!
@@ -920,6 +922,109 @@ impl User {
             }
             .into()
         })
+    }
+
+    /// Enable sync for a tracked database.
+    ///
+    /// Sets `sync_enabled = true` on the user's preference for this database,
+    /// preserving `sync_on_commit`, `interval_seconds`, and `properties`.
+    /// Propagates the change to the host-level combined sync state by
+    /// calling [`Sync::sync_user`] if sync is attached to the instance.
+    ///
+    /// No-op if already enabled.
+    ///
+    /// # Errors
+    /// Returns `DatabaseNotTracked` if the database is not in the user's list.
+    pub async fn enable_sync(&mut self, database_id: &ID) -> Result<()> {
+        self.set_sync_enabled(database_id, true).await
+    }
+
+    /// Disable sync for a tracked database.
+    ///
+    /// Sets `sync_enabled = false` on the user's preference for this database,
+    /// preserving other sync settings. Propagates to the host via
+    /// [`Sync::sync_user`] if sync is attached.
+    ///
+    /// The host-level combined state is OR'd across all users on the instance,
+    /// so another user with sync enabled for the same database will keep the
+    /// host serving it.
+    ///
+    /// No-op if already disabled.
+    ///
+    /// # Errors
+    /// Returns `DatabaseNotTracked` if the database is not in the user's list.
+    pub async fn disable_sync(&mut self, database_id: &ID) -> Result<()> {
+        self.set_sync_enabled(database_id, false).await
+    }
+
+    /// Check whether this user has sync enabled for a tracked database.
+    ///
+    /// Returns this user's own preference, not the host's combined state.
+    /// A `false` result means this user is not personally sharing the database;
+    /// another user on the same instance may still have sync enabled for it.
+    ///
+    /// Returns `Ok(false)` for databases not tracked by this user.
+    pub async fn is_sync_enabled(&self, database_id: &ID) -> Result<bool> {
+        let databases_table = self
+            .user_database()
+            .get_store_viewer::<Table<TrackedDatabase>>("databases")
+            .await?;
+        let db_id_key = database_id.to_string();
+        match databases_table.get(&db_id_key).await {
+            Ok(tracked) => Ok(tracked.sync_settings.sync_enabled),
+            Err(_) => Ok(false),
+        }
+    }
+
+    /// Internal helper backing [`Self::enable_sync`] and [`Self::disable_sync`].
+    ///
+    /// Reads the user's existing `TrackedDatabase`, updates only
+    /// `sync_settings.sync_enabled`, and writes it back in a single transaction.
+    /// All other fields on `TrackedDatabase` (`key_id`, `sync_on_commit`,
+    /// `interval_seconds`, `properties`) are preserved as-is.
+    ///
+    /// Short-circuits without touching the user database when `sync_enabled`
+    /// already matches `enabled`, so repeated calls don't create churn in the
+    /// preferences DAG or trigger redundant `Sync::sync_user` propagation.
+    ///
+    /// On a real change, after the preferences commit succeeds, this calls
+    /// [`Sync::sync_user`] when sync is attached to the instance so the
+    /// host-level combined sync state (computed across all users by
+    /// `merge_sync_settings`) updates immediately rather than waiting for
+    /// the background worker.
+    ///
+    /// # Errors
+    /// Returns `DatabaseNotTracked` if the database is not in the user's
+    /// tracked list. The error is intentionally indistinguishable from a
+    /// transaction read error on the tracking table — both are degenerate
+    /// states from the caller's perspective.
+    async fn set_sync_enabled(&mut self, database_id: &ID, enabled: bool) -> Result<()> {
+        let tx = self.user_database.new_transaction().await?;
+        let databases_table = tx.get_store::<Table<TrackedDatabase>>("databases").await?;
+        let db_id_key = database_id.to_string();
+
+        let mut tracked =
+            databases_table
+                .get(&db_id_key)
+                .await
+                .map_err(|_| UserError::DatabaseNotTracked {
+                    database_id: database_id.clone(),
+                })?;
+
+        if tracked.sync_settings.sync_enabled == enabled {
+            return Ok(());
+        }
+
+        tracked.sync_settings.sync_enabled = enabled;
+        databases_table.set(&db_id_key, tracked).await?;
+        tx.commit().await?;
+
+        if let Some(sync) = self.instance.sync() {
+            sync.sync_user(&self.user_uuid, self.user_database.root_id())
+                .await?;
+        }
+
+        Ok(())
     }
 
     /// Stop tracking a database.

--- a/crates/lib/tests/it/user/database_tracking_tests.rs
+++ b/crates/lib/tests/it/user/database_tracking_tests.rs
@@ -447,3 +447,147 @@ async fn test_update_tracked_auto_creates_mapping() -> Result<()> {
 
     Ok(())
 }
+
+/// Test enable_sync flips the user's sync preference to true
+#[tokio::test]
+async fn test_enable_sync_flips_preference() -> Result<()> {
+    let instance = setup_instance().await;
+
+    instance.create_user("test_user", None).await?;
+    let mut user = login_user(&instance, "test_user", None).await;
+    let user_key = user.get_default_key()?;
+
+    let (alice_key, _) = generate_keypair();
+    let mut db_settings = Doc::new();
+    db_settings.set("name", "test_db");
+    let db = Database::create(&instance, alice_key, db_settings).await?;
+    let db_id = db.root_id().clone();
+    set_global_auth_key(&db, AuthKey::active(None, Permission::Write(10))).await;
+
+    // Track with sync disabled initially
+    user.track_database(db_id.clone(), &user_key, SyncSettings::disabled())
+        .await?;
+    assert!(!user.is_sync_enabled(&db_id).await?);
+
+    // Enable
+    user.enable_sync(&db_id).await?;
+    assert!(user.is_sync_enabled(&db_id).await?);
+    let tracked = user.database(&db_id).await?;
+    assert!(tracked.sync_settings.sync_enabled);
+
+    Ok(())
+}
+
+/// Test disable_sync flips the user's sync preference to false
+#[tokio::test]
+async fn test_disable_sync_flips_preference() -> Result<()> {
+    let instance = setup_instance().await;
+
+    instance.create_user("test_user", None).await?;
+    let mut user = login_user(&instance, "test_user", None).await;
+    let user_key = user.get_default_key()?;
+
+    let (alice_key, _) = generate_keypair();
+    let mut db_settings = Doc::new();
+    db_settings.set("name", "test_db");
+    let db = Database::create(&instance, alice_key, db_settings).await?;
+    let db_id = db.root_id().clone();
+    set_global_auth_key(&db, AuthKey::active(None, Permission::Write(10))).await;
+
+    user.track_database(db_id.clone(), &user_key, SyncSettings::enabled())
+        .await?;
+    assert!(user.is_sync_enabled(&db_id).await?);
+
+    user.disable_sync(&db_id).await?;
+    assert!(!user.is_sync_enabled(&db_id).await?);
+
+    Ok(())
+}
+
+/// Test that toggling sync preserves other sync settings
+#[tokio::test]
+async fn test_toggle_sync_preserves_other_settings() -> Result<()> {
+    let instance = setup_instance().await;
+
+    instance.create_user("test_user", None).await?;
+    let mut user = login_user(&instance, "test_user", None).await;
+    let user_key = user.get_default_key()?;
+
+    let (alice_key, _) = generate_keypair();
+    let mut db_settings = Doc::new();
+    db_settings.set("name", "test_db");
+    let db = Database::create(&instance, alice_key, db_settings).await?;
+    let db_id = db.root_id().clone();
+    set_global_auth_key(&db, AuthKey::active(None, Permission::Write(10))).await;
+
+    // Track with on_commit + custom interval
+    user.track_database(
+        db_id.clone(),
+        &user_key,
+        SyncSettings::on_commit().with_interval(45),
+    )
+    .await?;
+
+    // Disable, then re-enable — other fields should round-trip
+    user.disable_sync(&db_id).await?;
+    user.enable_sync(&db_id).await?;
+
+    let tracked = user.database(&db_id).await?;
+    assert!(tracked.sync_settings.sync_enabled);
+    assert!(tracked.sync_settings.sync_on_commit);
+    assert_eq!(tracked.sync_settings.interval_seconds, Some(45));
+
+    Ok(())
+}
+
+/// Test enable/disable on an untracked database errors; is_sync_enabled returns false
+#[tokio::test]
+async fn test_sync_toggle_on_untracked_database() -> Result<()> {
+    let instance = setup_instance().await;
+
+    instance.create_user("test_user", None).await?;
+    let mut user = login_user(&instance, "test_user", None).await;
+
+    let (alice_key, _) = generate_keypair();
+    let mut db_settings = Doc::new();
+    db_settings.set("name", "untracked_db");
+    let db = Database::create(&instance, alice_key, db_settings).await?;
+    let db_id = db.root_id().clone();
+
+    // is_sync_enabled returns false rather than erroring
+    assert!(!user.is_sync_enabled(&db_id).await?);
+
+    // enable/disable both error with DatabaseNotTracked
+    assert!(user.enable_sync(&db_id).await.is_err());
+    assert!(user.disable_sync(&db_id).await.is_err());
+
+    Ok(())
+}
+
+/// Test that repeated enable is a no-op (idempotent)
+#[tokio::test]
+async fn test_enable_sync_is_idempotent() -> Result<()> {
+    let instance = setup_instance().await;
+
+    instance.create_user("test_user", None).await?;
+    let mut user = login_user(&instance, "test_user", None).await;
+    let user_key = user.get_default_key()?;
+
+    let (alice_key, _) = generate_keypair();
+    let mut db_settings = Doc::new();
+    db_settings.set("name", "test_db");
+    let db = Database::create(&instance, alice_key, db_settings).await?;
+    let db_id = db.root_id().clone();
+    set_global_auth_key(&db, AuthKey::active(None, Permission::Write(10))).await;
+
+    user.track_database(db_id.clone(), &user_key, SyncSettings::enabled())
+        .await?;
+
+    user.enable_sync(&db_id).await?;
+    user.enable_sync(&db_id).await?;
+    user.enable_sync(&db_id).await?;
+
+    assert!(user.is_sync_enabled(&db_id).await?);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Adds three methods on `User` that let a caller toggle and inspect this user's per-database sync preference without juggling `SyncSettings` constructors or re-supplying the mapped key.
- `enable_sync` / `disable_sync` modify only `sync_settings.sync_enabled`, preserving `sync_on_commit`, `interval_seconds`, `properties`, and the existing key mapping; no-op when already in the requested state. Both propagate to the host-level combined state via `Sync::sync_user`, matching `track_database`'s behavior.
- `is_sync_enabled` returns this user's own preference as a bool. Returns `Ok(false)` for untracked databases (predicate, not a lookup).

## Why these names

"Share" is already taken in this codebase for the `DatabaseTicket` / `sync_with_ticket` transmission flow; reusing it on `User` would conflate "the host may serve this DB" with "I'm handing someone a ticket." "Allow"/"deny" hints at a per-peer ACL, which is the wrong mental model — the host-level sync_enabled is a blanket OR across all users (`merge_sync_settings`). The chosen names mirror the underlying `SyncSettings::sync_enabled` field exactly, so there's no translation layer between the API and what's on disk.

## Scope note

These methods return this user's preference, not the host's combined state. Another user on the same instance enabling sync for the same DB will still keep the host serving it. An instance-wide "is this shareable right now" query belongs on `Sync` if needed — not added here.

## Test plan

- [x] `cargo test -p eidetica --test it --all-features -- user::database_tracking_tests` — 5 new tests pass alongside existing 11
- [x] `just test` — full suite (1115 tests) green
- [x] `just lint clippy` — no warnings
- [x] `just fmt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)