### PR TITLE
refactor(database)!: replace open/open_unauthenticated with open().with_key()

### DIFF
--- a/crates/lib/src/auth/validation/delegation.rs
+++ b/crates/lib/src/auth/validation/delegation.rs
@@ -66,11 +66,12 @@ impl DelegationResolver {
             let delegated_tree_ref = current_auth_settings.get_delegated_tree(&step.tree)?;
 
             let root_id = delegated_tree_ref.tree.root.clone();
-            let delegated_tree = Database::open_unauthenticated(root_id.clone(), instance)
-                .map_err(|e| AuthError::DelegatedTreeLoadFailed {
+            let delegated_tree = Database::open(instance, &root_id).await.map_err(|e| {
+                AuthError::DelegatedTreeLoadFailed {
                     tree_id: root_id.clone(),
                     source: Box::new(e),
-                })?;
+                }
+            })?;
 
             // Validate tips
             let current_tips = current_backend.get_tips(&root_id).await.map_err(|e| {

--- a/crates/lib/src/database/mod.rs
+++ b/crates/lib/src/database/mod.rs
@@ -261,7 +261,6 @@ impl Database {
     /// # Returns
     /// A `Result` containing the new `Database` instance or an error.
     pub(crate) fn open_unauthenticated(id: ID, instance: &Instance) -> Result<Self> {
-        // TODO: Audit all usages of this function
         Ok(Self {
             root: id,
             instance: instance.downgrade(),

--- a/crates/lib/src/database/mod.rs
+++ b/crates/lib/src/database/mod.rs
@@ -237,62 +237,18 @@ impl Database {
         })
     }
 
-    /// Opens a database for read-only access, bypassing authentication validation.
+    /// Opens an existing database by its root ID.
     ///
-    /// # Internal Use Only
-    ///
-    /// This method bypasses authentication validation and is intended for internal
-    /// operations that require reading database state (loading settings, checking
-    /// permissions, resolving delegations, etc.).
-    ///
-    /// These operations should only be performed by the server/instance administrator,
-    /// but we don't verify that yet. Future versions may add admin permission checks.
-    ///
-    /// # Behavior
-    ///
-    /// - No authentication validation is performed
-    /// - The resulting database has no key source, so commits will fail
-    /// - Used internally for system operations that need read access
-    ///
-    /// # Arguments
-    /// * `id` - The `ID` of the root entry.
-    /// * `instance` - Instance handle for storage and coordination
-    ///
-    /// # Returns
-    /// A `Result` containing the new `Database` instance or an error.
-    pub(crate) fn open_unauthenticated(id: ID, instance: &Instance) -> Result<Self> {
-        Ok(Self {
-            root: id,
-            instance: instance.downgrade(),
-            key: None,
-        })
-    }
-
-    /// Opens an existing `Database` with a `DatabaseKey`.
-    ///
-    /// This constructor opens an existing database by its root ID and configures it to use
-    /// a `DatabaseKey` for all subsequent operations. This is used in the User
-    /// context where keys are managed by UserKeyManager and already decrypted in memory.
-    ///
-    /// # Key Management
-    ///
-    /// This constructor uses **user-managed keys**:
-    /// - The key is provided directly (e.g., from UserKeyManager)
-    /// - Uses `DatabaseKey` for all subsequent operations
-    /// - No backend key storage needed
-    ///
-    /// Note: To **create** a new database with user-managed keys, use `create()`.
-    /// This method is for **opening existing** databases.
-    ///
-    /// To discover which SigKey to use for a given public key, use `Database::find_sigkeys()`.
+    /// Verifies the root entry exists in the backend, then returns a handle
+    /// for read-only access. To perform authenticated writes, chain
+    /// `.with_key(key)` after opening.
     ///
     /// # Arguments
     /// * `instance` - Instance handle for storage and coordination
-    /// * `root_id` - The root entry ID of the existing database to open
-    /// * `key` - A `DatabaseKey` combining signing key and auth identity
+    /// * `root_id` - The root entry ID of the database to open
     ///
-    /// # Returns
-    /// A `Result` containing the `Database` instance configured with the `DatabaseKey`
+    /// # Errors
+    /// Returns an error if the root entry does not exist in the backend.
     ///
     /// # Example
     /// ```rust,no_run
@@ -304,28 +260,43 @@ impl Database {
     /// # let instance = Instance::open(Box::new(InMemory::new())).await?;
     /// # let (signing_key, _verifying_key) = generate_keypair();
     /// # let root_id = ID::from_bytes(b"existing_database_root_id");
-    /// // Open database with a PrivateKey that has Direct access
-    /// let database = Database::open(instance, &root_id, signing_key).await?;
+    /// // Open database for reading
+    /// let db = Database::open(&instance, &root_id).await?;
     ///
-    /// // All transactions automatically use the provided key
-    /// let tx = database.new_transaction().await?;
+    /// // Open database with a signing key for writes
+    /// let db = Database::open(&instance, &root_id).await?.with_key(signing_key);
+    /// let tx = db.new_transaction().await?;
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn open(
-        instance: Instance,
-        root_id: &ID,
-        key: impl Into<DatabaseKey>,
-    ) -> Result<Self> {
-        let key = key.into();
-        let temp_db = Self::open_unauthenticated(root_id.clone(), &instance)?;
-        temp_db.validate_key(&key).await?;
+    pub async fn open(instance: &Instance, root_id: &ID) -> Result<Self> {
+        // Verify the root entry exists. Surfaces "database doesn't exist"
+        // at open time instead of at first read/write.
+        instance.backend().get(root_id).await?;
 
         Ok(Self {
             root: root_id.clone(),
             instance: instance.downgrade(),
-            key: Some(key),
+            key: None,
         })
+    }
+
+    /// Attach a signing key to this database handle.
+    ///
+    /// The key is stored for use by future transactions. No validation is
+    /// performed; invalid keys will cause errors at commit time or when
+    /// calling [`current_permission`](Self::current_permission).
+    ///
+    /// Calling `with_key` again replaces any previously-attached key — the
+    /// most recent call wins.
+    ///
+    /// To discover which `SigKey` identity to use for a given public key,
+    /// use [`Database::find_sigkeys`].
+    pub fn with_key(self, key: impl Into<DatabaseKey>) -> Self {
+        Self {
+            key: Some(key.into()),
+            ..self
+        }
     }
 
     /// Validate a `DatabaseKey` against this database's auth settings.
@@ -334,10 +305,9 @@ impl Database {
     /// 1. The signing key derives to the public key claimed by the identity
     /// 2. The identity exists in the database's auth settings
     ///
-    /// Returns the effective permission for the validated key.
-    ///
-    /// Used by `Database::open` (on an unauthenticated temp db) to fail fast
-    /// on invalid keys, and by `current_permission` to look up permissions.
+    /// Returns the effective permission for the validated key. Callers wanting
+    /// to fail fast on an invalid key should call
+    /// [`current_permission`](Self::current_permission), which wraps this.
     async fn validate_key(&self, key: &DatabaseKey) -> Result<Permission> {
         let settings_store = self.get_settings().await?;
         let auth_settings = settings_store.auth_snapshot().await?;
@@ -480,7 +450,7 @@ impl Database {
     /// // Use the first available SigKey (highest permission)
     /// if let Some((sigkey, _permission)) = sigkeys.first() {
     ///     let key = DatabaseKey::with_identity(signing_key, sigkey.clone());
-    ///     let database = Database::open(instance, &root_id, key).await?;
+    ///     let database = Database::open(&instance, &root_id).await?.with_key(key);
     /// }
     /// # Ok(())
     /// # }
@@ -493,7 +463,7 @@ impl Database {
         use crate::auth::{permission::clamp_permission, types::DelegationStep};
 
         // Create temporary database to load settings (no key source needed for reading)
-        let temp_db = Self::open_unauthenticated(root_id.clone(), instance)?;
+        let temp_db = Self::open(instance, root_id).await?;
 
         // Load auth settings
         let settings_store = temp_db.get_settings().await?;
@@ -507,11 +477,10 @@ impl Database {
         if let Ok(delegated_trees) = auth_settings.get_all_delegated_trees() {
             for (delegated_root_id, delegated_tree_ref) in &delegated_trees {
                 // Load the delegated tree's auth settings
-                let delegated_db =
-                    match Self::open_unauthenticated(delegated_root_id.clone(), instance) {
-                        Ok(db) => db,
-                        Err(_) => continue,
-                    };
+                let delegated_db = match Self::open(instance, delegated_root_id).await {
+                    Ok(db) => db,
+                    Err(_) => continue,
+                };
                 let delegated_settings = match delegated_db.get_settings().await {
                     Ok(s) => s,
                     Err(_) => continue,
@@ -1006,7 +975,7 @@ impl Database {
     ///
     /// Returns the effective permission for the key that was configured when opening
     /// or creating this database. This uses the already-resolved identity stored in
-    /// the database's `DatabaseKey`, ensuring consistency with `Database::open`.
+    /// the database's `DatabaseKey`.
     ///
     /// # Returns
     /// The effective Permission for the configured signing key.

--- a/crates/lib/src/instance/mod.rs
+++ b/crates/lib/src/instance/mod.rs
@@ -605,12 +605,9 @@ impl Instance {
     ///
     /// This constructs a Database instance on-the-fly to avoid circular references.
     pub(crate) async fn users_db(&self) -> Result<Database> {
-        Database::open(
-            self.clone(),
-            &self.inner.metadata.users_db,
-            self.signing_key()?.clone(),
-        )
-        .await
+        Ok(Database::open(self, &self.inner.metadata.users_db)
+            .await?
+            .with_key(self.signing_key()?.clone()))
     }
 
     // === User Management ===
@@ -681,7 +678,7 @@ impl Instance {
     /// These operations should only be performed by the server/instance administrator,
     /// but we don't verify that yet. Future versions may add admin permission checks.
     ///
-    /// Similar to `Database::open_unauthenticated`, this is a controlled escape hatch
+    /// Similar to `Database::open` (without a key), this is a controlled escape hatch
     /// for internal library operations. Use with care - prefer User API for normal operations.
     ///
     /// Returns an error if this is a remote Instance that does not have access to the
@@ -1039,7 +1036,7 @@ impl Instance {
         }
 
         // Create a Database handle for the callbacks
-        let database = match Database::open_unauthenticated(tree_id.clone(), self) {
+        let database = match Database::open(self, tree_id).await {
             Ok(db) => db,
             Err(e) => {
                 tracing::error!(tree_id = %tree_id, "Failed to open database for callbacks: {}", e);

--- a/crates/lib/src/sync/background/mod.rs
+++ b/crates/lib/src/sync/background/mod.rs
@@ -209,7 +209,9 @@ impl BackgroundSync {
         // Load sync tree with the device key
         let instance = self.instance()?;
         let signing_key = instance.signing_key()?.clone();
-        Database::open(instance, &self.sync_tree_id, signing_key).await
+        Ok(Database::open(&instance, &self.sync_tree_id)
+            .await?
+            .with_key(signing_key))
     }
 
     /// Get the minimum sync interval from all tracked databases

--- a/crates/lib/src/sync/bootstrap.rs
+++ b/crates/lib/src/sync/bootstrap.rs
@@ -261,7 +261,9 @@ impl Sync {
         }
 
         // Load the existing database with the user's signing key
-        let database = Database::open(self.instance()?, &request.tree_id, key.clone()).await?;
+        let database = Database::open(&self.instance()?, &request.tree_id)
+            .await?
+            .with_key(key.clone());
 
         // Explicitly check that the approving user has Admin permission
         // This provides clear error messages and fails fast before modifying the database
@@ -368,7 +370,9 @@ impl Sync {
         }
 
         // Load the existing database with the user's signing key to validate permissions
-        let database = Database::open(self.instance()?, &request.tree_id, key.clone()).await?;
+        let database = Database::open(&self.instance()?, &request.tree_id)
+            .await?
+            .with_key(key.clone());
 
         // Check that the rejecting user has Admin permission
         let permission = database.current_permission().await?;

--- a/crates/lib/src/sync/handler.rs
+++ b/crates/lib/src/sync/handler.rs
@@ -87,7 +87,9 @@ impl SyncHandlerImpl {
         // Load sync tree with the device key
         let instance = self.instance()?;
         let signing_key = instance.signing_key()?.clone();
-        Database::open(instance, &self.sync_tree_id, signing_key).await
+        Ok(Database::open(&instance, &self.sync_tree_id)
+            .await?
+            .with_key(signing_key))
     }
 
     /// Store a bootstrap request in the sync database for manual approval.
@@ -232,7 +234,7 @@ impl SyncHandlerImpl {
         tree_id: &ID,
         requesting_pubkey: &PublicKey,
     ) -> Result<Option<Permission>> {
-        let database = Database::open_unauthenticated(tree_id.clone(), &self.instance()?)?;
+        let database = Database::open(&self.instance()?, tree_id).await?;
         let transaction = database.new_transaction().await?;
         let settings_store = SettingsStore::new(&transaction)?;
         let auth_settings = settings_store.auth_snapshot().await?;
@@ -266,8 +268,7 @@ impl SyncHandlerImpl {
         requesting_pubkey: &PublicKey,
         requested_permission: &Permission,
     ) -> Result<bool> {
-        // Use open_unauthenticated since we only need to read auth settings
-        let database = Database::open_unauthenticated(tree_id.clone(), &self.instance()?)?;
+        let database = Database::open(&self.instance()?, tree_id).await?;
         let settings_store = database.get_settings().await?;
 
         let auth_settings = settings_store.auth_snapshot().await?;
@@ -301,7 +302,7 @@ impl SyncHandlerImpl {
     /// - `Ok(false)` if database allows unauthenticated access (no auth or has global permission)
     /// - `Err` if the check fails
     async fn check_if_database_has_auth(&self, tree_id: &ID) -> Result<bool> {
-        let database = Database::open_unauthenticated(tree_id.clone(), &self.instance()?)?;
+        let database = Database::open(&self.instance()?, tree_id).await?;
         let transaction = database.new_transaction().await?;
         let settings_store = SettingsStore::new(&transaction)?;
 
@@ -365,11 +366,10 @@ impl SyncHandlerImpl {
             Err(_) => return false, // Fail closed
         };
 
-        let sync_database =
-            match Database::open(instance.clone(), &self.sync_tree_id, signing_key).await {
-                Ok(db) => db,
-                Err(_) => return false, // Fail closed
-            };
+        let sync_database = match Database::open(&instance, &self.sync_tree_id).await {
+            Ok(db) => db.with_key(signing_key),
+            Err(_) => return false, // Fail closed
+        };
 
         let transaction = match sync_database.new_transaction().await {
             Ok(tx) => tx,

--- a/crates/lib/src/sync/mod.rs
+++ b/crates/lib/src/sync/mod.rs
@@ -91,8 +91,6 @@ use std::sync::{Arc, OnceLock};
 use std::time::SystemTime;
 use tokio::sync::mpsc;
 
-use handle_trait::Handle;
-
 use crate::{
     Database, Instance, Result, WeakInstance,
     auth::{Permission, crypto::PublicKey},
@@ -324,7 +322,9 @@ impl Sync {
     pub async fn load(instance: Instance, sync_tree_root_id: &ID) -> Result<Self> {
         let device_key = instance.signing_key()?.clone();
 
-        let sync_tree = Database::open(instance.handle(), sync_tree_root_id, device_key).await?;
+        let sync_tree = Database::open(&instance, sync_tree_root_id)
+            .await?
+            .with_key(device_key);
 
         let sync = Self {
             background_tx: OnceLock::new(),

--- a/crates/lib/src/sync/ticket.rs
+++ b/crates/lib/src/sync/ticket.rs
@@ -57,9 +57,10 @@ const PR_PARAM: &str = "pr";
 /// eidetica:?db=sha256:abc...&pr=http:192.168.1.1:8080&pr=iroh:endpointABC...
 /// ```
 ///
-/// The database ID is passed through as an opaque string. Peer addresses
-/// use the transport's native encoding, prefixed by the transport name and
-/// a colon if the encoding doesn't already include it.
+/// The database ID is passed through as an opaque string. If `db` appears
+/// more than once, the last value wins. Peer addresses use the transport's
+/// native encoding, prefixed by the transport name and a colon if the
+/// encoding doesn't already include it.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(into = "String", try_from = "String")]
 pub struct DatabaseTicket {
@@ -183,8 +184,7 @@ impl FromStr for DatabaseTicket {
         for (key, value) in url::form_urlencoded::parse(query.as_bytes()) {
             match key.as_ref() {
                 DB_PARAM => {
-                    // TODO: if `db` appears more than once, the last value
-                    // silently wins.
+                    // If `db` appears more than once, the last value wins.
                     database_id = Some(ID::parse(&value)?);
                 }
                 PR_PARAM => {

--- a/crates/lib/src/sync/user.rs
+++ b/crates/lib/src/sync/user.rs
@@ -64,7 +64,7 @@ impl Sync {
 
         // Open user's preferences database (read-only)
         let instance = self.instance.upgrade().ok_or(SyncError::InstanceDropped)?;
-        let prefs_db = Database::open_unauthenticated(preferences_db_id.clone(), &instance)?;
+        let prefs_db = Database::open(&instance, preferences_db_id).await?;
         let current_tips = prefs_db.get_tips().await?;
 
         // Check if preferences have changed via tip comparison
@@ -132,7 +132,7 @@ impl Sync {
             for uuid in &users {
                 // Read preferences from each user's database
                 if let Some((user_prefs_db_id, _)) = user_mgr.get_tracked_user_state(uuid).await? {
-                    let user_db = Database::open_unauthenticated(user_prefs_db_id, &instance)?;
+                    let user_db = Database::open(&instance, &user_prefs_db_id).await?;
                     let user_table = user_db
                         .get_store_viewer::<Table<TrackedDatabase>>("databases")
                         .await?;

--- a/crates/lib/src/transaction/mod.rs
+++ b/crates/lib/src/transaction/mod.rs
@@ -377,13 +377,12 @@ impl Transaction {
 
     /// Set the tree root field for the entry being built.
     ///
-    /// This is primarily used during tree creation to ensure the root entry
-    /// has an empty tree.root field, making it a proper top-level root.
+    /// Called by `Database::create()` to override the placeholder root with
+    /// `ID::default()`, making the entry a proper top-level root.
     ///
     /// # Arguments
     /// * `root` - The tree root ID to set (use `ID::default()` for top-level roots)
     pub(crate) fn set_entry_root(&self, root: ID) -> Result<()> {
-        // FIXME: This is only called by Database::create()
         let mut builder_ref = self.entry_builder.lock().unwrap();
         let builder = builder_ref
             .as_mut()

--- a/crates/lib/src/transaction/mod.rs
+++ b/crates/lib/src/transaction/mod.rs
@@ -223,8 +223,8 @@ impl Transaction {
 
     /// Set signing key directly for user context (internal API).
     ///
-    /// This method is used when a Database is created with a user-provided key
-    /// (via `Database::open()`). The provided SigningKey is already
+    /// This method is used when a Database has a key attached
+    /// (via `Database::open().with_key()`). The provided SigningKey is already
     /// decrypted and ready to use, eliminating the need for backend key lookup.
     ///
     /// # Arguments

--- a/crates/lib/src/user/session/mod.rs
+++ b/crates/lib/src/user/session/mod.rs
@@ -36,7 +36,6 @@
 //! This explicit approach ensures predictable behavior and avoids ambiguity about which
 //! keys have access to which databases.
 
-use handle_trait::Handle;
 use std::collections::HashMap;
 
 use super::{UserKeyManager, types::UserInfo};
@@ -317,9 +316,6 @@ impl User {
         root_id: &ID,
         key_id: &PublicKey,
     ) -> Result<Database> {
-        // Validate the root exists
-        self.instance.backend().get(root_id).await?;
-
         // Get the SigningKey from UserKeyManager
         let signing_key = self.key_manager.get_signing_key(key_id).ok_or_else(|| {
             super::errors::UserError::KeyNotFound {
@@ -337,7 +333,7 @@ impl User {
 
         // Create Database with user-provided key using resolved SigKey identity
         let key = DatabaseKey::with_identity(signing_key.clone(), sigkey);
-        Database::open(self.instance.handle(), root_id, key).await
+        Ok(Database::open(&self.instance, root_id).await?.with_key(key))
     }
 
     /// Find databases by name among the user's tracked databases.

--- a/crates/lib/src/user/session/tests.rs
+++ b/crates/lib/src/user/session/tests.rs
@@ -1,5 +1,7 @@
 //! Tests for the user_session module.
 
+use handle_trait::Handle;
+
 use super::*;
 use crate::{
     Clock, SystemClock,

--- a/crates/lib/src/user/system_databases.rs
+++ b/crates/lib/src/user/system_databases.rs
@@ -323,8 +323,7 @@ pub async fn login_user(
     }
 
     // 3. Temporarily open user's private database to read keys (unauthenticated read)
-    let temp_user_database =
-        Database::open_unauthenticated(user_info.user_database_id.clone(), instance)?;
+    let temp_user_database = Database::open(instance, &user_info.user_database_id).await?;
 
     // 4. Load keys from user database
     let keys_table = temp_user_database
@@ -366,12 +365,9 @@ pub async fn login_user(
         })?
         .clone();
 
-    let user_database = Database::open(
-        instance.handle(),
-        &user_info.user_database_id,
-        default_signing_key,
-    )
-    .await?;
+    let user_database = Database::open(instance, &user_info.user_database_id)
+        .await?
+        .with_key(default_signing_key);
 
     // 7. Update last_login in separate table
     // TODO: this is a log, so it will grow unbounded over time and should probably be moved to a log table

--- a/crates/lib/tests/it/auth/crypto.rs
+++ b/crates/lib/tests/it/auth/crypto.rs
@@ -201,9 +201,10 @@ async fn test_multi_key_authentication() {
         .get_signing_key(&key_id2)
         .expect("Failed to get signing key")
         .clone();
-    let tree_with_key2 = Database::open(instance.clone(), tree.root_id(), signing_key2_for_load)
+    let tree_with_key2 = Database::open(&instance, tree.root_id())
         .await
-        .expect("Failed to load database with key2");
+        .expect("Failed to load database with key2")
+        .with_key(signing_key2_for_load);
 
     let txn2 = tree_with_key2
         .new_transaction()

--- a/crates/lib/tests/it/auth/delegated_trees.rs
+++ b/crates/lib/tests/it/auth/delegated_trees.rs
@@ -797,8 +797,9 @@ async fn setup_delegation_pair(
 
     let delegation_ref = create_delegation_ref(&identity_db, max_permission, None).await?;
     let admin_db_key = DatabaseKey::new(admin_signing_key.clone());
-    let target_db_authed =
-        Database::open(instance.clone(), target_db.root_id(), admin_db_key).await?;
+    let target_db_authed = Database::open(instance, target_db.root_id())
+        .await?
+        .with_key(admin_db_key);
     let txn = target_db_authed.new_transaction().await?;
     txn.get_settings()?
         .add_delegated_tree(delegation_ref)
@@ -829,7 +830,9 @@ async fn open_via_delegation(
         hint: KeyHint::from_pubkey(hint_key_id),
     };
     let db_key = DatabaseKey::with_identity(signing_key, delegation_sigkey);
-    Database::open(instance.clone(), pair.target_db.root_id(), db_key).await
+    Ok(Database::open(instance, pair.target_db.root_id())
+        .await?
+        .with_key(db_key))
 }
 
 /// Test writing entries via delegation identity using the Database API directly
@@ -989,8 +992,9 @@ async fn test_delegated_entry_validation_across_instances() -> Result<()> {
 
     // Open target_db on instance B with the admin key to read settings
     let admin_db_key = DatabaseKey::new(pair.admin_signing_key);
-    let target_db_b =
-        Database::open(instance_b.clone(), pair.target_db.root_id(), admin_db_key).await?;
+    let target_db_b = Database::open(&instance_b, pair.target_db.root_id())
+        .await?
+        .with_key(admin_db_key);
 
     let settings_b = target_db_b.get_settings().await?;
     let auth_settings_b = settings_b.auth_snapshot().await?;
@@ -1045,8 +1049,9 @@ async fn test_delegated_write_secondary_identity_key() -> Result<()> {
 
     let delegation_ref = create_delegation_ref(&identity_db, Permission::Write(10), None).await?;
     let admin_db_key = DatabaseKey::new(admin_signing_key);
-    let target_db_authed =
-        Database::open(instance.clone(), target_db.root_id(), admin_db_key).await?;
+    let target_db_authed = Database::open(&instance, target_db.root_id())
+        .await?
+        .with_key(admin_db_key);
     let txn = target_db_authed.new_transaction().await?;
     txn.get_settings()?
         .add_delegated_tree(delegation_ref)
@@ -1066,8 +1071,9 @@ async fn test_delegated_write_secondary_identity_key() -> Result<()> {
     let secondary_signing_key = user.get_signing_key(&secondary_key_id)?;
     let delegation_db_key =
         DatabaseKey::with_identity(secondary_signing_key, delegation_sigkey.clone());
-    let target_via_delegation =
-        Database::open(instance.clone(), target_db.root_id(), delegation_db_key).await?;
+    let target_via_delegation = Database::open(&instance, target_db.root_id())
+        .await?
+        .with_key(delegation_db_key);
 
     // Verify the database is using the secondary key's delegation identity
     assert_eq!(

--- a/crates/lib/tests/it/auth/integration.rs
+++ b/crates/lib/tests/it/auth/integration.rs
@@ -116,9 +116,10 @@ async fn test_validation_pipeline_with_concurrent_settings_changes() {
         .expect("Failed to get KEY2 signing key")
         .clone();
 
-    let tree_with_key2 = Database::open(instance.clone(), tree.root_id(), key2_signing_key)
+    let tree_with_key2 = Database::open(&instance, tree.root_id())
         .await
-        .expect("Failed to reload database with KEY2");
+        .expect("Failed to reload database with KEY2")
+        .with_key(key2_signing_key);
 
     // Create operation with KEY2 (should work after settings change)
     let txn2 = tree_with_key2

--- a/crates/lib/tests/it/auth/validation.rs
+++ b/crates/lib/tests/it/auth/validation.rs
@@ -36,13 +36,10 @@ async fn test_authentication_validation_revoked_key() {
         .expect("Failed to get revoked key")
         .clone();
 
-    let tree_with_revoked_key = Database::open(
-        instance.clone(),
-        tree.root_id(),
-        DatabaseKey::with_name(revoked_signing_key, "REVOKED_KEY"),
-    )
-    .await
-    .expect("Failed to load tree with revoked key");
+    let tree_with_revoked_key = Database::open(&instance, tree.root_id())
+        .await
+        .expect("Failed to load tree with revoked key")
+        .with_key(DatabaseKey::with_name(revoked_signing_key, "REVOKED_KEY"));
 
     let txn = tree_with_revoked_key
         .new_transaction()
@@ -81,13 +78,10 @@ async fn test_permission_checking_admin_operations() {
         .expect("Failed to get write key")
         .clone();
 
-    let tree_with_write_key = Database::open(
-        instance.clone(),
-        tree.root_id(),
-        DatabaseKey::with_name(write_signing_key, "WRITE_KEY"),
-    )
-    .await
-    .expect("Failed to load tree with write key");
+    let tree_with_write_key = Database::open(&instance, tree.root_id())
+        .await
+        .expect("Failed to load tree with write key")
+        .with_key(DatabaseKey::with_name(write_signing_key, "WRITE_KEY"));
 
     test_operation_succeeds(
         &tree_with_write_key,
@@ -102,13 +96,13 @@ async fn test_permission_checking_admin_operations() {
         .expect("Failed to get secondary admin key")
         .clone();
 
-    let tree_with_secondary_admin_key = Database::open(
-        instance.clone(),
-        tree.root_id(),
-        DatabaseKey::with_name(secondary_admin_signing_key, "SECONDARY_ADMIN_KEY"),
-    )
-    .await
-    .expect("Failed to load tree with secondary admin key");
+    let tree_with_secondary_admin_key = Database::open(&instance, tree.root_id())
+        .await
+        .expect("Failed to load tree with secondary admin key")
+        .with_key(DatabaseKey::with_name(
+            secondary_admin_signing_key,
+            "SECONDARY_ADMIN_KEY",
+        ));
 
     test_operation_succeeds(
         &tree_with_secondary_admin_key,
@@ -266,13 +260,10 @@ async fn test_entry_validation_with_mixed_key_states() {
         .expect("Failed to get active key")
         .clone();
 
-    let tree_with_active_key = Database::open(
-        instance.clone(),
-        tree.root_id(),
-        DatabaseKey::with_name(active_signing_key, "ACTIVE_KEY"),
-    )
-    .await
-    .expect("Failed to load tree with active key");
+    let tree_with_active_key = Database::open(&instance, tree.root_id())
+        .await
+        .expect("Failed to load tree with active key")
+        .with_key(DatabaseKey::with_name(active_signing_key, "ACTIVE_KEY"));
 
     assert_operation_permissions(
         &tree_with_active_key,
@@ -288,13 +279,10 @@ async fn test_entry_validation_with_mixed_key_states() {
         .expect("Failed to get revoked key")
         .clone();
 
-    let tree_with_revoked_key = Database::open(
-        instance.clone(),
-        tree.root_id(),
-        DatabaseKey::with_name(revoked_signing_key, "REVOKED_KEY"),
-    )
-    .await
-    .expect("Failed to load tree with revoked key");
+    let tree_with_revoked_key = Database::open(&instance, tree.root_id())
+        .await
+        .expect("Failed to load tree with revoked key")
+        .with_key(DatabaseKey::with_name(revoked_signing_key, "REVOKED_KEY"));
 
     assert_operation_permissions(
         &tree_with_revoked_key,

--- a/crates/lib/tests/it/database/api_methods.rs
+++ b/crates/lib/tests/it/database/api_methods.rs
@@ -337,18 +337,21 @@ async fn test_verify_entry_signature_unauthorized_key() {
 
     assert_entry_authentication(&tree, &authorized_entry_id, &authorized_key_id.to_string()).await;
 
-    // Test with unauthorized key (should fail at open because key is not in tree's auth settings)
+    // Test with unauthorized key (open succeeds but permission check should fail)
     let unauthorized_signing_key = user
         .get_signing_key(&unauthorized_key_id)
         .expect("Failed to get unauthorized signing key");
 
-    // Database::open should fail because the unauthorized key is not in the tree's auth settings
-    // and no global permission exists
-    let open_result =
-        Database::open(instance.clone(), tree.root_id(), unauthorized_signing_key).await;
+    // Database::open succeeds (no key validation at open time)
+    // but current_permission should fail because the key is not in the tree's auth settings
+    let unauthorized_db = Database::open(&instance, tree.root_id())
+        .await
+        .expect("open should succeed without key validation")
+        .with_key(unauthorized_signing_key);
 
-    assert!(open_result.is_err());
-    let error_msg = open_result.unwrap_err().to_string();
+    let perm_result = unauthorized_db.current_permission().await;
+    assert!(perm_result.is_err());
+    let error_msg = perm_result.unwrap_err().to_string();
     assert!(
         error_msg.contains("not found") || error_msg.contains("no global permission"),
         "Expected error about key not found, got: {error_msg}"

--- a/crates/lib/tests/it/store/index_store.rs
+++ b/crates/lib/tests/it/store/index_store.rs
@@ -572,9 +572,10 @@ async fn test_index_survives_database_reload() {
 
     // Reload database from same instance to test persistence
     // Reopen with the same key that was used to create
-    let database = Database::open(instance.clone(), &root_id, private_key)
+    let database = Database::open(&instance, &root_id)
         .await
-        .unwrap();
+        .unwrap()
+        .with_key(private_key);
 
     // Verify index is intact using viewer (read-only)
     let viewer = database

--- a/crates/lib/tests/it/sync/bootstrap_with_key_tests.rs
+++ b/crates/lib/tests/it/sync/bootstrap_with_key_tests.rs
@@ -452,13 +452,10 @@ async fn test_full_e2e_bootstrap_with_database_instances() {
     // Verify client successfully bootstrapped and can load the database
     // Use global permission (server has global permission configured)
     let (reader_key, _) = generate_keypair();
-    let client_database = Database::open(
-        client_instance.clone(),
-        &tree_id,
-        DatabaseKey::global(reader_key),
-    )
-    .await
-    .expect("Client should be able to load the database after bootstrap");
+    let client_database = Database::open(&client_instance, &tree_id)
+        .await
+        .expect("Client should be able to load the database after bootstrap")
+        .with_key(DatabaseKey::global(reader_key));
 
     println!("✅ Client: Successfully loaded database after bootstrap");
 

--- a/crates/lib/tests/it/sync/chat_simulation_test.rs
+++ b/crates/lib/tests/it/sync/chat_simulation_test.rs
@@ -158,13 +158,13 @@ async fn test_chat_app_authenticated_bootstrap() {
         .expect("Should have signing key")
         .clone();
 
-    let client_database = Database::open(
-        client_instance.clone(),
-        &tree_id,
-        DatabaseKey::with_identity(client_signing_key, sigkey.clone()),
-    )
-    .await
-    .expect("Client should load database");
+    let client_database = Database::open(&client_instance, &tree_id)
+        .await
+        .expect("Client should load database")
+        .with_key(DatabaseKey::with_identity(
+            client_signing_key,
+            sigkey.clone(),
+        ));
 
     // Verify client can read the initial message
     {
@@ -273,13 +273,13 @@ async fn test_global_key_bootstrap() {
         .expect("Should have signing key")
         .clone();
 
-    let client_database = Database::open(
-        client_instance.clone(),
-        &tree_id,
-        DatabaseKey::with_identity(client_signing_key, sigkey.clone()),
-    )
-    .await
-    .expect("Client should load database");
+    let client_database = Database::open(&client_instance, &tree_id)
+        .await
+        .expect("Client should load database")
+        .with_key(DatabaseKey::with_identity(
+            client_signing_key,
+            sigkey.clone(),
+        ));
 
     // Client writes using global permission
     {
@@ -395,13 +395,10 @@ async fn test_multiple_databases_sync() {
 
         // Open and verify room name
         let (reader_key, _) = generate_keypair();
-        let database = Database::open(
-            client_instance.clone(),
-            room_id,
-            DatabaseKey::global(reader_key),
-        )
-        .await
-        .unwrap_or_else(|e| panic!("Failed to load room {}: {e}", i + 1));
+        let database = Database::open(&client_instance, room_id)
+            .await
+            .unwrap_or_else(|e| panic!("Failed to load room {}: {e}", i + 1))
+            .with_key(DatabaseKey::global(reader_key));
 
         let settings = database.get_settings().await.unwrap();
         let name = settings.get_string("name").await.unwrap();

--- a/crates/lib/tests/it/sync/dag_sync_tests.rs
+++ b/crates/lib/tests/it/sync/dag_sync_tests.rs
@@ -674,13 +674,10 @@ async fn test_sync_protocol_implementation() {
     // Reload the tree to get the latest state
     // Use global permission (public database with Permission::Read)
     let (reader_key, _) = generate_keypair();
-    let tree2 = Database::open(
-        base_db2.clone(),
-        &tree_root_id,
-        DatabaseKey::global(reader_key),
-    )
-    .await
-    .unwrap();
+    let tree2 = Database::open(&base_db2, &tree_root_id)
+        .await
+        .unwrap()
+        .with_key(DatabaseKey::global(reader_key));
 
     // Verify ALL synced data is correct
     {

--- a/crates/lib/tests/it/sync/helpers.rs
+++ b/crates/lib/tests/it/sync/helpers.rs
@@ -754,8 +754,9 @@ pub async fn enable_sync_for_instance_database(sync: &Sync, database_id: &ID) ->
     let instance = sync.instance()?;
     let signing_key = instance.signing_key()?.clone();
 
-    let sync_database =
-        Database::open(instance.clone(), sync.sync_tree_root_id(), signing_key).await?;
+    let sync_database = Database::open(&instance, sync.sync_tree_root_id())
+        .await?
+        .with_key(signing_key);
 
     let tx = sync_database.new_transaction().await?;
     let database_users = tx.get_store::<DocStore>("database_users").await?;

--- a/crates/lib/tests/it/sync/manual_approval_test.rs
+++ b/crates/lib/tests/it/sync/manual_approval_test.rs
@@ -1032,13 +1032,13 @@ async fn test_global_permission_enables_transactions() {
     let (sigkey, _permission) = &sigkeys[0];
     assert!(sigkey.is_global(), "Should resolve to global permission");
 
-    let client_db = Database::open(
-        client_instance.clone(),
-        &tree_id,
-        DatabaseKey::with_identity(client_signing_key, sigkey.clone()),
-    )
-    .await
-    .expect("Client should be able to load database");
+    let client_db = Database::open(&client_instance, &tree_id)
+        .await
+        .expect("Client should be able to load database")
+        .with_key(DatabaseKey::with_identity(
+            client_signing_key,
+            sigkey.clone(),
+        ));
 
     // Create a transaction and commit data
     let transaction = client_db.new_transaction().await.unwrap();

--- a/crates/lib/tests/it/sync/multi_transport_tests.rs
+++ b/crates/lib/tests/it/sync/multi_transport_tests.rs
@@ -198,12 +198,11 @@ async fn test_http_and_iroh_sync_interoperability() -> Result<()> {
     // HTTP client opens the database using the global permission
     // The global permission allows any key to write, so we use the client's device key
     // with a global SigKey
-    let http_client_db = Database::open(
-        http_client_instance.clone(),
-        &tree_id,
-        DatabaseKey::global(http_client_instance.signing_key()?.clone()),
-    )
-    .await?;
+    let http_client_db = Database::open(&http_client_instance, &tree_id)
+        .await?
+        .with_key(DatabaseKey::global(
+            http_client_instance.signing_key()?.clone(),
+        ));
 
     let entry_id = {
         let tx = http_client_db.new_transaction().await?;

--- a/crates/lib/tests/it/sync/sync_enabled_security_tests.rs
+++ b/crates/lib/tests/it/sync/sync_enabled_security_tests.rs
@@ -187,13 +187,10 @@ async fn test_incremental_sync_rejected_when_sync_disabled() {
     // Load the database on client to get tips for incremental sync
     // Use global permission (configured above with Permission::Read)
     let (reader_key, _) = generate_keypair();
-    let client_db = Database::open(
-        client_instance.clone(),
-        &tree_id,
-        DatabaseKey::global(reader_key),
-    )
-    .await
-    .unwrap();
+    let client_db = Database::open(&client_instance, &tree_id)
+        .await
+        .unwrap()
+        .with_key(DatabaseKey::global(reader_key));
     let client_tips = client_instance
         .backend()
         .get_tips(client_db.root_id())
@@ -333,13 +330,10 @@ async fn test_sync_succeeds_when_enabled() {
     // Verify data was synced
     // Use global permission (configured with Permission::Read)
     let (reader_key, _) = generate_keypair();
-    let client_db = Database::open(
-        client_instance.clone(),
-        &tree_id,
-        DatabaseKey::global(reader_key),
-    )
-    .await
-    .unwrap();
+    let client_db = Database::open(&client_instance, &tree_id)
+        .await
+        .unwrap()
+        .with_key(DatabaseKey::global(reader_key));
     let doc_store = client_db
         .get_store_viewer::<DocStore>("data")
         .await

--- a/docs/src/design/users.md
+++ b/docs/src/design/users.md
@@ -697,7 +697,7 @@ The user accesses databases through the `User.open_database()` method, which han
    - Selects key with highest permission level
 3. System retrieves decrypted SigningKey from UserKeyManager
 4. System gets SigKey mapping via `key_mapping()`
-5. System loads Database with `Database::open()`
+5. System loads Database with `Database::open().with_key()`
    - Database stores `DatabaseKey` with signing key and auth identity
 6. User creates transactions normally: `database.new_transaction()`
    - Transaction automatically receives provided key from Database


### PR DESCRIPTION
## Summary

Replace `Database::open(instance, &id, key).await?` and the pub(crate) `Database::open_unauthenticated(id, &instance)?` with a single builder:

```rust
let db = Database::open(&instance, &root_id).await?;            // read-only
let db = Database::open(&instance, &root_id).await?.with_key(k); // writes
```

- `Database::open(&Instance, &ID)` is async, verifies the root entry exists in the backend, and returns a read-only handle.
- `.with_key(impl Into<DatabaseKey>)` is sync, no validation. The most recent call wins if chained.
- Key correctness is checked lazily — at commit time, or eagerly via `current_permission()`.
- The pub(crate) `open_unauthenticated` escape hatch is gone; the 24 internal callers (sync handler, delegation walker, `find_sigkeys`, etc.) all use the same `open` everyone else does.

## Why

- **One open path.** No more two-tier (`open` for writes, `open_unauthenticated` for internal reads). Same constructor for every caller.
- **Read-only is the default rung.** Attach a key when you need writes. Matches the natural "browse first, sign later" flow.
- **Existence proven at open time.** "Database doesn't exist" errors surface at `open()`, not at the first read or commit.
- **Lazy key validation.** Most internal callers only need read access — eager key validation was either skipped (`open_unauthenticated`) or wasted on read-only paths.

## Breaking change

`Database::open` signature changed:

```rust
// Before
async fn open(instance: Instance, root_id: &ID, key: impl Into<DatabaseKey>) -> Result<Database>;

// After
async fn open(instance: &Instance, root_id: &ID) -> Result<Database>;
```

`Database::open_unauthenticated` is removed (was `pub(crate)`).

Migration is mechanical:

```rust
// Before
Database::open(instance.clone(), &root_id, key).await?

// After
Database::open(&instance, &root_id).await?.with_key(key)
```

For internal sites that previously used `open_unauthenticated`:

```rust
// Before
Database::open_unauthenticated(root_id.clone(), &instance)?

// After
Database::open(&instance, &root_id).await?
```

Key validation timing changes: previously `open` would fail fast on invalid keys (mismatched pubkey, missing identity). Now those errors surface at the first commit, or eagerly when you call `current_permission()`. Existence checking is unchanged in spirit — `open()` still verifies the root entry exists.

The User API (`User::open_database`, `User::open_database_with_key`) is unaffected — they wrap the new builder internally and keep the same signature.

## Included cleanups

This branch also bundles two small, unrelated quality-of-life commits that rode along in the original stack:

- **`docs(sync): document duplicate db param behavior in DatabaseTicket`** — documents that if `db=` appears more than once in a ticket URL, the last value wins. Replaces a stale TODO with the actual behavior.
- **`chore: remove resolved TODOs from transaction and database`** — drops a stale `FIXME` on `Transaction::set_entry_root` (replaced with an accurate docstring describing the single caller) and a `TODO: Audit all usages of this function` on `open_unauthenticated` (which this refactor now deletes entirely).

These are independent of the API change and could ship in any order; they're here to avoid a separate trivial PR.
