### PR TITLE
fix(sync): make rejection logs honest and add requester context

### DIFF
--- a/crates/lib/src/sync/handler.rs
+++ b/crates/lib/src/sync/handler.rs
@@ -645,11 +645,16 @@ impl SyncHandlerImpl {
         requested_permission: Option<Permission>,
     ) -> SyncResponse {
         // SECURITY: Check if database has sync enabled (FIRST CHECK - before anything else)
-        // This prevents information leakage about database existence
+        // This prevents information leakage about database existence: the gate
+        // returns false both for databases that are absent and for databases that
+        // are present-but-not-tracked-for-sync, and we deliberately respond with
+        // the same opaque "Tree not found" to peers in either case.
         if !self.is_database_sync_enabled(tree_id).await {
             warn!(
                 tree_id = %tree_id,
-                "Sync request for non-sync-enabled database - rejecting as not found"
+                requesting_key = ?requesting_key,
+                requesting_key_name = ?requesting_key_name,
+                "Bootstrap request rejected: database is absent or has no user with sync enabled (responding as not-found)"
             );
             return SyncResponse::Error(format!("Tree not found: {tree_id}"));
         }
@@ -662,7 +667,12 @@ impl SyncHandlerImpl {
         let _root_entry = match instance.backend().get(tree_id).await {
             Ok(entry) => entry,
             Err(e) if e.is_not_found() => {
-                warn!(tree_id = %tree_id, "Tree not found for bootstrap");
+                warn!(
+                    tree_id = %tree_id,
+                    requesting_key = ?requesting_key,
+                    requesting_key_name = ?requesting_key_name,
+                    "Bootstrap request rejected: a user has this tree marked sync-enabled but the backend has no root entry for it"
+                );
                 return SyncResponse::Error(format!("Tree not found: {tree_id}"));
             }
             Err(e) => {
@@ -864,11 +874,15 @@ impl SyncHandlerImpl {
     /// Handle incremental sync request
     async fn handle_incremental_sync(&self, tree_id: &ID, peer_tips: &[ID]) -> SyncResponse {
         // SECURITY: Check if database has sync enabled (FIRST CHECK - before anything else)
-        // This prevents information leakage about database existence
+        // This prevents information leakage about database existence: the gate
+        // returns false both for databases that are absent and for databases that
+        // are present-but-not-tracked-for-sync, and we deliberately respond with
+        // the same opaque "Tree not found" to peers in either case.
         if !self.is_database_sync_enabled(tree_id).await {
             warn!(
                 tree_id = %tree_id,
-                "Incremental sync request for non-sync-enabled database - rejecting as not found"
+                peer_tip_count = peer_tips.len(),
+                "Incremental sync request rejected: database is absent or has no user with sync enabled (responding as not-found)"
             );
             return SyncResponse::Error(format!("Tree not found: {tree_id}"));
         }


### PR DESCRIPTION
## Summary

The three sync-handler "rejected as not-found" branches all logged warnings, but two over-claimed and one was missing context:

- The bootstrap and incremental gates check `is_database_sync_enabled`, which returns false for *both* "tree absent" and "tree present but no user has it tracked for sync." The previous log only mentioned the second case, so absent-DB rejections read misleadingly.
- Bootstrap rejection logs didn't include `requesting_key` / `requesting_key_name` even though both are in scope — operators could see "DB X rejected" but not "by whom."

Rephrased the two gate logs to honestly cover both cases. Added `requesting_key` / `requesting_key_name` to bootstrap rejection branches and `peer_tip_count` to the incremental gate (no requester info available at that layer). Expanded the SECURITY comments to spell out *why* both cases deliberately collapse to the same opaque response, so nobody later "fixes" the conflation and reintroduces the existence-leak.

No wire behavior change — peers see the same `Tree not found` response in all rejection cases.

## Test plan

- [x] `cargo build -p eidetica` clean
- [x] `cargo clippy -p eidetica --lib` clean
- [x] `cargo test -p eidetica --lib sync` — 34/34 passing
- [ ] Manual: confirm new fields render correctly in tracing output on a host that receives a bootstrap request for a sync-disabled DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)