### PR TITLE
feat(user): expose key display names to callers

### DIFF
--- a/crates/lib/src/user/session/mod.rs
+++ b/crates/lib/src/user/session/mod.rs
@@ -623,6 +623,43 @@ impl User {
             .ok_or_else(|| Error::from(InstanceError::AuthenticationRequired))
     }
 
+    /// Get the display name set for a key.
+    ///
+    /// Display names are caller-supplied human-readable labels passed to
+    /// `add_private_key`. They have no cryptographic significance and are
+    /// not unique across keys. Returns `None` if the user does not hold a
+    /// key with this pubkey, or if it was added without a display name.
+    ///
+    /// # Arguments
+    /// * `key_id` - Public key of a key held by this user
+    pub fn key_display_name(&self, key_id: &PublicKey) -> Option<&str> {
+        self.key_manager
+            .get_key_metadata(key_id)
+            .and_then(|metadata| metadata.display_name.as_deref())
+    }
+
+    /// Find user-held keys whose display name matches `name`.
+    ///
+    /// Display names are not unique, so this returns every key whose
+    /// `display_name` exactly matches the provided string. Keys without a
+    /// display name are never returned. Returns an empty `Vec` when there
+    /// are no matches.
+    ///
+    /// # Arguments
+    /// * `name` - Exact display name to match
+    pub fn find_keys_by_display_name(&self, name: &str) -> Vec<PublicKey> {
+        self.key_manager
+            .list_key_ids()
+            .into_iter()
+            .filter(|key_id| {
+                self.key_manager
+                    .get_key_metadata(key_id)
+                    .and_then(|metadata| metadata.display_name.as_deref())
+                    == Some(name)
+            })
+            .collect()
+    }
+
     /// Get a signing key by its ID.
     ///
     /// # Arguments

--- a/crates/lib/tests/it/user/key_management_tests.rs
+++ b/crates/lib/tests/it/user/key_management_tests.rs
@@ -801,3 +801,89 @@ async fn test_multiple_manual_mappings_persist() {
         "key3->db3 mapping should persist"
     );
 }
+
+// ===== DISPLAY NAME ACCESSOR TESTS =====
+
+#[tokio::test]
+async fn test_key_display_name_returns_set_name() {
+    let (instance, username) = setup_instance_with_user("zelda", None).await;
+    let mut user = login_user(&instance, &username, None).await;
+
+    let key = add_user_key(&mut user, Some("agent_alice")).await;
+
+    assert_eq!(user.key_display_name(&key), Some("agent_alice"));
+}
+
+#[tokio::test]
+async fn test_key_display_name_returns_none_when_unset() {
+    let (instance, username) = setup_instance_with_user("aaron", None).await;
+    let mut user = login_user(&instance, &username, None).await;
+
+    let key = add_user_key(&mut user, None).await;
+
+    assert_eq!(user.key_display_name(&key), None);
+}
+
+#[tokio::test]
+async fn test_key_display_name_returns_none_for_unknown_pubkey() {
+    let (instance, username) = setup_instance_with_user("brigid", None).await;
+    let user = login_user(&instance, &username, None).await;
+
+    let (_priv, foreign_pubkey) = generate_keypair();
+
+    assert_eq!(user.key_display_name(&foreign_pubkey), None);
+}
+
+#[tokio::test]
+async fn test_find_keys_by_display_name_returns_matches() {
+    let (instance, username) = setup_instance_with_user("clara", None).await;
+    let mut user = login_user(&instance, &username, None).await;
+
+    let alice_key = add_user_key(&mut user, Some("agent_alice")).await;
+    let _bob_key = add_user_key(&mut user, Some("agent_bob")).await;
+
+    let found = user.find_keys_by_display_name("agent_alice");
+    assert_eq!(found, vec![alice_key]);
+}
+
+#[tokio::test]
+async fn test_find_keys_by_display_name_returns_all_duplicates() {
+    let (instance, username) = setup_instance_with_user("dahlia", None).await;
+    let mut user = login_user(&instance, &username, None).await;
+
+    let key_a = add_user_key(&mut user, Some("shared")).await;
+    let key_b = add_user_key(&mut user, Some("shared")).await;
+    let _key_c = add_user_key(&mut user, Some("other")).await;
+
+    let found = user.find_keys_by_display_name("shared");
+    assert_eq!(found.len(), 2);
+    assert!(found.contains(&key_a));
+    assert!(found.contains(&key_b));
+}
+
+#[tokio::test]
+async fn test_find_keys_by_display_name_skips_unnamed_keys() {
+    let (instance, username) = setup_instance_with_user("evelyn", None).await;
+    let mut user = login_user(&instance, &username, None).await;
+
+    // Two keys with no display_name plus one named.
+    let _unnamed_a = add_user_key(&mut user, None).await;
+    let _unnamed_b = add_user_key(&mut user, None).await;
+    let named = add_user_key(&mut user, Some("only_one")).await;
+
+    // Empty string should not match keys with `display_name = None`.
+    assert!(user.find_keys_by_display_name("").is_empty());
+
+    // Named lookup still works.
+    assert_eq!(user.find_keys_by_display_name("only_one"), vec![named]);
+}
+
+#[tokio::test]
+async fn test_find_keys_by_display_name_no_match() {
+    let (instance, username) = setup_instance_with_user("fiona", None).await;
+    let mut user = login_user(&instance, &username, None).await;
+
+    let _key = add_user_key(&mut user, Some("present")).await;
+
+    assert!(user.find_keys_by_display_name("absent").is_empty());
+}


### PR DESCRIPTION
## Summary

- Adds `User::key_display_name(&PublicKey) -> Option<&str>` and `User::find_keys_by_display_name(&str) -> Vec<PublicKey>`.
- Closes a write-only-at-the-public-API gap: `add_private_key(display_name)` already persists the label in the user's private DB, but the read path (`UserKeyManager::get_key_metadata`) is `pub(crate)`. Callers (e.g. chaz) had to mirror their own `pubkey -> name` map.
- Reverse lookup returns `Vec` because display names are not unique; matches the existing `AuthSettings::find_keys_by_name` shape.
- Pure read-back of caller-supplied strings — no crypto material crosses the API boundary.

## Test plan

- [x] `just test` — full suite passes (1126 tests)
- [x] `just nix` — all 18 checks (sqlite/inmemory/minimal/postgres backends, clippy, format, deny, typos, doc, links)
- [x] New tests cover: forward returns set name; forward returns `None` for unset and unknown pubkey; reverse returns matches, all duplicates, empty for no match; reverse never matches unnamed keys via empty string

🤖 Generated with [Claude Code](https://claude.com/claude-code)