### PR TITLE
chore(deps): update flake inputs

### DIFF
--- a/crates/lib/src/auth/settings.rs
+++ b/crates/lib/src/auth/settings.rs
@@ -399,7 +399,7 @@ impl AuthSettings {
         // because it requires async Instance access to load delegated tree auth settings.
 
         // Sort by permission, highest first (reverse sort since Permission Ord has higher > lower)
-        results.sort_by(|a, b| b.1.cmp(&a.1));
+        results.sort_by_key(|b| std::cmp::Reverse(b.1));
         results
     }
 

--- a/crates/lib/src/backend/database/in_memory/traversal.rs
+++ b/crates/lib/src/backend/database/in_memory/traversal.rs
@@ -346,7 +346,7 @@ pub(crate) fn find_merge_base(
         candidates.push((id, height));
     }
     // Sort by height descending (highest first = closest to tips)
-    candidates.sort_by(|a, b| b.1.cmp(&a.1));
+    candidates.sort_by_key(|b| std::cmp::Reverse(b.1));
 
     tracing::trace!(
         candidate_count = candidates.len(),

--- a/crates/lib/src/database/mod.rs
+++ b/crates/lib/src/database/mod.rs
@@ -556,7 +556,7 @@ impl Database {
         }
 
         // Sort by permission, highest first
-        results.sort_by(|a, b| b.1.cmp(&a.1));
+        results.sort_by_key(|b| std::cmp::Reverse(b.1));
         Ok(results)
     }
 

--- a/crates/lib/src/user/key_manager.rs
+++ b/crates/lib/src/user/key_manager.rs
@@ -214,7 +214,7 @@ impl UserKeyManager {
         }
 
         // Sort by key_id string representation for deterministic output
-        serialized.sort_by(|a, b| a.key_id.to_string().cmp(&b.key_id.to_string()));
+        serialized.sort_by_key(|a| a.key_id.to_string());
 
         Ok(serialized)
     }

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1774313767,
-        "narHash": "sha256-hy0XTQND6avzGEUFrJtYBBpFa/POiiaGBr2vpU6Y9tY=",
+        "lastModified": 1777335812,
+        "narHash": "sha256-bEg5xoAxAwsyfnGhkEX7RJViTIBIYPd8ISg4O1c0HFc=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "3d9df76e29656c679c744968b17fbaf28f0e923d",
+        "rev": "5e0fb2f64edff2822249f21293b8304dedaaf676",
         "type": "github"
       },
       "original": {
@@ -23,11 +23,11 @@
         "rust-analyzer-src": []
       },
       "locked": {
-        "lastModified": 1774942139,
-        "narHash": "sha256-Wib0RDVsptJWQd2ldBgFpMF0kRjQKHejQq9an+ActYo=",
+        "lastModified": 1777538343,
+        "narHash": "sha256-tW6Szt8/FmRTEi3KdB2TAwZZ3jEwjDD74zIL7uGLsgk=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "0beafd2252f80385610e2f12cbecfdb9d2dfb0a0",
+        "rev": "298b12d701ef0d12c0f2e4858d4208bee24d14e5",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772408722,
-        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
+        "lastModified": 1775087534,
+        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1774709303,
-        "narHash": "sha256-D3Q07BbIA2KnTcSXIqqu9P586uWxN74zNoCH3h2ESHg=",
+        "lastModified": 1777268161,
+        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8110df5ad7abf5d4c0f6fb0f8f978390e77f9685",
+        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
         "type": "github"
       },
       "original": {
@@ -88,11 +88,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773297127,
-        "narHash": "sha256-6E/yhXP7Oy/NbXtf1ktzmU8SdVqJQ09HC/48ebEGBpk=",
+        "lastModified": 1775636079,
+        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "71b125cd05fbfd78cab3e070b73544abe24c5016",
+        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
         "type": "github"
       },
       "original": {

--- a/nix/dev-shell.nix
+++ b/nix/dev-shell.nix
@@ -50,7 +50,7 @@ in
 
         # Code formatting and quality
         alejandra # Nix formatter
-        nodePackages.prettier # General formatter
+        prettier # General formatter
         typos # Spell checker
 
         # Release management


### PR DESCRIPTION
## Flake Input Update

Monthly `nix flake update` of Nix dependencies.

### Input Changes

- **crane**: [`3d9df76` → `5e0fb2f`](https://github.com/ipetkov/crane/compare/3d9df76e29656c679c744968b17fbaf28f0e923d...5e0fb2f64edff2822249f21293b8304dedaaf676)
- **fenix**: [`0beafd2` → `298b12d`](https://github.com/nix-community/fenix/compare/0beafd2252f80385610e2f12cbecfdb9d2dfb0a0...298b12d701ef0d12c0f2e4858d4208bee24d14e5)
- **flake-parts**: [`f20dc5d` → `3107b77`](https://github.com/hercules-ci/flake-parts/compare/f20dc5d9b8027381c474144ecabc9034d6a839a3...3107b77cd68437b9a76194f0f7f9c55f2329ca5b)
- **nixpkgs**: [`8110df5` → `1c3fe55`](https://github.com/nixos/nixpkgs/compare/8110df5ad7abf5d4c0f6fb0f8f978390e77f9685...1c3fe55ad329cbcb28471bb30f05c9827f724c76)
- **treefmt-nix**: [`71b125c` → `790751f`](https://github.com/numtide/treefmt-nix/compare/71b125cd05fbfd78cab3e070b73544abe24c5016...790751ff7fd3801feeaf96d7dc416a8d581265ba)


<details>
<summary>nix flake update output</summary>

```
unpacking 'github:ipetkov/crane/5e0fb2f64edff2822249f21293b8304dedaaf676' into the Git cache...
unpacking 'github:nix-community/fenix/298b12d701ef0d12c0f2e4858d4208bee24d14e5' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/3107b77cd68437b9a76194f0f7f9c55f2329ca5b' into the Git cache...
unpacking 'github:nixos/nixpkgs/1c3fe55ad329cbcb28471bb30f05c9827f724c76' into the Git cache...
unpacking 'github:numtide/treefmt-nix/790751ff7fd3801feeaf96d7dc416a8d581265ba' into the Git cache...
warning: updating lock file "/home/runner/work/eidetica/eidetica/flake.lock":
• Updated input 'crane':
    'github:ipetkov/crane/3d9df76' (2026-03-24)
  → 'github:ipetkov/crane/5e0fb2f' (2026-04-28)
• Updated input 'fenix':
    'github:nix-community/fenix/0beafd2' (2026-03-31)
  → 'github:nix-community/fenix/298b12d' (2026-04-30)
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/f20dc5d' (2026-03-01)
  → 'github:hercules-ci/flake-parts/3107b77' (2026-04-01)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/8110df5' (2026-03-28)
  → 'github:nixos/nixpkgs/1c3fe55' (2026-04-27)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/71b125c' (2026-03-12)
  → 'github:numtide/treefmt-nix/790751f' (2026-04-08)
```

</details>

### Hold

This PR is on hold until **2026-05-08** (7-day waiting period).
The `on-hold` label will be automatically removed after the hold expires.

<!-- hold-until: 2026-05-08 -->