### PR TITLE
feat(user): add open_database_with_key for explicit key selection

### DIFF
--- a/crates/lib/src/user/session/mod.rs
+++ b/crates/lib/src/user/session/mod.rs
@@ -10,6 +10,7 @@
 //!
 //! - **`create_database()`** - Create a new database
 //! - **`open_database()`** - Open an existing database
+//! - **`open_database_with_key()`** - Open with an explicitly chosen user key
 //! - **`find_database()`** - Search for databases by name
 //!
 //! ## Tracked Databases
@@ -278,9 +279,6 @@ impl User {
     /// - Returns an error if no SigKey mapping exists
     /// - Returns an error if the key is not in the UserKeyManager
     pub async fn open_database(&self, root_id: &ID) -> Result<Database> {
-        // Validate the root exists
-        self.instance.backend().get(root_id).await?;
-
         // Find an appropriate key for this database
         let key_id =
             self.find_key(root_id)?
@@ -288,15 +286,48 @@ impl User {
                     database_id: root_id.clone(),
                 })?;
 
+        self.open_database_with_key(root_id, &key_id).await
+    }
+
+    /// Open an existing database with an explicitly chosen key.
+    ///
+    /// Equivalent to `open_database`, but selects the user's signing key by
+    /// public key instead of relying on `find_key`'s iteration order. Use this
+    /// when the user holds multiple authorized keys for a database and you
+    /// need writes signed by a specific one (e.g. agent-as-signer scenarios
+    /// where cryptographic provenance matters, not just authorization).
+    ///
+    /// The `key_id` is purely a selector into this user's `UserKeyManager`;
+    /// no crypto material is passed in.
+    ///
+    /// # Arguments
+    /// * `root_id` - The root entry ID of the database
+    /// * `key_id` - Public key of the user-held key to sign with
+    ///
+    /// # Returns
+    /// The opened Database configured to use the specified key
+    ///
+    /// # Errors
+    /// - Returns an error if the root entry does not exist
+    /// - Returns an error if the user does not hold a key with that pubkey
+    /// - Returns an error if the key has no SigKey mapping for this database
+    pub async fn open_database_with_key(
+        &self,
+        root_id: &ID,
+        key_id: &PublicKey,
+    ) -> Result<Database> {
+        // Validate the root exists
+        self.instance.backend().get(root_id).await?;
+
         // Get the SigningKey from UserKeyManager
-        let signing_key = self.key_manager.get_signing_key(&key_id).ok_or_else(|| {
+        let signing_key = self.key_manager.get_signing_key(key_id).ok_or_else(|| {
             super::errors::UserError::KeyNotFound {
                 key_id: key_id.to_string(),
             }
         })?;
 
         // Get the SigKey mapping for this database
-        let sigkey = self.key_mapping(&key_id, root_id)?.ok_or_else(|| {
+        let sigkey = self.key_mapping(key_id, root_id)?.ok_or_else(|| {
             super::errors::UserError::NoSigKeyMapping {
                 key_id: key_id.to_string(),
                 database_id: root_id.clone(),

--- a/crates/lib/tests/it/user/database_operations_tests.rs
+++ b/crates/lib/tests/it/user/database_operations_tests.rs
@@ -8,7 +8,15 @@
 
 use super::helpers::*;
 
-use eidetica::{auth::crypto::generate_keypair, crdt::Doc, entry::ID, store::DocStore};
+use eidetica::{
+    auth::{
+        crypto::generate_keypair,
+        types::{AuthKey, Permission, SigKey},
+    },
+    crdt::Doc,
+    entry::ID,
+    store::DocStore,
+};
 
 // ===== CREATE DATABASE TESTS =====
 
@@ -572,4 +580,105 @@ async fn test_user_can_discover_own_databases() {
     assert!(found_a.is_ok(), "Should find Project A");
     assert!(found_b.is_ok(), "Should find Project B");
     assert!(found_c.is_ok(), "Should find Project C");
+}
+
+// ===== OPEN_DATABASE_WITH_KEY TESTS =====
+
+#[tokio::test]
+async fn test_open_database_with_key_selects_requested_key() {
+    let (instance, username) = setup_instance_with_user("octavia", None).await;
+    let mut user = login_user(&instance, &username, None).await;
+
+    // key1 = default key (created with the user). Create DB with it (Admin(0)).
+    let keys = user.list_keys().expect("list keys");
+    let key1 = keys[0].clone();
+    let database = create_named_database(&mut user, "multi_key_db").await;
+    let db_id = database.root_id().clone();
+
+    // Add a second key and authorize it as Write in the database's auth settings.
+    let key2 = add_user_key(&mut user, Some("agent_key")).await;
+    let tx = database.new_transaction().await.expect("new transaction");
+    tx.get_settings()
+        .expect("settings store")
+        .set_auth_key(&key2, AuthKey::active(None, Permission::Write(10)))
+        .await
+        .expect("authorize key2");
+    tx.commit().await.expect("commit auth change");
+
+    // Map key2 locally so the user can open the DB with it.
+    user.map_key(&key2, &db_id, SigKey::from_pubkey(&key2))
+        .await
+        .expect("map key2");
+
+    // Each explicit selection produces a Database bound to the requested identity.
+    let opened_with_key1 = user
+        .open_database_with_key(&db_id, &key1)
+        .await
+        .expect("open with key1");
+    assert_eq!(
+        opened_with_key1.auth_identity(),
+        Some(&SigKey::from_pubkey(&key1)),
+        "open_database_with_key(&key1) should bind key1's identity"
+    );
+
+    let opened_with_key2 = user
+        .open_database_with_key(&db_id, &key2)
+        .await
+        .expect("open with key2");
+    assert_eq!(
+        opened_with_key2.auth_identity(),
+        Some(&SigKey::from_pubkey(&key2)),
+        "open_database_with_key(&key2) should bind key2's identity"
+    );
+}
+
+#[tokio::test]
+async fn test_open_database_with_key_errors_when_user_does_not_hold_key() {
+    let (instance, username) = setup_instance_with_user("portia", None).await;
+    let mut user = login_user(&instance, &username, None).await;
+
+    let database = create_named_database(&mut user, "db").await;
+    let db_id = database.root_id().clone();
+
+    // A pubkey the user does not hold.
+    let (_priv, foreign_pubkey) = generate_keypair();
+
+    let result = user.open_database_with_key(&db_id, &foreign_pubkey).await;
+    assert!(
+        result.is_err(),
+        "Opening with a pubkey not in the user's key manager should error"
+    );
+}
+
+#[tokio::test]
+async fn test_open_database_with_key_errors_when_key_lacks_mapping() {
+    let (instance, username) = setup_instance_with_user("quinn", None).await;
+    let mut user = login_user(&instance, &username, None).await;
+
+    let database = create_named_database(&mut user, "db").await;
+    let db_id = database.root_id().clone();
+
+    // Held by the user, but never mapped to this database.
+    let unmapped_key = add_user_key(&mut user, Some("unmapped")).await;
+
+    let result = user.open_database_with_key(&db_id, &unmapped_key).await;
+    assert!(
+        result.is_err(),
+        "Opening with a held key that has no mapping for this DB should error"
+    );
+}
+
+#[tokio::test]
+async fn test_open_database_with_key_errors_on_nonexistent_database() {
+    let (instance, username) = setup_instance_with_user("riley", None).await;
+    let user = login_user(&instance, &username, None).await;
+
+    let key = user.list_keys().expect("list keys")[0].clone();
+    let fake_id = ID::from_bytes("nonexistent_database");
+
+    let result = user.open_database_with_key(&fake_id, &key).await;
+    assert!(
+        result.is_err(),
+        "Opening a nonexistent database should error"
+    );
 }


### PR DESCRIPTION
## Summary

- Adds `User::open_database_with_key(&self, root_id: &ID, key_id: &PublicKey)` so callers holding multiple authorized keys for the same database can pick which one signs subsequent writes (agent-as-signer / ephemeral task keys / co-owned admin handover).
- `key_id` is purely a selector into the user's `UserKeyManager` — no crypto material crosses the API boundary.
- `open_database` now delegates to `open_database_with_key` after `find_key`. Pure addition; existing callers unchanged.

## Test plan

- [x] `just test` — full suite passes
- [x] `just nix` — all 18 checks (sqlite/inmemory/minimal/postgres backends, clippy, format, deny, typos, doc, links)
- [x] New tests cover: explicit selection across two authorized+mapped keys; held-but-unmapped key errors; pubkey-not-in-manager errors; nonexistent database errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)