### PR TITLE
feat(instance)!: URL-based connect API and memory snapshot persistence

### DIFF
--- a/crates/bin/src/commands/daemon.rs
+++ b/crates/bin/src/commands/daemon.rs
@@ -24,7 +24,7 @@ use crate::cli::{BackendConfig, DaemonArgs, DaemonInitArgs};
 /// Run the Eidetica daemon against an already-initialised backend.
 ///
 /// Errors with a pointer to `eidetica daemon init` if the backend hasn't been
-/// initialised yet (i.e. `Instance::open` returns
+/// initialised yet (i.e. `Instance::open_backend` returns
 /// [`InstanceError::NotInitialized`]).
 pub async fn run(args: &DaemonArgs) -> Result<(), Box<dyn std::error::Error>> {
     // Initialize tracing
@@ -39,7 +39,7 @@ pub async fn run(args: &DaemonArgs) -> Result<(), Box<dyn std::error::Error>> {
 
     // Initialize Instance — load only. Map NotInitialized to a friendly
     // pointer at `daemon init`.
-    let instance = match Instance::open(backend).await {
+    let instance = match Instance::open_backend(backend).await {
         Ok(instance) => instance,
         Err(e) => {
             if let eidetica::Error::Instance(boxed) = &e
@@ -70,7 +70,7 @@ pub async fn run(args: &DaemonArgs) -> Result<(), Box<dyn std::error::Error>> {
     );
     println!();
     println!("Connect with:");
-    println!("  Instance::connect(\"{}\")", socket_path.display());
+    println!("  Instance::connect(\"unix://{}\")", socket_path.display());
     println!();
     println!("Press Ctrl+C to shutdown");
 
@@ -98,7 +98,7 @@ pub async fn run(args: &DaemonArgs) -> Result<(), Box<dyn std::error::Error>> {
 ///
 /// Builds the [`NewUser`] from `--username` + one of `--password` /
 /// `--passwordless` / an interactive double-prompt, then calls
-/// [`Instance::create`]. Exits after initialisation; the operator runs
+/// [`Instance::create_backend`]. Exits after initialisation; the operator runs
 /// `eidetica daemon` separately to actually serve the socket.
 pub async fn run_init(
     args: &DaemonInitArgs,
@@ -135,7 +135,7 @@ pub async fn run_init(
     };
 
     let backend = create_backend(backend_args).await?;
-    let (instance, _user) = match Instance::create(backend, new_user).await {
+    let (instance, _user) = match Instance::create_backend(backend, new_user).await {
         Ok(pair) => pair,
         Err(e) => {
             if let eidetica::Error::Instance(boxed) = &e

--- a/crates/bin/src/commands/db.rs
+++ b/crates/bin/src/commands/db.rs
@@ -12,7 +12,7 @@ pub async fn list(
     format: OutputFormat,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let backend = create_backend(&args.backend_config).await?;
-    let instance = Instance::open(backend).await?;
+    let instance = Instance::open_backend(backend).await?;
 
     let all_roots = instance
         .backend()

--- a/crates/bin/src/commands/info.rs
+++ b/crates/bin/src/commands/info.rs
@@ -10,7 +10,7 @@ use crate::output::OutputFormat;
 /// Run the info command
 pub async fn run(args: &InfoArgs, format: OutputFormat) -> Result<(), Box<dyn std::error::Error>> {
     let backend = create_backend(&args.backend_config).await?;
-    let instance = match Instance::open(backend).await {
+    let instance = match Instance::open_backend(backend).await {
         Ok(instance) => instance,
         Err(e) => {
             if let eidetica::Error::Instance(boxed) = &e

--- a/crates/bin/src/commands/serve.rs
+++ b/crates/bin/src/commands/serve.rs
@@ -84,7 +84,7 @@ pub async fn run(args: &ServeArgs) -> Result<(), Box<dyn std::error::Error>> {
     // Load the existing Instance — initialise via `eidetica daemon init`
     // first if the backend is empty. The auto-bootstrapped `admin/admin`
     // pair is gone.
-    let instance = match Instance::open(backend_box).await {
+    let instance = match Instance::open_backend(backend_box).await {
         Ok(instance) => instance,
         Err(e) => {
             if let eidetica::Error::Instance(boxed) = &e
@@ -216,7 +216,7 @@ pub async fn run(args: &ServeArgs) -> Result<(), Box<dyn std::error::Error>> {
             engine.as_ref().and_then(|e| e.as_any().downcast_ref::<InMemory>())
         {
             let json_path = data_dir.join("eidetica.json");
-            match in_memory_backend.save_to_file(&json_path).await {
+            match in_memory_backend.save_to_file(&json_path) {
                 Ok(_) => {
                     tracing::info!("Database saved to {}", json_path.display());
                     println!("\nDatabase saved successfully");

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -17,7 +17,7 @@ y-crdt = ["dep:yrs"]
 sqlite = ["dep:sqlx"]
 postgres = ["dep:sqlx"]
 # Exposes internal testing utilities
-# Includes FixedClock, Instance::open_with_clock, and other internal hooks.
+# Includes FixedClock, Instance::*_with_clock, and other internal hooks.
 testing = []
 
 [dependencies]

--- a/crates/lib/benches/benchmarks.rs
+++ b/crates/lib/benches/benchmarks.rs
@@ -247,10 +247,12 @@ fn bench_tree_operations(c: &mut Criterion) {
                 let backend = Box::new(InMemory::new());
                 // Bootstrap "bench_user" as the initial admin. They double
                 // as the benchmark's only User session.
-                let (_instance, mut user) =
-                    Instance::create(backend, eidetica::NewUser::passwordless("bench_user"))
-                        .await
-                        .expect("Benchmark setup failed");
+                let (_instance, mut user) = Instance::create_backend(
+                    backend,
+                    eidetica::NewUser::passwordless("bench_user"),
+                )
+                .await
+                .expect("Benchmark setup failed");
 
                 let key_id = user.get_default_key().expect("Failed to get default key");
                 black_box(

--- a/crates/lib/benches/helpers.rs
+++ b/crates/lib/benches/helpers.rs
@@ -76,9 +76,10 @@ async fn setup_tree_with_backend(backend: Box<dyn BackendImpl>) -> (Instance, Us
     // Bootstrap "bench_user" as the initial admin. They double as the
     // benchmark's only User session and (since they're the first user)
     // hold Admin on the system DBs by construction.
-    let (instance, mut user) = Instance::create(backend, NewUser::passwordless("bench_user"))
-        .await
-        .expect("Benchmark setup failed");
+    let (instance, mut user) =
+        Instance::create_backend(backend, NewUser::passwordless("bench_user"))
+            .await
+            .expect("Benchmark setup failed");
 
     let key_id = user.get_default_key().expect("Failed to get default key");
     let db = user

--- a/crates/lib/benches/iroh_benchmarks.rs
+++ b/crates/lib/benches/iroh_benchmarks.rs
@@ -1,6 +1,6 @@
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use eidetica::{
-    Instance,
+    Instance, NewUser,
     entry::Entry,
     sync::{Sync, peer_types::Address, transports::iroh::IrohTransport},
 };
@@ -19,17 +19,20 @@ fn create_root_entry() -> Entry {
 
 // Helper function to setup sync engines for benchmarking
 async fn setup_iroh_sync_pair() -> (Arc<Instance>, Sync, Arc<Instance>, Sync, Address) {
-    // Create databases
-    let base_db1 = Arc::new(
-        Instance::open(test_backend().await)
+    // Create databases. `test_backend` returns a fresh, uninitialised
+    // backend, so we need the bootstrap path (`create_backend`) rather
+    // than the load-only `open_backend`. The initial user is discarded —
+    // the bench only needs an Instance that can drive sync.
+    let (instance1, _user1) =
+        Instance::create_backend(test_backend().await, NewUser::passwordless("bench_peer1"))
             .await
-            .expect("Benchmark setup failed"),
-    );
-    let base_db2 = Arc::new(
-        Instance::open(test_backend().await)
+            .expect("Benchmark setup failed");
+    let (instance2, _user2) =
+        Instance::create_backend(test_backend().await, NewUser::passwordless("bench_peer2"))
             .await
-            .expect("Benchmark setup failed"),
-    );
+            .expect("Benchmark setup failed");
+    let base_db1 = Arc::new(instance1);
+    let base_db2 = Arc::new(instance2);
 
     // Create sync engines
     let sync1 = Sync::new((*base_db1).clone()).await.unwrap();

--- a/crates/lib/src/auth/validation/tests.rs
+++ b/crates/lib/src/auth/validation/tests.rs
@@ -327,9 +327,10 @@ async fn test_complete_delegation_workflow() {
 
     // Create a backend and database for testing
     let backend = Box::new(InMemory::new());
-    let (instance, _admin) = Instance::create(backend, crate::NewUser::passwordless("admin"))
-        .await
-        .expect("Failed to create test instance");
+    let (instance, _admin) =
+        Instance::create_backend(backend, crate::NewUser::passwordless("admin"))
+            .await
+            .expect("Failed to create test instance");
 
     // Generate a separate key for the delegated user role
     let (_, delegated_pubkey) = generate_keypair();
@@ -429,9 +430,10 @@ async fn test_delegated_tree_requires_tips() {
 
     // Create a backend and database for testing
     let backend = Box::new(InMemory::new());
-    let (instance, _admin) = Instance::create(backend, crate::NewUser::passwordless("admin"))
-        .await
-        .expect("Failed to create test instance");
+    let (instance, _admin) =
+        Instance::create_backend(backend, crate::NewUser::passwordless("admin"))
+            .await
+            .expect("Failed to create test instance");
 
     // Create a simple delegated tree
     let delegated_tree = Database::create(
@@ -513,9 +515,10 @@ async fn test_nested_delegation_with_permission_clamping() {
 
     // Create a backend and database for testing
     let backend = Box::new(InMemory::new());
-    let (instance, _admin) = Instance::create(backend, crate::NewUser::passwordless("admin"))
-        .await
-        .expect("Failed to create test instance");
+    let (instance, _admin) =
+        Instance::create_backend(backend, crate::NewUser::passwordless("admin"))
+            .await
+            .expect("Failed to create test instance");
 
     // Generate a separate key for the delegated user
     let (_, user_pubkey) = generate_keypair();

--- a/crates/lib/src/backend/database/in_memory/mod.rs
+++ b/crates/lib/src/backend/database/in_memory/mod.rs
@@ -109,18 +109,29 @@ impl InMemory {
 
     /// Saves the entire database state (all entries) to a specified file as JSON.
     ///
+    /// The write is atomic on POSIX (writes to `<path>.tmp` then renames
+    /// into place). On Windows the final rename is not atomic when the
+    /// destination already exists.
+    ///
+    /// This is synchronous — the body is just `std::fs::write` + `rename`
+    /// with no await points — so it's safe to call from `Drop` impls and
+    /// other non-async contexts. Callers on a tokio runtime should be
+    /// aware that the write briefly blocks the calling worker thread.
+    ///
     /// # Arguments
     /// * `path` - The path to the file where the state should be saved.
     ///
     /// # Returns
     /// A `Result` indicating success or an I/O or serialization error.
-    pub async fn save_to_file<P: AsRef<Path>>(&self, path: P) -> Result<()> {
+    pub fn save_to_file<P: AsRef<Path>>(&self, path: P) -> Result<()> {
         persistence::save_to_file(self, path)
     }
 
     /// Loads the database state from a specified JSON file.
     ///
     /// If the file does not exist, a new, empty `InMemory` database is returned.
+    /// Callers that need to tell "missing" apart from "loaded empty" should
+    /// use [`Self::try_load_from_file`].
     ///
     /// # Arguments
     /// * `path` - The path to the file from which to load the state.
@@ -129,6 +140,15 @@ impl InMemory {
     /// A `Result` containing the loaded `InMemory` database or an I/O or deserialization error.
     pub async fn load_from_file<P: AsRef<Path>>(path: P) -> Result<Self> {
         persistence::load_from_file(path)
+    }
+
+    /// Like [`Self::load_from_file`], but returns `Ok(None)` when the file
+    /// does not exist instead of falling back to an empty backend. Lets
+    /// callers distinguish "no snapshot yet" from "snapshot loaded as
+    /// empty" without a separate `path.exists()` round-trip (and the TOCTOU
+    /// window that comes with it).
+    pub async fn try_load_from_file<P: AsRef<Path>>(path: P) -> Result<Option<Self>> {
+        persistence::try_load_from_file(path)
     }
 
     /// Sort entries by their height within a tree (exposed for testing)

--- a/crates/lib/src/backend/database/in_memory/persistence.rs
+++ b/crates/lib/src/backend/database/in_memory/persistence.rs
@@ -122,6 +122,13 @@ impl<'de> Deserialize<'de> for InMemory {
 
 /// Saves the entire database state (all entries) to a specified file as JSON.
 ///
+/// **Atomicity:** the write goes to `<path>.tmp` first, then renames into
+/// place. On POSIX the final rename is atomic — a process crash mid-write
+/// leaves the previous snapshot intact and any stale `.tmp` is overwritten
+/// on the next save. On Windows the rename is not atomic when the
+/// destination already exists, so a crash during the rename can leave a
+/// stale `.tmp` and an out-of-date snapshot.
+///
 /// # Arguments
 /// * `backend` - The InMemory database to save
 /// * `path` - The path to the file where the state should be saved.
@@ -146,12 +153,54 @@ pub(crate) fn save_to_file<P: AsRef<Path>>(backend: &InMemory, path: P) -> Resul
 
     let json = serde_json::to_string_pretty(&serializable)
         .map_err(|e| -> Error { BackendError::SerializationFailed { source: e }.into() })?;
-    std::fs::write(path, json).map_err(|e| -> Error { BackendError::FileIo { source: e }.into() })
+
+    // Write to a sibling tempfile, then atomic rename. `<path>.tmp` is the
+    // standard convention; a stale tempfile from a crashed previous run is
+    // overwritten on the next save.
+    let path = path.as_ref();
+    let mut tmp = path.as_os_str().to_owned();
+    tmp.push(".tmp");
+    let tmp_path = std::path::PathBuf::from(tmp);
+
+    std::fs::write(&tmp_path, json.as_bytes())
+        .map_err(|e| -> Error { BackendError::FileIo { source: e }.into() })?;
+    std::fs::rename(&tmp_path, path).map_err(|e| -> Error {
+        // Best-effort cleanup of the tempfile if rename failed; ignore
+        // any cleanup error (the original failure is what the caller
+        // needs to see).
+        let _ = std::fs::remove_file(&tmp_path);
+        BackendError::FileIo { source: e }.into()
+    })
+}
+
+/// Attempts to load the database state from a specified JSON file.
+///
+/// Returns `Ok(None)` when the file does not exist; the caller decides
+/// whether that's a fresh-start signal or an error (strict load vs.
+/// bootstrap). Other I/O errors and deserialisation errors surface
+/// directly.
+///
+/// Reading the bytes and parsing happen in a single call so there's no
+/// TOCTOU window between an external "does this snapshot exist?" check
+/// and the actual read.
+pub(crate) fn try_load_from_file<P: AsRef<Path>>(path: P) -> Result<Option<InMemory>> {
+    match std::fs::read_to_string(path) {
+        Ok(json) => {
+            let database: InMemory = serde_json::from_str(&json).map_err(|e| -> Error {
+                BackendError::DeserializationFailed { source: e }.into()
+            })?;
+            Ok(Some(database))
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(BackendError::FileIo { source: e }.into()),
+    }
 }
 
 /// Loads the database state from a specified JSON file.
 ///
 /// If the file does not exist, a new, empty `InMemory` database is returned.
+/// Callers that need to distinguish "missing" from "loaded empty" should
+/// use [`try_load_from_file`] instead.
 ///
 /// # Arguments
 /// * `path` - The path to the file from which to load the state.
@@ -159,14 +208,5 @@ pub(crate) fn save_to_file<P: AsRef<Path>>(backend: &InMemory, path: P) -> Resul
 /// # Returns
 /// A `Result` containing the loaded `InMemory` database or an I/O or deserialization error.
 pub(crate) fn load_from_file<P: AsRef<Path>>(path: P) -> Result<InMemory> {
-    match std::fs::read_to_string(path) {
-        Ok(json) => {
-            let database: InMemory = serde_json::from_str(&json).map_err(|e| -> Error {
-                BackendError::DeserializationFailed { source: e }.into()
-            })?;
-            Ok(database)
-        }
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(InMemory::new()),
-        Err(e) => Err(BackendError::FileIo { source: e }.into()),
-    }
+    Ok(try_load_from_file(path)?.unwrap_or_else(InMemory::new))
 }

--- a/crates/lib/src/backend/database/sql/mod.rs
+++ b/crates/lib/src/backend/database/sql/mod.rs
@@ -149,8 +149,12 @@ impl SqlxBackend {
         // Install any driver support
         sqlx::any::install_default_drivers();
 
-        // Detect if this is an in-memory database
-        let is_in_memory = url.contains("mode=memory");
+        // Detect if this is an in-memory database. Two URL conventions
+        // exist: `?mode=memory` (sqlx's explicit query flag, used by
+        // `Sqlite::in_memory`) and `:memory:` (SQLite's classic magic
+        // filename, embedded in URI-filename forms like
+        // `sqlite:file::memory:?cache=shared`).
+        let is_in_memory = url.contains("mode=memory") || url.contains(":memory:");
 
         // For SQLite in-memory databases with shared cache, we must prevent
         // all connections from being closed. When the last connection closes,

--- a/crates/lib/src/backend/mod.rs
+++ b/crates/lib/src/backend/mod.rs
@@ -571,7 +571,7 @@ pub trait BackendImpl: Send + Sync + Any {
     /// Get the instance metadata.
     ///
     /// Returns `None` for a fresh/uninitialized backend, `Some(metadata)` for an
-    /// initialized instance. This is used during `Instance::open()` to determine
+    /// initialized instance. This is used during `Instance::open_backend()` to determine
     /// whether to create a new instance or load an existing one.
     ///
     /// # Returns

--- a/crates/lib/src/database/mod.rs
+++ b/crates/lib/src/database/mod.rs
@@ -211,7 +211,7 @@ impl Database {
     /// # use eidetica::crdt::Doc;
     /// # #[tokio::main]
     /// # async fn main() -> Result<()> {
-    /// let instance = Instance::open(Box::new(InMemory::new())).await?;
+    /// let instance = Instance::open_backend(Box::new(InMemory::new())).await?;
     /// let (signing_key, _public_key) = generate_keypair();
     ///
     /// let mut settings = Doc::new();
@@ -347,7 +347,7 @@ impl Database {
     /// # use eidetica::auth::crypto::generate_keypair;
     /// # #[tokio::main]
     /// # async fn main() -> Result<()> {
-    /// # let instance = Instance::open(Box::new(InMemory::new())).await?;
+    /// # let instance = Instance::open_backend(Box::new(InMemory::new())).await?;
     /// # let (signing_key, _verifying_key) = generate_keypair();
     /// # let root_id = ID::from_bytes(b"existing_database_root_id");
     /// // Open database for reading
@@ -526,7 +526,7 @@ impl Database {
     /// # use eidetica::auth::types::SigKey;
     /// # #[tokio::main]
     /// # async fn main() -> Result<()> {
-    /// # let instance = Instance::open(Box::new(InMemory::new())).await?;
+    /// # let instance = Instance::open_backend(Box::new(InMemory::new())).await?;
     /// # let (signing_key, pubkey) = generate_keypair();
     /// # let root_id = ID::from_bytes(b"database_root_id");
     /// // Find all SigKeys this pubkey can use (sorted highest permission first)
@@ -679,7 +679,7 @@ impl Database {
     /// # use eidetica::auth::crypto::PrivateKey;
     /// # #[tokio::main]
     /// # async fn main() -> Result<()> {
-    /// let instance = Instance::open(Box::new(InMemory::new())).await?;
+    /// let instance = Instance::open_backend(Box::new(InMemory::new())).await?;
     /// # let signing_key = PrivateKey::generate();
     /// # let database = Database::create(&instance, signing_key, Doc::new()).await?;
     ///
@@ -1230,7 +1230,7 @@ impl Database {
     /// # use eidetica::crdt::Doc;
     /// # #[tokio::main]
     /// # async fn main() -> Result<()> {
-    /// # let (_instance, mut user) = Instance::create(
+    /// # let (_instance, mut user) = Instance::create_backend(
     /// #     Box::new(InMemory::new()),
     /// #     NewUser::passwordless("test"),
     /// # ).await?;
@@ -1289,7 +1289,7 @@ impl Database {
     /// # use eidetica::crdt::Doc;
     /// # #[tokio::main]
     /// # async fn main() -> Result<()> {
-    /// # let (_instance, mut user) = Instance::create(
+    /// # let (_instance, mut user) = Instance::create_backend(
     /// #     Box::new(InMemory::new()),
     /// #     NewUser::passwordless("test"),
     /// # ).await?;
@@ -1394,7 +1394,7 @@ impl Database {
     /// # use eidetica::auth::crypto::generate_keypair;
     /// # #[tokio::main]
     /// # async fn main() -> Result<()> {
-    /// # let instance = Instance::open(Box::new(InMemory::new())).await?;
+    /// # let instance = Instance::open_backend(Box::new(InMemory::new())).await?;
     /// # let (signing_key, _public_key) = generate_keypair();
     /// # let database = Database::create(&instance, signing_key, Doc::new()).await?;
     /// // Check if the current key has Admin permission

--- a/crates/lib/src/database/tests.rs
+++ b/crates/lib/src/database/tests.rs
@@ -11,7 +11,7 @@ use crate::{
 #[tokio::test]
 async fn test_find_sigkeys_returns_sorted_by_permission() -> Result<()> {
     // Create instance
-    let (instance, _admin) = Instance::create(
+    let (instance, _admin) = Instance::create_backend(
         Box::new(InMemory::new()),
         crate::NewUser::passwordless("admin"),
     )
@@ -62,7 +62,7 @@ async fn test_find_sigkeys_returns_sorted_by_permission() -> Result<()> {
 
 #[tokio::test]
 async fn test_create_bootstraps_signing_key_as_admin_zero() -> Result<()> {
-    let (instance, _admin) = Instance::create(
+    let (instance, _admin) = Instance::create_backend(
         Box::new(InMemory::new()),
         crate::NewUser::passwordless("admin"),
     )
@@ -87,7 +87,7 @@ async fn test_create_bootstraps_signing_key_as_admin_zero() -> Result<()> {
 
 #[tokio::test]
 async fn test_create_rejects_preconfigured_auth() -> Result<()> {
-    let (instance, _admin) = Instance::create(
+    let (instance, _admin) = Instance::create_backend(
         Box::new(InMemory::new()),
         crate::NewUser::passwordless("admin"),
     )
@@ -125,7 +125,7 @@ async fn test_create_rejects_preconfigured_auth() -> Result<()> {
 
 /// Helper: create an Instance + Database for callback tests
 async fn setup_callback_test() -> (Instance, Database) {
-    let (instance, _admin) = Instance::create(
+    let (instance, _admin) = Instance::create_backend(
         Box::new(InMemory::new()),
         crate::NewUser::passwordless("admin"),
     )

--- a/crates/lib/src/instance/errors.rs
+++ b/crates/lib/src/instance/errors.rs
@@ -3,6 +3,8 @@
 //! This module defines structured error types for tree operations, entry management,
 //! and database operations, providing better error context and type safety compared to string-based errors.
 
+use std::path::PathBuf;
+
 use thiserror::Error;
 
 use crate::entry::ID;
@@ -39,15 +41,61 @@ pub enum InstanceError {
     /// Backend has no Instance on it; the operator must create one before
     /// it can be opened.
     ///
-    /// Returned by [`Instance::open`](super::Instance::open) when the
-    /// backend has no instance metadata. Use
-    /// [`Instance::create`](super::Instance::create) (or
-    /// [`Instance::open_or_create`](super::Instance::open_or_create)) with
-    /// a [`NewUser`](super::NewUser) to initialise it first.
+    /// Returned by [`Instance::connect`](super::Instance::connect) when the
+    /// backend at the URL has no instance metadata. Use
+    /// [`Instance::connect_or_create`](super::Instance::connect_or_create)
+    /// with a [`NewUser`](super::NewUser) to initialise it first.
     #[error(
-        "Instance not initialised on this backend; use Instance::create or Instance::open_or_create"
+        "Instance not initialised on this backend; use Instance::connect_or_create to bootstrap"
     )]
     NotInitialized,
+
+    /// URL failed to parse or is missing required components.
+    #[error("Invalid URL `{url}`: {reason}")]
+    InvalidUrl {
+        /// The URL string the caller provided.
+        url: String,
+        /// What was wrong, with a hint where possible.
+        reason: String,
+    },
+
+    /// Scheme is not recognised (e.g. `mysql://`, `foo://`).
+    #[error("Unsupported URL scheme `{scheme}://`{hint}", hint = match suggested {
+        Some(s) => format!(" — did you mean `{s}://`?"),
+        None => String::new(),
+    })]
+    UnsupportedScheme {
+        /// The scheme the caller passed.
+        scheme: String,
+        /// Best-effort typo suggestion, if any.
+        suggested: Option<&'static str>,
+    },
+
+    /// Scheme is recognised but its backend isn't compiled into this build.
+    #[error(
+        "Backend for `{scheme}://` is not available in this build; rebuild with `--features {missing_feature}`"
+    )]
+    BackendUnavailable {
+        /// The scheme that requires the missing feature.
+        scheme: &'static str,
+        /// Cargo feature flag that enables the backend.
+        missing_feature: &'static str,
+    },
+
+    /// Snapshot file is present but cannot be loaded.
+    #[error("Invalid snapshot at `{path}`: {reason}")]
+    InvalidSnapshot {
+        /// Path to the offending snapshot file.
+        path: PathBuf,
+        /// Why the load failed (parse error, missing metadata, etc.).
+        reason: String,
+    },
+
+    /// Snapshotting is only supported on the in-memory backend.
+    #[error(
+        "Snapshot is only supported on the in-memory backend; use a `memory:///path.json` URL for auto-save on close/Drop, or call `flush()` manually on an in-memory instance"
+    )]
+    SnapshotNotSupported,
 
     /// Entry does not belong to the specified database.
     #[error("Entry '{entry_id}' does not belong to database '{database_id}'")]

--- a/crates/lib/src/instance/mod.rs
+++ b/crates/lib/src/instance/mod.rs
@@ -7,6 +7,7 @@
 use std::{
     collections::HashMap,
     future::Future,
+    path::PathBuf,
     pin::Pin,
     sync::{
         Arc, Mutex, Weak,
@@ -31,6 +32,7 @@ pub mod backend;
 pub mod errors;
 pub mod new_user;
 pub mod settings_merge;
+pub mod url;
 
 #[cfg(test)]
 mod tests;
@@ -220,6 +222,20 @@ pub(crate) struct InstanceInternal {
     metadata: InstanceMetadata,
     /// Private instance secrets (None for remote instances without key access)
     secrets: Option<InstanceSecrets>,
+    /// JSON snapshot file path for an in-memory backend constructed via
+    /// `memory:///path.json` (or set explicitly through
+    /// [`Instance::snapshot_to_path`]). [`Instance::flush`] and the
+    /// [`Drop`] safety net write through this. `None` on any non-snapshot
+    /// backend.
+    ///
+    /// The mutex serves double duty: it guards the path slot itself (so
+    /// `set_snapshot_path` doesn't race with readers) AND serializes the
+    /// actual write so concurrent callers from `flush` / `snapshot_to_path`
+    /// / `Drop` don't race on the shared `<path>.tmp` staging file in
+    /// [`InMemory::save_to_file`]. Held across sync I/O only — never
+    /// across an `.await`. Poison-tolerant: a panic mid-write leaves the
+    /// on-disk snapshot unchanged but must not strand the [`Instance`].
+    snapshot_path: Mutex<Option<PathBuf>>,
     /// Per-database callbacks keyed by tree_id. Each callback fires for both
     /// local and remote writes; consumers branch on [`WriteEvent::source`] if
     /// they only care about one.
@@ -264,6 +280,81 @@ impl std::fmt::Debug for InstanceInternal {
             .finish()
     }
 }
+
+impl InstanceInternal {
+    /// Synchronously write a JSON snapshot of the underlying backend to `path`.
+    ///
+    /// Returns [`InstanceError::SnapshotNotSupported`] for any backend other
+    /// than the local in-memory backend. Shared by [`Instance::snapshot_to_path`],
+    /// [`Instance::flush`], and the [`Drop`] fallback so the three can't drift.
+    ///
+    /// **Caller must hold the [`snapshot_path`](Self::snapshot_path) mutex.**
+    /// That lock serializes the write — without it, concurrent callers
+    /// would race on the shared `<path>.tmp` staging file in
+    /// [`InMemory::save_to_file`]. The critical section is fully sync; no
+    /// `.await` happens while the lock is held.
+    fn save_snapshot_locked(&self, path: &std::path::Path) -> Result<()> {
+        use crate::backend::database::InMemory;
+        let engine = self
+            .backend
+            .local_engine()
+            .ok_or(InstanceError::SnapshotNotSupported)?;
+        let in_memory = engine
+            .as_any()
+            .downcast_ref::<InMemory>()
+            .ok_or(InstanceError::SnapshotNotSupported)?;
+        in_memory.save_to_file(path)
+    }
+}
+
+/// Best-effort snapshot save on the *last* `InstanceInternal` drop.
+///
+/// Fires when the `Arc<InstanceInternal>` reaches refcount 0 and a snapshot
+/// path is armed (i.e. the `Instance` was constructed via a
+/// `memory:///path.json` URL). [`Instance::flush`] does **not** clear the
+/// snapshot path, so Drop fires even after a successful `flush()` — the
+/// write is idempotent (same atomic tmp+rename), so the worst case is one
+/// extra write of unchanged JSON.
+///
+/// **Errors are logged via `tracing::error!`, not surfaced** — `Drop` can't
+/// return a `Result` and panicking would be worse than logging. Apps that
+/// care about snapshot durability should call [`Instance::flush`] at
+/// well-defined checkpoints and inspect its `Result`; Drop is a safety net,
+/// not the primary persistence path. If `flush()` failed with a permanent
+/// error (e.g. nonexistent parent directory), Drop will fail the same way
+/// and emit a second log line — accept this redundancy as the cost of a
+/// best-effort fallback.
+///
+/// **Blocking I/O warning:** the snapshot write is synchronous
+/// (`std::fs::write` + `rename`). If the `Instance` is dropped on a tokio
+/// worker thread, this blocks that worker for the duration of the write —
+/// negligible for small snapshots, but pathological for very large ones.
+/// Prefer `flush().await` (which still blocks briefly, but does so under
+/// explicit caller control).
+impl Drop for InstanceInternal {
+    fn drop(&mut self) {
+        // Drop runs at Arc refcount 0, so no other handle can race here —
+        // any in-flight `flush()` future holds `&self` and thus an Arc
+        // clone, which would have prevented Drop from firing. We still
+        // acquire the lock for the write so the locking discipline in
+        // `save_snapshot_locked`'s doc-comment holds uniformly. The lock
+        // is uncontended at this point.
+        let mut guard = match self.snapshot_path.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        let Some(path) = guard.take() else { return };
+
+        if let Err(e) = self.save_snapshot_locked(&path) {
+            tracing::error!(
+                snapshot_path = %path.display(),
+                error = %e,
+                "Drop: snapshot save failed. Call `Instance::flush().await` at \
+                 checkpoints to inspect the error via Result; Drop is a safety net only.",
+            );
+        }
+    }
+}
 /// Database implementation on top of the storage backend.
 ///
 /// Instance manages infrastructure only:
@@ -278,16 +369,17 @@ impl std::fmt::Debug for InstanceInternal {
 /// ## Example
 ///
 /// ```
-/// # use eidetica::{backend::database::InMemory, Instance, NewUser, crdt::Doc};
+/// # use eidetica::{Instance, NewUser, crdt::Doc};
 /// # #[tokio::main]
 /// # async fn main() -> eidetica::Result<()> {
-/// // Create a fresh instance with an initial admin user. The first user
+/// // Bootstrap a fresh instance with an initial admin user. The first user
 /// // created on an instance is automatically granted Admin on the system
 /// // databases.
-/// let (instance, mut user) = Instance::create(
-///     Box::new(InMemory::new()),
+/// let (instance, maybe_user) = Instance::connect_or_create(
+///     "memory://",
 ///     NewUser::passwordless("alice"),
 /// ).await?;
+/// let mut user = maybe_user.expect("memory:// is always fresh");
 ///
 /// // Use User API for operations
 /// let mut settings = Doc::new();
@@ -315,27 +407,312 @@ pub struct WeakInstance {
 }
 
 impl Instance {
-    /// Connect to a running Eidetica service daemon over a Unix domain socket.
+    /// Open a connection to an eidetica instance described by a connection URL.
     ///
-    /// This creates a `RemoteConnection` that forwards all storage operations
-    /// to the daemon via RPC, wrapped in a `RemoteBackend`.
+    /// Strict load: returns [`InstanceError::NotInitialized`] when the URL
+    /// points at an embedded backend (`sqlite://`, `postgres://`, `memory://`)
+    /// that has no eidetica metadata yet. Use
+    /// [`Instance::connect_or_create`] to bootstrap an embedded backend on
+    /// first run.
     ///
-    /// Authentication uses client-side signing. `login_user()` runs the
-    /// challenge-response handshake, decrypting the user's signing key
-    /// in-process and signing the challenge locally; the daemon never
-    /// receives the password or the plaintext signing key and never signs
-    /// on the client's behalf. A connected Instance holds no local instance
-    /// secrets. A key-holding daemon was considered and rejected — see the
-    /// Service Architecture doc § Decision record for the rationale.
+    /// Supported URL schemes:
+    /// - `sqlite://./app.db` — embedded sqlite backend; URL is passed through
+    ///   to `sqlx::sqlite`, so any sqlx-accepted form works
+    ///   (`?mode=rwc&journal_mode=WAL` etc.).
+    /// - `postgres://user:pwd@host/db` — embedded postgres backend; URL is
+    ///   passed through to `sqlx::postgres`.
+    /// - `unix:///run/eidetica/sock` — thin client to a running daemon.
+    /// - `memory://` — empty in-memory backend. Strict load against an
+    ///   empty in-memory backend always errors `NotInitialized`; use
+    ///   `connect_or_create` for a fresh in-memory instance.
+    /// - `memory:///path/to/snap.json` — in-memory backend with a JSON
+    ///   snapshot file (load-on-start; snapshot writes via
+    ///   [`Instance::flush`] / [`Instance::snapshot_to_path`] / Drop fallback).
     ///
-    /// # Arguments
-    /// * `socket_path` - Path to the Unix domain socket
+    /// See [`crate::instance::url`] for the full URL grammar.
     ///
-    /// # Returns
-    /// A Result containing the connected Instance
+    /// # Example
+    ///
+    /// `connect()` only succeeds against an already-initialised backend.
+    /// The two-phase pattern below bootstraps once, then re-opens with
+    /// the strict load:
+    ///
+    /// ```
+    /// # #[tokio::main]
+    /// # async fn main() -> eidetica::Result<()> {
+    /// use eidetica::{Instance, NewUser};
+    ///
+    /// let temp = tempfile::tempdir()?;
+    /// let snapshot = temp.path().join("app.json");
+    /// let url = format!("memory://{}", snapshot.display());
+    ///
+    /// // First run: bootstrap and flush a snapshot to disk.
+    /// {
+    ///     let (instance, maybe_user) =
+    ///         Instance::connect_or_create(&url, NewUser::passwordless("alice")).await?;
+    ///     let _user = maybe_user.expect("fresh bootstrap on first run");
+    ///     instance.flush()?;
+    /// }
+    ///
+    /// // Later: strict connect against the persisted snapshot.
+    /// let instance = Instance::connect(&url).await?;
+    /// let _user = instance.login_user("alice", None).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// Calling `connect()` on a backend with no eidetica metadata returns
+    /// [`InstanceError::NotInitialized`]; reach for
+    /// [`Instance::connect_or_create`] when first-run bootstrap is part
+    /// of the expected lifecycle.
+    pub async fn connect(url: impl AsRef<str>) -> Result<Self> {
+        Self::connect_impl(url.as_ref(), Arc::new(SystemClock)).await
+    }
+
+    /// Open or initialise an eidetica instance described by a connection URL.
+    ///
+    /// On the load arm: identical to [`Instance::connect`]; `initial` is
+    /// silently ignored and the second tuple element is `None`.
+    ///
+    /// On the bootstrap arm: initialises the backend at the URL with the
+    /// supplied [`NewUser`] as the first admin and returns
+    /// `(Instance, Some(User))`. Only embedded backends
+    /// (sqlite/postgres/memory) ever take the bootstrap arm — `unix://` URLs
+    /// degrade to `connect` (the daemon owns its own initialisation), so the
+    /// returned `Option<User>` is always `None` for `unix://`.
+    ///
+    /// # Example
+    /// ```
+    /// # use eidetica::{Instance, NewUser};
+    /// # #[tokio::main]
+    /// # async fn main() -> eidetica::Result<()> {
+    /// let (instance, maybe_user) = Instance::connect_or_create(
+    ///     "memory://",
+    ///     NewUser::passwordless("alice"),
+    /// ).await?;
+    /// let mut user = match maybe_user {
+    ///     Some(u) => u,
+    ///     None => instance.login_user("alice", None).await?,
+    /// };
+    /// # let _ = user.get_default_key()?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn connect_or_create(
+        url: impl AsRef<str>,
+        initial: NewUser,
+    ) -> Result<(Self, Option<User>)> {
+        Self::connect_or_create_impl(url.as_ref(), initial, Arc::new(SystemClock)).await
+    }
+
+    /// Escape hatch: open or initialise an eidetica instance against a
+    /// pre-built [`BackendImpl`] (sqlite, postgres, in-memory, or custom).
+    ///
+    /// Same load-or-bootstrap semantics as [`Instance::connect_or_create`]
+    /// but skips URL parsing. Useful for tests, embedded apps that want to
+    /// configure the backend's pool/runtime manually, or backends not yet
+    /// exposed via a URL scheme.
+    pub async fn connect_or_create_backend(
+        backend: Box<dyn BackendImpl>,
+        initial: NewUser,
+    ) -> Result<(Self, Option<User>)> {
+        Self::connect_or_create_backend_impl(
+            Arc::from(backend),
+            initial,
+            Arc::new(SystemClock),
+            None,
+        )
+        .await
+    }
+
+    /// Strict-load escape hatch: open an eidetica instance against a
+    /// pre-built [`BackendImpl`] that's already been initialised. Mirrors
+    /// [`Instance::connect`]'s strict semantics for the URL-less case.
+    ///
+    /// Errors with [`InstanceError::NotInitialized`] if the backend has no
+    /// instance metadata; use [`Instance::connect_or_create_backend`] when you want
+    /// to bootstrap on an empty backend.
+    pub async fn open_backend(backend: Box<dyn BackendImpl>) -> Result<Self> {
+        Self::open_impl(backend, Arc::new(SystemClock)).await
+    }
+
+    /// Test variant of [`Instance::open_backend`] with an injectable clock.
+    #[cfg(any(test, feature = "testing"))]
+    pub async fn open_backend_with_clock(
+        backend: Box<dyn BackendImpl>,
+        clock: Arc<dyn Clock>,
+    ) -> Result<Self> {
+        Self::open_impl(backend, clock).await
+    }
+
+    /// Strict-create escape hatch: initialise an eidetica instance on a
+    /// fresh pre-built [`BackendImpl`] and bootstrap an initial admin user.
+    ///
+    /// Errors with [`InstanceError::InstanceAlreadyExists`] if the backend
+    /// is already initialised; use [`Instance::connect_or_create_backend`] when the
+    /// caller doesn't want to choose between load and create up front.
+    pub async fn create_backend(
+        backend: Box<dyn BackendImpl>,
+        initial: NewUser,
+    ) -> Result<(Self, User)> {
+        Self::create_backend_impl(backend, initial, Arc::new(SystemClock)).await
+    }
+
+    /// Test variant of [`Instance::create_backend`] with an injectable clock.
+    ///
+    /// Arg order: backend, clock, initial — clock goes in the middle so
+    /// migrating from the prior `create_with_clock` is a pure rename.
+    #[cfg(any(test, feature = "testing"))]
+    pub async fn create_backend_with_clock(
+        backend: Box<dyn BackendImpl>,
+        clock: Arc<dyn Clock>,
+        initial: NewUser,
+    ) -> Result<(Self, User)> {
+        Self::create_backend_impl(backend, initial, clock).await
+    }
+
+    async fn create_backend_impl(
+        backend: Box<dyn BackendImpl>,
+        initial: NewUser,
+        clock: Arc<dyn Clock>,
+    ) -> Result<(Self, User)> {
+        let backend: Arc<dyn BackendImpl> = Arc::from(backend);
+        if backend.get_instance_metadata().await?.is_some() {
+            return Err(InstanceError::InstanceAlreadyExists.into());
+        }
+        Self::create_internal(backend, clock, initial).await
+    }
+
+    // Clock injection is exposed only through the pre-built-backend
+    // variants ([`open_backend_with_clock`] and [`create_backend_with_clock`]).
+    // The URL-based `connect_*` constructors deliberately have no
+    // `_with_clock` siblings: every existing test that needs deterministic
+    // timestamps already builds an `InMemory` backend directly, so a URL-
+    // shaped clock entry point would be dead weight.
+
+    // ============ Internal URL dispatchers ============
+
+    async fn connect_impl(url: &str, clock: Arc<dyn Clock>) -> Result<Self> {
+        let parsed = url::parse(url)?;
+        match parsed {
+            url::ConnectionUrl::Sqlite { url } => Self::connect_sqlite(&url, clock).await,
+            url::ConnectionUrl::Postgres { url } => Self::connect_postgres(&url, clock).await,
+            url::ConnectionUrl::Unix { socket_path } => {
+                Self::connect_unix_socket(socket_path, clock).await
+            }
+            url::ConnectionUrl::Memory { snapshot_path } => {
+                Self::connect_memory(snapshot_path, clock).await
+            }
+        }
+    }
+
+    async fn connect_or_create_impl(
+        url: &str,
+        initial: NewUser,
+        clock: Arc<dyn Clock>,
+    ) -> Result<(Self, Option<User>)> {
+        let parsed = url::parse(url)?;
+        match parsed {
+            url::ConnectionUrl::Sqlite { url } => {
+                let backend = open_sqlite_backend(&url).await?;
+                Self::connect_or_create_backend_impl(Arc::from(backend), initial, clock, None).await
+            }
+            url::ConnectionUrl::Postgres { url } => {
+                let backend = open_postgres_backend(&url).await?;
+                Self::connect_or_create_backend_impl(Arc::from(backend), initial, clock, None).await
+            }
+            url::ConnectionUrl::Unix { socket_path } => {
+                // Daemons own their own initialisation. connect_or_create
+                // against `unix://` degrades to a plain connect; `initial`
+                // is unused on this arm. Log it so the silent drop is
+                // discoverable when debugging "why didn't my initial user
+                // get created?" on a remote URL.
+                tracing::debug!(
+                    socket_path = %socket_path.display(),
+                    username = %initial.username,
+                    "connect_or_create against `unix://` is degrading to `connect`; \
+                     `initial` is ignored — daemons own their own initialisation. \
+                     Run `eidetica daemon init` to bootstrap a daemon-side instance."
+                );
+                let instance = Self::connect_unix_socket(socket_path, clock).await?;
+                Ok((instance, None))
+            }
+            url::ConnectionUrl::Memory { snapshot_path } => {
+                use crate::backend::database::InMemory;
+                // Build the backend from a single `try_load_from_file` call.
+                // `Ok(None)` means the file didn't exist at read time (the
+                // bootstrap-friendly "first run" case → empty backend).
+                // `Ok(Some(loaded))` means the file existed and parsed; if
+                // it carries no instance metadata it's foreign data that
+                // happened to satisfy the `SerializableDatabase` shape, and
+                // we refuse to bootstrap over it (the next snapshot would
+                // silently overwrite the caller's file). Doing the existence
+                // test and the read in one call removes the TOCTOU window a
+                // separate `path.exists()` check would open.
+                let backend: Box<dyn BackendImpl> = match snapshot_path.as_deref() {
+                    None => Box::new(InMemory::new()),
+                    Some(path) => {
+                        let loaded = InMemory::try_load_from_file(path).await.map_err(|e| {
+                            InstanceError::InvalidSnapshot {
+                                path: path.to_path_buf(),
+                                reason: e.to_string(),
+                            }
+                        })?;
+                        match loaded {
+                            None => Box::new(InMemory::new()),
+                            Some(loaded) => {
+                                let boxed: Box<dyn BackendImpl> = Box::new(loaded);
+                                if boxed.get_instance_metadata().await?.is_none() {
+                                    return Err(InstanceError::InvalidSnapshot {
+                                        path: path.to_path_buf(),
+                                        reason: "snapshot file exists but contains no instance \
+                                             metadata; refusing to bootstrap on top of foreign \
+                                             data. Delete or move the file to create a fresh \
+                                             instance at this path."
+                                            .into(),
+                                    }
+                                    .into());
+                                }
+                                boxed
+                            }
+                        }
+                    }
+                };
+                Self::connect_or_create_backend_impl(
+                    Arc::from(backend),
+                    initial,
+                    clock,
+                    snapshot_path,
+                )
+                .await
+            }
+        }
+    }
+
+    /// Internal: load-or-bootstrap against a pre-built backend, optionally
+    /// remembering a snapshot path so Drop / flush can write to it.
+    async fn connect_or_create_backend_impl(
+        backend: Arc<dyn BackendImpl>,
+        initial: NewUser,
+        clock: Arc<dyn Clock>,
+        snapshot_path: Option<PathBuf>,
+    ) -> Result<(Self, Option<User>)> {
+        if let Some(metadata) = backend.get_instance_metadata().await? {
+            let instance = Self::open_impl_arc_with_metadata(backend, clock, metadata).await?;
+            instance.set_snapshot_path(snapshot_path);
+            Ok((instance, None))
+        } else {
+            let (instance, user) = Self::create_internal(backend, clock, initial).await?;
+            instance.set_snapshot_path(snapshot_path);
+            Ok((instance, Some(user)))
+        }
+    }
+
+    // ============ Backend connection helpers ============
+
     #[cfg(all(unix, feature = "service"))]
-    pub async fn connect(socket_path: impl AsRef<std::path::Path>) -> Result<Self> {
-        let conn = crate::service::client::RemoteConnection::connect(socket_path).await?;
+    async fn connect_unix_socket(socket_path: PathBuf, clock: Arc<dyn Clock>) -> Result<Self> {
+        let conn = crate::service::client::RemoteConnection::connect(&socket_path).await?;
         let backend: Arc<dyn Backend> = Arc::new(RemoteBackend::new(conn, None));
 
         // Load metadata from the remote backend
@@ -344,75 +721,151 @@ impl Instance {
             .await?
             .ok_or(InstanceError::DeviceKeyNotFound)?;
 
-        // No local secrets — keys are held server-side after login
+        // No local secrets — keys are held server-side after login.
         let inner = Arc::new(InstanceInternal {
             backend,
-            clock: Arc::new(SystemClock),
+            clock,
             sync: std::sync::OnceLock::new(),
             metadata,
             secrets: None,
+            snapshot_path: Mutex::new(None),
             write_callbacks: Mutex::new(HashMap::new()),
             global_write_callbacks: Mutex::new(Vec::new()),
             next_callback_id: AtomicU64::new(0),
             tree_locks: Mutex::new(HashMap::new()),
         });
-        let instance = Self { inner };
+        Ok(Self { inner })
+    }
+
+    #[cfg(not(all(unix, feature = "service")))]
+    async fn connect_unix_socket(_socket_path: PathBuf, _clock: Arc<dyn Clock>) -> Result<Self> {
+        Err(InstanceError::BackendUnavailable {
+            scheme: "unix",
+            missing_feature: "service",
+        }
+        .into())
+    }
+
+    async fn connect_sqlite(url: &str, clock: Arc<dyn Clock>) -> Result<Self> {
+        let backend = open_sqlite_backend(url).await?;
+        Self::open_impl(backend, clock).await
+    }
+
+    async fn connect_postgres(url: &str, clock: Arc<dyn Clock>) -> Result<Self> {
+        let backend = open_postgres_backend(url).await?;
+        Self::open_impl(backend, clock).await
+    }
+
+    async fn connect_memory(snapshot_path: Option<PathBuf>, clock: Arc<dyn Clock>) -> Result<Self> {
+        use crate::backend::database::InMemory;
+        // Strict load: a snapshot URL that points at a non-existent file
+        // cannot satisfy `connect`'s "must already be initialised" contract.
+        // `try_load_from_file` returns `Ok(None)` when the file doesn't
+        // exist, which we translate into a pointed `InvalidSnapshot`. Using
+        // the same call for the existence test and the read removes the
+        // TOCTOU window a separate `path.exists()` check would open: if the
+        // file vanishes mid-call, the underlying `read_to_string` surfaces
+        // `NotFound` and lands us in the same `None` arm.
+        let backend: Box<dyn BackendImpl> = match snapshot_path.as_deref() {
+            None => Box::new(InMemory::new()),
+            Some(path) => {
+                let loaded = InMemory::try_load_from_file(path).await.map_err(|e| {
+                    InstanceError::InvalidSnapshot {
+                        path: path.to_path_buf(),
+                        reason: e.to_string(),
+                    }
+                })?;
+                match loaded {
+                    Some(loaded) => Box::new(loaded),
+                    None => {
+                        return Err(InstanceError::InvalidSnapshot {
+                            path: path.to_path_buf(),
+                            reason: "snapshot file does not exist; \
+                                     use `Instance::connect_or_create` to bootstrap a new instance \
+                                     at this path, or pass `memory://` for an ephemeral instance"
+                                .into(),
+                        }
+                        .into());
+                    }
+                }
+            }
+        };
+        let instance = Self::open_impl(backend, clock).await?;
+        instance.set_snapshot_path(snapshot_path);
         Ok(instance)
     }
 
-    /// Load an existing Instance from an initialised backend.
+    /// Flush deferred persistence state to disk.
     ///
-    /// Strict load: returns [`InstanceError::NotInitialized`] if the backend
-    /// has no instance metadata yet. Use [`Instance::create`] to initialise a
-    /// fresh backend, or [`Instance::open_or_create`] for a load-or-init
-    /// convenience.
+    /// For an `Instance` constructed via a `memory:///path.json` URL, this
+    /// writes the current backend state to the snapshot path (atomic on
+    /// POSIX — `<path>.tmp` then rename). For sqlite/postgres/unix
+    /// backends this is a no-op; those storage layers handle persistence
+    /// inline.
     ///
-    /// # Arguments
-    /// * `backend` - The storage backend to load from (must already be initialised)
+    /// Idempotent and reentrant — call it as often as you like at
+    /// well-defined checkpoints. The snapshot path stays armed, so the
+    /// [`Drop`] fallback continues to fire on the last handle as a safety
+    /// net. The `Instance` (and any clones) remain fully usable after
+    /// `flush()` returns; this is not a shutdown.
     ///
-    /// # Example
-    /// ```
-    /// # use eidetica::{backend::database::InMemory, Instance, NewUser};
-    /// # #[tokio::main]
-    /// # async fn main() -> eidetica::Result<()> {
-    /// // Once a backend has been initialised by `Instance::create`,
-    /// // subsequent runs against the same persistent backend load via
-    /// // `Instance::open`. The InMemory backend in this doctest can't
-    /// // round-trip across handles; in real code the second invocation
-    /// // would point at the same on-disk SQLite (or Postgres) file:
-    /// //
-    /// //     let instance = Instance::open(Box::new(persistent_backend)).await?;
-    /// //     let user = instance.login_user("alice", None).await?;
-    /// let (_instance, _user) = Instance::create(
-    ///     Box::new(InMemory::new()),
-    ///     NewUser::passwordless("alice"),
-    /// ).await?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub async fn open(backend: Box<dyn BackendImpl>) -> Result<Self> {
-        Self::open_impl(backend, Arc::new(SystemClock)).await
+    /// If `flush()` fails (e.g. nonexistent parent directory), the error
+    /// surfaces in the `Result`. Drop will later try the same write and
+    /// fail the same way, logging via `tracing::error!`. The duplicate
+    /// signal is intentional — Drop must report what it sees.
+    ///
+    /// **Blocking I/O note:** the snapshot write is synchronous
+    /// (`std::fs::write` + `rename`) and runs inline on the caller. Hence
+    /// the sync signature — there is no `.await` inside. If you're calling
+    /// from a tokio task, this briefly blocks the runtime worker;
+    /// negligible for small snapshots.
+    pub fn flush(&self) -> Result<()> {
+        // Acquire the snapshot_path lock once and hold it across the
+        // write — the lock both gates the path slot and serializes the
+        // sync I/O so concurrent flushes don't clobber each other's
+        // staging tempfile. The path stays armed (we read, don't take)
+        // so subsequent flushes and the Drop safety net keep working.
+        let guard = self
+            .inner
+            .snapshot_path
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        if let Some(path) = guard.as_deref() {
+            self.inner.save_snapshot_locked(path)?;
+        }
+        Ok(())
     }
 
-    /// Load an existing Instance with a custom clock.
+    /// Write a JSON snapshot of the in-memory backend to `path`.
     ///
-    /// Same strict-load semantics as [`Instance::open`] (errors with
-    /// [`InstanceError::NotInitialized`] on an empty backend), but allows
-    /// injecting a custom clock for controllable timestamps in tests. The
-    /// clock is used for timestamps in height calculations and peer
-    /// tracking.
-    ///
-    /// Only available with the `testing` feature or in test builds.
-    ///
-    /// # Arguments
-    /// * `backend` - The storage backend to load from (must already be initialised)
-    /// * `clock` - The time provider to use (typically [`FixedClock`](crate::FixedClock))
-    #[cfg(any(test, feature = "testing"))]
-    pub async fn open_with_clock(
-        backend: Box<dyn BackendImpl>,
-        clock: Arc<dyn Clock>,
-    ) -> Result<Self> {
-        Self::open_impl(backend, clock).await
+    /// The write goes to `<path>.tmp` and then renames into place. On POSIX
+    /// the rename is atomic; on Windows it is not atomic when the
+    /// destination already exists. Returns
+    /// [`InstanceError::SnapshotNotSupported`] on any backend other than
+    /// the in-memory backend.
+    pub fn snapshot_to_path(&self, path: impl AsRef<std::path::Path>) -> Result<()> {
+        let _guard = self
+            .inner
+            .snapshot_path
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        self.inner.save_snapshot_locked(path.as_ref())
+    }
+
+    /// Stash the snapshot path on the InstanceInternal so Drop / close can
+    /// find it. Only meaningful for in-memory backends — no-op for others.
+    fn set_snapshot_path(&self, path: Option<PathBuf>) {
+        if path.is_none() {
+            return;
+        }
+        // Poison-tolerant: a panic in another holder must not strand the
+        // Instance — the snapshot path is a simple swappable Option.
+        let mut guard = self
+            .inner
+            .snapshot_path
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        *guard = path;
     }
 
     /// Internal load-only implementation that works with any clock.
@@ -420,7 +873,7 @@ impl Instance {
         let backend: Arc<dyn BackendImpl> = Arc::from(backend);
 
         // Strict: require existing InstanceMetadata. Initialisation is the
-        // caller's responsibility (`create` / `open_or_create`).
+        // caller's responsibility (`connect_or_create` / `connect_or_create_backend`).
         let metadata = backend
             .get_instance_metadata()
             .await?
@@ -444,6 +897,7 @@ impl Instance {
             sync: std::sync::OnceLock::new(),
             metadata,
             secrets,
+            snapshot_path: Mutex::new(None),
             write_callbacks: Mutex::new(HashMap::new()),
             global_write_callbacks: Mutex::new(Vec::new()),
             next_callback_id: AtomicU64::new(0),
@@ -452,120 +906,16 @@ impl Instance {
         Ok(Self { inner })
     }
 
-    /// Create a new Instance on a fresh backend with an initial admin user.
-    ///
-    /// Fails with [`InstanceError::InstanceAlreadyExists`] if the backend is
-    /// already initialised. The supplied [`NewUser`] is the first user
-    /// created on the instance and is automatically granted Admin on the
-    /// system databases (via the first-user-becomes-admin logic in
-    /// [`system_databases::create_user`](crate::user::system_databases)).
-    /// The returned [`User`] is already logged in.
-    ///
-    /// # Arguments
-    /// * `backend` - The storage backend to use (must be uninitialised)
-    /// * `initial` - The first user to create on this instance
-    ///
-    /// # Example
-    /// ```
-    /// # use eidetica::{backend::database::InMemory, Instance, NewUser, crdt::Doc};
-    /// # #[tokio::main]
-    /// # async fn main() -> eidetica::Result<()> {
-    /// let (instance, mut user) = Instance::create(
-    ///     Box::new(InMemory::new()),
-    ///     NewUser::passwordless("alice"),
-    /// ).await?;
-    ///
-    /// let mut settings = Doc::new();
-    /// settings.set("name", "my_database");
-    /// let default_key = user.get_default_key()?;
-    /// let db = user.create_database(settings, &default_key).await?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub async fn create(backend: Box<dyn BackendImpl>, initial: NewUser) -> Result<(Self, User)> {
-        Self::create_with_clock_impl(backend, Arc::new(SystemClock), initial).await
-    }
-
-    /// Strict create with an injectable clock — same semantics as
-    /// [`Instance::create`] but allows tests to pin timestamps via
-    /// [`FixedClock`](crate::FixedClock). Mirrors [`Instance::open_with_clock`].
-    #[cfg(any(test, feature = "testing"))]
-    pub async fn create_with_clock(
-        backend: Box<dyn BackendImpl>,
+    /// Load-only helper that accepts an already-arc'd backend and the
+    /// already-fetched metadata. Used by `connect_or_create_backend_impl`,
+    /// which has already inspected metadata to choose between the load
+    /// and bootstrap arms — passing it through avoids a redundant
+    /// `get_instance_metadata` round-trip.
+    async fn open_impl_arc_with_metadata(
+        backend: Arc<dyn BackendImpl>,
         clock: Arc<dyn Clock>,
-        initial: NewUser,
-    ) -> Result<(Self, User)> {
-        Self::create_with_clock_impl(backend, clock, initial).await
-    }
-
-    async fn create_with_clock_impl(
-        backend: Box<dyn BackendImpl>,
-        clock: Arc<dyn Clock>,
-        initial: NewUser,
-    ) -> Result<(Self, User)> {
-        let backend: Arc<dyn BackendImpl> = Arc::from(backend);
-
-        // Check if already initialized
-        if backend.get_instance_metadata().await?.is_some() {
-            return Err(InstanceError::InstanceAlreadyExists.into());
-        }
-
-        // Create new instance
-        Self::create_internal(backend, clock, initial).await
-    }
-
-    /// Load an existing Instance, or create a new one with the supplied
-    /// initial user if the backend is empty.
-    ///
-    /// Returns `(Instance, Some(User))` on a freshly initialised backend
-    /// (the new instance plus the just-created initial user, already logged
-    /// in) and `(Instance, None)` when loading an existing instance — the
-    /// caller is expected to call [`Instance::login_user`] for an existing
-    /// user. Suitable for embedded applications that don't want to choose
-    /// between `open` and `create` up front.
-    ///
-    /// # Example
-    /// ```
-    /// # use eidetica::{backend::database::InMemory, Instance, NewUser};
-    /// # #[tokio::main]
-    /// # async fn main() -> eidetica::Result<()> {
-    /// let (instance, maybe_user) = Instance::open_or_create(
-    ///     Box::new(InMemory::new()),
-    ///     NewUser::passwordless("alice"),
-    /// ).await?;
-    /// let mut user = match maybe_user {
-    ///     Some(u) => u,
-    ///     None => instance.login_user("alice", None).await?,
-    /// };
-    /// # let _ = user.get_default_key()?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub async fn open_or_create(
-        backend: Box<dyn BackendImpl>,
-        initial: NewUser,
-    ) -> Result<(Self, Option<User>)> {
-        let backend: Arc<dyn BackendImpl> = Arc::from(backend);
-        let clock: Arc<dyn Clock> = Arc::new(SystemClock);
-
-        if backend.get_instance_metadata().await?.is_some() {
-            // Existing instance: load only, no initial user produced.
-            let instance = Self::open_impl_arc(backend, clock).await?;
-            Ok((instance, None))
-        } else {
-            let (instance, user) = Self::create_internal(backend, clock, initial).await?;
-            Ok((instance, Some(user)))
-        }
-    }
-
-    /// Load-only helper that accepts an already-arc'd backend. Mirrors
-    /// `open_impl` but reuses the existing Arc — used by `open_or_create`,
-    /// which already checks metadata once and doesn't want to redo the work.
-    async fn open_impl_arc(backend: Arc<dyn BackendImpl>, clock: Arc<dyn Clock>) -> Result<Self> {
-        let metadata = backend
-            .get_instance_metadata()
-            .await?
-            .ok_or(InstanceError::NotInitialized)?;
+        metadata: InstanceMetadata,
+    ) -> Result<Self> {
         let secrets = backend.get_instance_secrets().await?;
         if let Some(ref secrets) = secrets {
             let derived_id = secrets.signing_key.public_key();
@@ -579,6 +929,7 @@ impl Instance {
             sync: std::sync::OnceLock::new(),
             metadata,
             secrets,
+            snapshot_path: Mutex::new(None),
             write_callbacks: Mutex::new(HashMap::new()),
             global_write_callbacks: Mutex::new(Vec::new()),
             next_callback_id: AtomicU64::new(0),
@@ -625,6 +976,7 @@ impl Instance {
                 secrets: Some(InstanceSecrets {
                     signing_key: device_key.clone(),
                 }),
+                snapshot_path: Mutex::new(None),
                 write_callbacks: Mutex::new(HashMap::new()),
                 global_write_callbacks: Mutex::new(Vec::new()),
                 next_callback_id: AtomicU64::new(0),
@@ -657,6 +1009,7 @@ impl Instance {
             sync: std::sync::OnceLock::new(),
             metadata,
             secrets: Some(secrets),
+            snapshot_path: Mutex::new(None),
             write_callbacks: Mutex::new(HashMap::new()),
             global_write_callbacks: Mutex::new(Vec::new()),
             next_callback_id: AtomicU64::new(0),
@@ -1382,13 +1735,14 @@ impl WeakInstance {
     ///
     /// # Example
     /// ```
-    /// # use eidetica::{backend::database::InMemory, Instance, NewUser};
+    /// # use eidetica::{Instance, NewUser};
     /// # #[tokio::main]
     /// # async fn main() -> eidetica::Result<()> {
-    /// let (instance, user) = Instance::create(
-    ///     Box::new(InMemory::new()),
+    /// let (instance, maybe_user) = Instance::connect_or_create(
+    ///     "memory://",
     ///     NewUser::passwordless("alice"),
     /// ).await?;
+    /// let user = maybe_user.expect("memory:// is always fresh");
     /// let weak = instance.downgrade();
     ///
     /// // Upgrade works while instance exists
@@ -1406,4 +1760,36 @@ impl WeakInstance {
     pub fn upgrade(&self) -> Option<Instance> {
         self.inner.upgrade().map(|inner| Instance { inner })
     }
+}
+
+// ============ URL-dispatch backend constructors ============
+
+#[cfg(feature = "sqlite")]
+async fn open_sqlite_backend(url: &str) -> Result<Box<dyn BackendImpl>> {
+    let backend = crate::backend::database::Sqlite::connect(url).await?;
+    Ok(Box::new(backend))
+}
+
+#[cfg(not(feature = "sqlite"))]
+async fn open_sqlite_backend(_url: &str) -> Result<Box<dyn BackendImpl>> {
+    Err(InstanceError::BackendUnavailable {
+        scheme: "sqlite",
+        missing_feature: "sqlite",
+    }
+    .into())
+}
+
+#[cfg(feature = "postgres")]
+async fn open_postgres_backend(url: &str) -> Result<Box<dyn BackendImpl>> {
+    let backend = crate::backend::database::Postgres::connect(url).await?;
+    Ok(Box::new(backend))
+}
+
+#[cfg(not(feature = "postgres"))]
+async fn open_postgres_backend(_url: &str) -> Result<Box<dyn BackendImpl>> {
+    Err(InstanceError::BackendUnavailable {
+        scheme: "postgres",
+        missing_feature: "postgres",
+    }
+    .into())
 }

--- a/crates/lib/src/instance/new_user.rs
+++ b/crates/lib/src/instance/new_user.rs
@@ -3,8 +3,8 @@
 //! [`NewUser`] is the request shape for "create a user with these settings",
 //! used in two places:
 //!
-//! - [`Instance::create`](super::Instance::create) and
-//!   [`Instance::open_or_create`](super::Instance::open_or_create) — the
+//! - [`Instance::create_backend`](super::Instance::create_backend) and
+//!   [`Instance::connect_or_create`](super::Instance::connect_or_create) — the
 //!   initial user who bootstraps a fresh instance, automatically granted
 //!   Admin on the system databases by virtue of being the first user.
 //! - [`InstanceAdmin::create_user`](crate::user::InstanceAdmin::create_user) —

--- a/crates/lib/src/instance/tests.rs
+++ b/crates/lib/src/instance/tests.rs
@@ -10,7 +10,7 @@ async fn save_in_memory_backend(instance: &Instance, path: &Path) -> Result<(), 
         .as_any()
         .downcast_ref::<InMemory>()
         .expect("Expected in-memory backend");
-    in_memory.save_to_file(path).await
+    in_memory.save_to_file(path)
 }
 
 async fn load_in_memory_backend(path: &Path) -> Result<InMemory, Error> {
@@ -29,7 +29,7 @@ async fn list_users_via(admin: &User) -> Result<Vec<String>, Error> {
 /// initial admin user. Mirrors the test-harness default and gives every test
 /// a logged-in admin to play with.
 async fn instance_with_admin() -> Result<(Instance, User), Error> {
-    Instance::create(Box::new(InMemory::new()), NewUser::passwordless("admin")).await
+    Instance::create_backend(Box::new(InMemory::new()), NewUser::passwordless("admin")).await
 }
 
 #[tokio::test]
@@ -61,7 +61,7 @@ async fn test_create_user() -> Result<(), Error> {
 #[cfg_attr(miri, ignore)] // Argon2 password hashing is extremely slow under Miri
 async fn test_login_user() -> Result<(), Error> {
     // Bootstrap alice as the initial admin with a password.
-    let (instance, _alice) = Instance::create(
+    let (instance, _alice) = Instance::create_backend(
         Box::new(InMemory::new()),
         NewUser::with_password("alice", "password123"),
     )
@@ -81,7 +81,7 @@ async fn test_login_user() -> Result<(), Error> {
 async fn test_new_database() {
     // Bootstrap "test" as the initial user.
     let (_instance, mut user) =
-        Instance::create(Box::new(InMemory::new()), NewUser::passwordless("test"))
+        Instance::create_backend(Box::new(InMemory::new()), NewUser::passwordless("test"))
             .await
             .expect("Failed to create test instance");
 
@@ -96,7 +96,7 @@ async fn test_new_database() {
 #[tokio::test]
 async fn test_create_database_with_default_settings() {
     let (_instance, mut user) =
-        Instance::create(Box::new(InMemory::new()), NewUser::passwordless("test"))
+        Instance::create_backend(Box::new(InMemory::new()), NewUser::passwordless("test"))
             .await
             .expect("Failed to create test instance");
 
@@ -114,7 +114,7 @@ async fn test_create_database_with_default_settings() {
 #[tokio::test]
 async fn test_new_database_without_key_fails() -> Result<(), Error> {
     let (_instance, mut user) =
-        Instance::create(Box::new(InMemory::new()), NewUser::passwordless("test")).await?;
+        Instance::create_backend(Box::new(InMemory::new()), NewUser::passwordless("test")).await?;
 
     // Database creation requires a valid signing key.
     let mut settings = Doc::new();
@@ -133,7 +133,7 @@ async fn test_instance_load_new_backend() -> Result<(), Error> {
 
     // Initialise a fresh backend with alice as initial user, with an
     // injectable clock for deterministic timestamps.
-    let (_instance, user) = Instance::create_with_clock(
+    let (_instance, user) = Instance::create_backend_with_clock(
         Box::new(InMemory::new()),
         Arc::new(FixedClock::default()),
         NewUser::passwordless("alice"),
@@ -154,7 +154,7 @@ async fn test_instance_load_existing_backend() -> Result<(), Error> {
     let path = temp_dir.join("eidetica_test_instance_load.json");
 
     // Create an instance and user, then save the backend
-    let (instance1, mut user1) = Instance::create_with_clock(
+    let (instance1, mut user1) = Instance::create_backend_with_clock(
         Box::new(InMemory::new()),
         Arc::new(FixedClock::default()),
         NewUser::passwordless("bob"),
@@ -176,11 +176,12 @@ async fn test_instance_load_existing_backend() -> Result<(), Error> {
     drop(instance1);
     drop(user1);
 
-    // Load a new backend from the saved file — Instance::open is load-only
+    // Load a new backend from the saved file — Instance::open_backend is load-only
     // and must find existing metadata.
     let backend2 = load_in_memory_backend(&path).await?;
     let instance2 =
-        Instance::open_with_clock(Box::new(backend2), Arc::new(FixedClock::default())).await?;
+        Instance::open_backend_with_clock(Box::new(backend2), Arc::new(FixedClock::default()))
+            .await?;
 
     // Verify the bob user still exists.
     let bob = instance2.login_user("bob", None).await?;
@@ -209,7 +210,7 @@ async fn test_instance_load_device_id_persistence() -> Result<(), Error> {
 
     // Create instance and get device_id
     let (instance1, _user) =
-        Instance::create(Box::new(InMemory::new()), NewUser::passwordless("admin")).await?;
+        Instance::create_backend(Box::new(InMemory::new()), NewUser::passwordless("admin")).await?;
     let device_id1 = instance1.id().to_string();
 
     // Save backend
@@ -218,7 +219,7 @@ async fn test_instance_load_device_id_persistence() -> Result<(), Error> {
 
     // Load backend and verify device_id is the same
     let backend2 = load_in_memory_backend(&path).await?;
-    let instance2 = Instance::open(Box::new(backend2)).await?;
+    let instance2 = Instance::open_backend(Box::new(backend2)).await?;
     let device_id2 = instance2.id().to_string();
 
     assert_eq!(
@@ -242,7 +243,7 @@ async fn test_instance_load_with_password_protected_users() -> Result<(), Error>
     let path = temp_dir.join("eidetica_test_password_users.json");
 
     // Bootstrap a password-protected user as initial admin.
-    let (instance1, user1) = Instance::create(
+    let (instance1, user1) = Instance::create_backend(
         Box::new(InMemory::new()),
         NewUser::with_password("secure_alice", "secret123"),
     )
@@ -256,7 +257,7 @@ async fn test_instance_load_with_password_protected_users() -> Result<(), Error>
 
     // Reload and verify password still works
     let backend2 = load_in_memory_backend(&path).await?;
-    let instance2 = Instance::open(Box::new(backend2)).await?;
+    let instance2 = Instance::open_backend(Box::new(backend2)).await?;
 
     // Correct password should work
     let user2 = instance2
@@ -321,7 +322,7 @@ async fn test_instance_load_multiple_users() -> Result<(), Error> {
 
     // Reload and verify all users still exist and can login
     let backend2 = load_in_memory_backend(&path).await?;
-    let instance2 = Instance::open(Box::new(backend2)).await?;
+    let instance2 = Instance::open_backend(Box::new(backend2)).await?;
     let admin2 = instance2.login_user("admin", None).await?;
 
     let users = list_users_via(&admin2).await?;
@@ -360,7 +361,7 @@ async fn test_instance_load_user_databases_persist() -> Result<(), Error> {
     let path = temp_dir.join("eidetica_test_user_dbs.json");
 
     // Bootstrap eve as the initial user.
-    let (instance1, mut user1) = Instance::create_with_clock(
+    let (instance1, mut user1) = Instance::create_backend_with_clock(
         Box::new(InMemory::new()),
         Arc::new(FixedClock::default()),
         NewUser::passwordless("eve"),
@@ -394,7 +395,8 @@ async fn test_instance_load_user_databases_persist() -> Result<(), Error> {
     // Reload and verify databases still exist
     let backend2 = load_in_memory_backend(&path).await?;
     let instance2 =
-        Instance::open_with_clock(Box::new(backend2), Arc::new(FixedClock::default())).await?;
+        Instance::open_backend_with_clock(Box::new(backend2), Arc::new(FixedClock::default()))
+            .await?;
     let user2 = instance2.login_user("eve", None).await?;
 
     // Load databases by root_id and verify their settings
@@ -426,7 +428,7 @@ async fn test_instance_load_idempotency() -> Result<(), Error> {
     let path = temp_dir.join("eidetica_test_idempotency.json");
 
     // Create and save initial state
-    let (instance1, _frank) = Instance::create_with_clock(
+    let (instance1, _frank) = Instance::create_backend_with_clock(
         Box::new(InMemory::new()),
         Arc::new(FixedClock::default()),
         NewUser::passwordless("frank"),
@@ -441,7 +443,8 @@ async fn test_instance_load_idempotency() -> Result<(), Error> {
     for i in 0..3 {
         let backend = load_in_memory_backend(&path).await?;
         let instance =
-            Instance::open_with_clock(Box::new(backend), Arc::new(FixedClock::default())).await?;
+            Instance::open_backend_with_clock(Box::new(backend), Arc::new(FixedClock::default()))
+                .await?;
 
         // Device ID should be the same every time
         let device_id = instance.id().to_string();
@@ -479,7 +482,7 @@ async fn test_instance_load_new_vs_existing() -> Result<(), Error> {
     let path = temp_dir.join("eidetica_test_new_vs_existing.json");
 
     // Create first instance with grace as initial user.
-    let (instance1, _grace) = Instance::create_with_clock(
+    let (instance1, _grace) = Instance::create_backend_with_clock(
         Box::new(InMemory::new()),
         Arc::new(FixedClock::default()),
         NewUser::passwordless("grace"),
@@ -493,7 +496,8 @@ async fn test_instance_load_new_vs_existing() -> Result<(), Error> {
     // Load existing backend
     let backend2 = load_in_memory_backend(&path).await?;
     let instance2 =
-        Instance::open_with_clock(Box::new(backend2), Arc::new(FixedClock::default())).await?;
+        Instance::open_backend_with_clock(Box::new(backend2), Arc::new(FixedClock::default()))
+            .await?;
     let device_id2 = instance2.id().to_string();
 
     // Device ID should match (existing backend)
@@ -507,7 +511,7 @@ async fn test_instance_load_new_vs_existing() -> Result<(), Error> {
     drop(instance2);
 
     // Create a separate fresh instance (different backend) — distinct device id.
-    let (instance3, henry) = Instance::create_with_clock(
+    let (instance3, henry) = Instance::create_backend_with_clock(
         Box::new(InMemory::new()),
         Arc::new(FixedClock::default()),
         NewUser::passwordless("henry"),
@@ -534,14 +538,14 @@ async fn test_instance_load_new_vs_existing() -> Result<(), Error> {
 #[tokio::test]
 #[cfg_attr(miri, ignore)] // Uses file I/O which Miri doesn't support
 async fn test_instance_create_strict_fails_on_existing() -> Result<(), Error> {
-    // Test that Instance::create() fails on already-initialized backend.
+    // Test that Instance::create_backend() fails on already-initialized backend.
     use crate::clock::FixedClock;
 
     let temp_dir = std::env::temp_dir();
     let path = temp_dir.join("eidetica_test_create_strict.json");
 
     // Create first instance with alice as initial user.
-    let (instance1, _alice) = Instance::create_with_clock(
+    let (instance1, _alice) = Instance::create_backend_with_clock(
         Box::new(InMemory::new()),
         Arc::new(FixedClock::default()),
         NewUser::passwordless("alice"),
@@ -554,7 +558,7 @@ async fn test_instance_create_strict_fails_on_existing() -> Result<(), Error> {
 
     // Try to create() on the existing backend - should fail.
     let backend2 = load_in_memory_backend(&path).await?;
-    let result = Instance::create(Box::new(backend2), NewUser::passwordless("bob")).await;
+    let result = Instance::create_backend(Box::new(backend2), NewUser::passwordless("bob")).await;
     assert!(result.is_err(), "create() should fail on existing backend");
 
     // Verify error type
@@ -572,7 +576,8 @@ async fn test_instance_create_strict_fails_on_existing() -> Result<(), Error> {
     // Verify open() still works on the existing backend.
     let backend3 = load_in_memory_backend(&path).await?;
     let instance3 =
-        Instance::open_with_clock(Box::new(backend3), Arc::new(FixedClock::default())).await?;
+        Instance::open_backend_with_clock(Box::new(backend3), Arc::new(FixedClock::default()))
+            .await?;
     let alice = instance3.login_user("alice", None).await?;
     let users = list_users_via(&alice).await?;
     assert_eq!(users.len(), 1, "Should have 1 user (alice)");
@@ -589,9 +594,9 @@ async fn test_instance_create_strict_fails_on_existing() -> Result<(), Error> {
 #[tokio::test]
 #[cfg_attr(miri, ignore)] // Uses SystemTime for timestamps in create_user
 async fn test_instance_create_on_fresh_backend() -> Result<(), Error> {
-    // Test that Instance::create() succeeds on fresh backend.
+    // Test that Instance::create_backend() succeeds on fresh backend.
     let (instance, bob) =
-        Instance::create(Box::new(InMemory::new()), NewUser::passwordless("bob")).await?;
+        Instance::create_backend(Box::new(InMemory::new()), NewUser::passwordless("bob")).await?;
     assert_eq!(bob.username(), "bob");
 
     // Bob can immediately log back in.
@@ -603,10 +608,10 @@ async fn test_instance_create_on_fresh_backend() -> Result<(), Error> {
 
 #[tokio::test]
 async fn test_instance_open_fails_on_empty_backend() -> Result<(), Error> {
-    // `Instance::open` is load-only. An empty backend must error with
+    // `Instance::open_backend` is load-only. An empty backend must error with
     // NotInitialized rather than auto-bootstrapping.
     let backend = InMemory::new();
-    let result = Instance::open(Box::new(backend)).await;
+    let result = Instance::open_backend(Box::new(backend)).await;
     let err = result.expect_err("open() must reject an uninitialised backend");
 
     if let crate::Error::Instance(boxed) = &err {
@@ -622,13 +627,288 @@ async fn test_instance_open_fails_on_empty_backend() -> Result<(), Error> {
 
 #[tokio::test]
 #[cfg_attr(miri, ignore)] // Uses file I/O which Miri doesn't support
+async fn test_memory_url_snapshot_round_trip_via_flush() -> Result<(), Error> {
+    // Verifies the `memory:///path.json` URL roundtrip: bootstrap, write
+    // snapshot via flush(), reload from snapshot, login as the persisted
+    // user. Exercises the URL dispatcher, the snapshot path tracking, and
+    // `Instance::flush`.
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let snapshot = temp_dir.path().join("snap.json");
+    let url = format!("memory://{}", snapshot.display());
+
+    // First run: file doesn't exist yet → bootstrap fresh, persist on flush.
+    let (instance, alice) =
+        Instance::connect_or_create(&url, NewUser::passwordless("alice")).await?;
+    let alice = alice.expect("memory:// URL with new snapshot path should bootstrap");
+    assert_eq!(alice.username(), "alice");
+    drop(alice);
+    instance.flush()?;
+    assert!(
+        snapshot.exists(),
+        "flush() should have written the snapshot"
+    );
+    // The instance is still fully usable after flush — flush is a
+    // checkpoint, not a shutdown.
+    let _ = instance.login_user("alice", None).await?;
+    drop(instance);
+
+    // Second run: file exists → load and yield None for the user.
+    let (instance2, maybe_user) =
+        Instance::connect_or_create(&url, NewUser::passwordless("alice")).await?;
+    assert!(
+        maybe_user.is_none(),
+        "load arm should not produce a fresh user"
+    );
+    let alice2 = instance2.login_user("alice", None).await?;
+    assert_eq!(alice2.username(), "alice");
+    drop(alice2);
+
+    // Flushing again with no new writes still leaves a valid snapshot.
+    instance2.flush()?;
+    assert!(snapshot.exists());
+
+    Ok(())
+}
+
+#[tokio::test]
+#[cfg_attr(miri, ignore)] // Uses file I/O which Miri doesn't support
+async fn test_flush_surfaces_io_error() -> Result<(), Error> {
+    // flush() must surface I/O errors via Result. Drop's safety net will
+    // fail the same way and log via tracing::error!; we don't observe Drop
+    // here — the contract is just "flush returns the error".
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let bad_path = temp_dir.path().join("missing-dir").join("snap.json");
+    let url = format!("memory://{}", bad_path.display());
+
+    let (instance, alice) =
+        Instance::connect_or_create(&url, NewUser::passwordless("alice")).await?;
+    let _ = alice.expect("fresh bootstrap");
+
+    let flush_err = instance.flush().expect_err("flush should fail");
+    // Walk the source chain to confirm the underlying cause is an I/O error;
+    // the top-level Display is the BackendError shell ("File I/O error")
+    // and doesn't include the underlying message.
+    let mut found_io = false;
+    let mut src: Option<&(dyn std::error::Error + 'static)> = Some(&flush_err);
+    while let Some(e) = src {
+        if e.downcast_ref::<std::io::Error>().is_some() {
+            found_io = true;
+            break;
+        }
+        src = e.source();
+    }
+    assert!(
+        found_io,
+        "expected an underlying io::Error in the chain, got: {flush_err}",
+    );
+    // Sanity: the file we tried to write is still absent.
+    assert!(!bad_path.exists(), "snapshot file should not exist");
+    Ok(())
+}
+
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn test_memory_url_drop_fallback_writes_snapshot() -> Result<(), Error> {
+    // Verifies the Drop fallback: if the caller drops without calling
+    // flush(), the snapshot is still written (best-effort, errors logged).
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let snapshot = temp_dir.path().join("drop-snap.json");
+    let url = format!("memory://{}", snapshot.display());
+
+    let (instance, alice) =
+        Instance::connect_or_create(&url, NewUser::passwordless("alice")).await?;
+    let _ = alice.expect("fresh bootstrap");
+    // Drop instance and the user (drop the User first so its Instance handle
+    // releases). No flush() — we exercise the Drop path.
+    drop(instance);
+
+    assert!(
+        snapshot.exists(),
+        "Drop fallback should have written the snapshot"
+    );
+    // Snapshot should round-trip: opening with strict `connect` succeeds.
+    let _reloaded = Instance::connect(&url).await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[cfg_attr(miri, ignore)] // Uses file I/O which Miri doesn't support
+async fn test_connect_or_create_rejects_foreign_data() -> Result<(), Error> {
+    // A pre-existing JSON file that parses into `SerializableDatabase` but
+    // carries no instance metadata must not be silently bootstrapped over —
+    // the next snapshot would overwrite the caller's file. Documents the
+    // safety contract called out in connect_or_create_impl.
+    let temp_dir = tempfile::tempdir().unwrap();
+    let snapshot = temp_dir.path().join("foreign.json");
+    std::fs::write(
+        &snapshot,
+        r#"{"entries":{},"verification_status":{},"tips":{}}"#,
+    )
+    .unwrap();
+
+    let url = format!("memory://{}", snapshot.display());
+    let err = Instance::connect_or_create(&url, NewUser::passwordless("alice"))
+        .await
+        .expect_err("foreign data must not be bootstrapped over");
+    let msg = format!("{err}");
+    assert!(msg.contains("foreign data"), "{msg}");
+    assert!(msg.contains("snapshot file"), "{msg}");
+    // File must be unchanged — refusal is the whole point.
+    let on_disk = std::fs::read_to_string(&snapshot).unwrap();
+    assert!(on_disk.contains("\"entries\""), "{on_disk}");
+    Ok(())
+}
+
+#[tokio::test]
+#[cfg_attr(miri, ignore)] // Uses file I/O which Miri doesn't support
+async fn test_connect_strict_missing_snapshot_errors() -> Result<(), Error> {
+    // Strict `connect` against a snapshot URL whose file doesn't exist must
+    // surface `InvalidSnapshot` with a message pointing at `connect_or_create`,
+    // not the generic `NotInitialized` an empty backend would otherwise produce.
+    let temp_dir = tempfile::tempdir().unwrap();
+    let missing = temp_dir.path().join("not-there.json");
+    let url = format!("memory://{}", missing.display());
+
+    let err = Instance::connect(&url)
+        .await
+        .expect_err("missing snapshot must error");
+    let msg = format!("{err}");
+    assert!(msg.contains("does not exist"), "{msg}");
+    assert!(msg.contains("connect_or_create"), "{msg}");
+    assert!(
+        !missing.exists(),
+        "strict connect must not create the snapshot file"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+#[cfg_attr(miri, ignore)] // Uses file I/O which Miri doesn't support
+async fn test_flush_keeps_snapshot_armed_for_drop() -> Result<(), Error> {
+    // `flush()` is reentrant: it must NOT take/clear the snapshot path, so
+    // the Drop safety net still fires after a successful flush. We prove
+    // this by flushing, deleting the on-disk file, then dropping — the
+    // file must reappear (Drop rewrote it).
+    let temp_dir = tempfile::tempdir().unwrap();
+    let snapshot = temp_dir.path().join("rearm.json");
+    let url = format!("memory://{}", snapshot.display());
+
+    let (instance, alice) =
+        Instance::connect_or_create(&url, NewUser::passwordless("alice")).await?;
+    drop(alice.expect("fresh bootstrap"));
+
+    instance.flush()?;
+    assert!(snapshot.exists(), "flush should have written the snapshot");
+
+    std::fs::remove_file(&snapshot).unwrap();
+    assert!(!snapshot.exists(), "precondition: file should be gone");
+
+    drop(instance);
+
+    assert!(
+        snapshot.exists(),
+        "Drop must rewrite snapshot — the path stays armed after flush()"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+#[cfg_attr(miri, ignore)] // Uses file I/O which Miri doesn't support
+async fn test_roundtrip_after_flush() -> Result<(), Error> {
+    // Round-trip via explicit flush() (rather than relying on the Drop
+    // fallback as `test_memory_url_drop_fallback_writes_snapshot` does).
+    // Confirms the load arm of strict `connect` finds metadata that
+    // `flush()` wrote.
+    let temp_dir = tempfile::tempdir().unwrap();
+    let snapshot = temp_dir.path().join("roundtrip.json");
+    let url = format!("memory://{}", snapshot.display());
+
+    let initial_device_id = {
+        let (instance, alice) =
+            Instance::connect_or_create(&url, NewUser::passwordless("alice")).await?;
+        drop(alice.expect("fresh bootstrap"));
+        instance.flush()?;
+        // Drop after this scope — but we already have the persisted state.
+        instance.id().to_string()
+    };
+
+    let reloaded = Instance::connect(&url).await?;
+    assert_eq!(
+        reloaded.id().to_string(),
+        initial_device_id,
+        "device id must survive flush + reload"
+    );
+    // The persisted user is still there.
+    let alice = reloaded.login_user("alice", None).await?;
+    assert_eq!(alice.username(), "alice");
+    Ok(())
+}
+
+#[tokio::test]
+#[cfg_attr(miri, ignore)] // Uses file I/O which Miri doesn't support
+async fn test_concurrent_flushes_are_serialized() -> Result<(), Error> {
+    // Many concurrent flush() calls must all succeed and leave a valid
+    // snapshot on disk. Without the snapshot_write_lock they would race
+    // on the shared `<path>.tmp`; the test fails by either returning an
+    // error from one of the flushes or leaving a corrupted snapshot that
+    // a subsequent `connect` can't load.
+    let temp_dir = tempfile::tempdir().unwrap();
+    let snapshot = temp_dir.path().join("concurrent.json");
+    let url = format!("memory://{}", snapshot.display());
+
+    let (instance, alice) =
+        Instance::connect_or_create(&url, NewUser::passwordless("alice")).await?;
+    drop(alice.expect("fresh bootstrap"));
+
+    let mut handles = Vec::with_capacity(16);
+    for _ in 0..16 {
+        let inst = instance.clone();
+        // `flush()` is sync (std::fs::write + a std::sync::Mutex held
+        // across the I/O), so we contend across blocking threads rather
+        // than awaiting in async tasks.
+        handles.push(tokio::task::spawn_blocking(move || inst.flush()));
+    }
+    for handle in handles {
+        handle
+            .await
+            .expect("flush task panicked")
+            .expect("concurrent flush failed");
+    }
+
+    // No leftover staging tempfile.
+    let mut tmp_path = snapshot.clone().into_os_string();
+    tmp_path.push(".tmp");
+    assert!(
+        !std::path::Path::new(&tmp_path).exists(),
+        "staging file `{}` should be cleaned up after the last rename",
+        std::path::Path::new(&tmp_path).display()
+    );
+
+    // Drop the instance so its own Drop-time write happens before reload.
+    drop(instance);
+
+    // The on-disk snapshot must still be a well-formed, fully-initialised
+    // instance.
+    let reloaded = Instance::connect(&url).await?;
+    let _alice = reloaded.login_user("alice", None).await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[cfg_attr(miri, ignore)] // Uses file I/O which Miri doesn't support
 async fn test_open_or_create_fresh_and_existing() -> Result<(), Error> {
     let temp_dir = std::env::temp_dir();
     let path = temp_dir.join("eidetica_test_open_or_create.json");
 
     // Fresh: should return Some(User) for the just-created initial user.
-    let (instance1, maybe_user) =
-        Instance::open_or_create(Box::new(InMemory::new()), NewUser::passwordless("alice")).await?;
+    let (instance1, maybe_user) = Instance::connect_or_create_backend(
+        Box::new(InMemory::new()),
+        NewUser::passwordless("alice"),
+    )
+    .await?;
     let alice = maybe_user.expect("fresh backend should yield the initial user");
     assert_eq!(alice.username(), "alice");
 
@@ -638,7 +918,7 @@ async fn test_open_or_create_fresh_and_existing() -> Result<(), Error> {
 
     // Existing: should return None (caller logs in explicitly).
     let backend2 = load_in_memory_backend(&path).await?;
-    let (instance2, maybe_user) = Instance::open_or_create(
+    let (instance2, maybe_user) = Instance::connect_or_create_backend(
         Box::new(backend2),
         // The supplied NewUser is unused on the existing-instance branch;
         // we still have to provide one because the signature requires it.
@@ -659,5 +939,25 @@ async fn test_open_or_create_fresh_and_existing() -> Result<(), Error> {
         std::fs::remove_file(&path).ok();
     }
 
+    Ok(())
+}
+
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn test_sqlite_in_memory_url_round_trip() -> Result<(), Error> {
+    // sqlx's URI-filename form is the canonical in-memory sqlite URL.
+    // Verifies the URL parser accepts the single-colon form and the
+    // backend's `is_in_memory` detection sees `:memory:`, so the pool
+    // keeps a connection alive long enough for the round trip.
+    let url = "sqlite:file::memory:?cache=shared";
+    let (instance, alice) =
+        Instance::connect_or_create(url, NewUser::passwordless("alice")).await?;
+    let alice = alice.expect("fresh in-memory sqlite should bootstrap");
+    assert_eq!(alice.username(), "alice");
+
+    // Schema setup + a real login round-trip across pool connections.
+    let alice2 = instance.login_user("alice", None).await?;
+    assert_eq!(alice2.username(), "alice");
     Ok(())
 }

--- a/crates/lib/src/instance/url.rs
+++ b/crates/lib/src/instance/url.rs
@@ -1,0 +1,499 @@
+//! Parser for eidetica connection URLs.
+//!
+//! Eidetica has one connection-string entry point that dispatches across all
+//! supported backends and the daemon socket:
+//!
+//! - `sqlite://./app.db` — embedded eidetica with the sqlite backend; URL is
+//!   handed through to `sqlx::sqlite` unchanged after the scheme check, so
+//!   any sqlx-accepted form works (relative path, `?mode=rwc&journal_mode=WAL`,
+//!   etc.).
+//! - `postgres://user:pwd@host/db` — embedded eidetica with the postgres
+//!   backend; URL is handed through to `sqlx::postgres` unchanged.
+//! - `unix:///absolute/socket/path` — thin client to a running eidetica
+//!   daemon. Path must be absolute; query strings and fragments are
+//!   rejected.
+//! - `memory://` — ephemeral in-process backend.
+//! - `memory:///absolute/path/snapshot.json` — in-process backend with a
+//!   JSON snapshot file (load-on-start, snapshot on `Instance::flush` /
+//!   best-effort on `Drop`).
+//!
+//! Schemes are matched case-insensitively per RFC 3986 (`SQLITE://`,
+//! `Sqlite://`, and `sqlite://` are all accepted). The scheme portion of
+//! the URL passed through to sqlx is normalised to lowercase so backends
+//! that demand a lowercase scheme don't reject it.
+//!
+//! `sqlite:` and `postgres:`/`postgresql:` also accept the single-colon
+//! URI form (`sqlite:file::memory:?cache=shared`, `sqlite:./app.db`) that
+//! sqlx natively understands. This is required for sqlx's in-memory URLs:
+//! the `://` variant triggers URL authority parsing in sqlx and rejects
+//! `:memory:` as a port number. `unix:` and `memory:` keep the strict
+//! `://` requirement so their typo hints still fire on `unix:/run/sock`.
+//!
+//! Schemes that aren't recognised return [`InstanceError::UnsupportedScheme`]
+//! with a typo hint when possible (`mysql://` → suggests `postgres://`).
+//! URLs missing the `scheme://` separator return [`InstanceError::InvalidUrl`]
+//! with a hint guessing at `sqlite://`.
+
+use std::path::PathBuf;
+
+use crate::Result;
+
+use super::errors::InstanceError;
+
+/// Parsed connection URL.
+///
+/// Schemes that delegate to sqlx (`sqlite`, `postgres`) carry the original
+/// URL string and let sqlx do the detailed parsing — this keeps eidetica from
+/// shadowing sqlx's `?param` surface and matches the user-facing expectation
+/// of "the URL after the scheme prefix means whatever sqlx says it means."
+#[derive(Debug, Clone)]
+pub(crate) enum ConnectionUrl {
+    /// `sqlite://...` — full URL handed through to sqlx
+    #[cfg_attr(not(feature = "sqlite"), allow(dead_code))]
+    Sqlite { url: String },
+    /// `postgres://...` — full URL handed through to sqlx
+    #[cfg_attr(not(feature = "postgres"), allow(dead_code))]
+    Postgres { url: String },
+    /// `unix:///path/to/sock` — absolute socket path.
+    #[cfg_attr(not(all(unix, feature = "service")), allow(dead_code))]
+    Unix { socket_path: PathBuf },
+    /// `memory://` or `memory:///path/to/snapshot.json`.
+    Memory { snapshot_path: Option<PathBuf> },
+}
+
+/// Parse an eidetica connection URL.
+///
+/// Returns a structured [`ConnectionUrl`] that the `Instance` dispatcher can
+/// switch on. Errors are [`InstanceError::InvalidUrl`] for malformed input
+/// (with a hint where possible) and [`InstanceError::UnsupportedScheme`] for
+/// recognised-but-typoed schemes (e.g. `mysql://`).
+pub(crate) fn parse(url: &str) -> Result<ConnectionUrl> {
+    if url.is_empty() {
+        return Err(InstanceError::InvalidUrl {
+            url: String::new(),
+            reason: "URL is empty; expected something like `sqlite://./app.db`, \
+                     `postgres://user@host/db`, `unix:///run/eidetica/sock`, or `memory://`"
+                .into(),
+        }
+        .into());
+    }
+
+    let Some((scheme_raw, rest, sep)) = split_scheme(url) else {
+        return Err(missing_scheme_error(url));
+    };
+
+    // RFC 3986: schemes are case-insensitive. Normalise to lowercase and
+    // rebuild so sqlx sees a lowercase prefix. The `rest` is left
+    // untouched (paths and query strings are case-sensitive). Preserve
+    // whichever separator the caller used — `sqlite:` and `sqlite://`
+    // aren't interchangeable for sqlx's in-memory URLs.
+    let scheme = scheme_raw.to_ascii_lowercase();
+    let normalised = format!("{scheme}{sep}{rest}");
+
+    match scheme.as_str() {
+        "sqlite" => Ok(ConnectionUrl::Sqlite { url: normalised }),
+        "postgres" | "postgresql" => Ok(ConnectionUrl::Postgres { url: normalised }),
+        "unix" => parse_unix(url, rest),
+        "memory" => parse_memory(url, rest),
+        // Common typos / unrelated DB URLs people might paste in.
+        "mysql" | "mariadb" => unsupported(scheme, Some("postgres")),
+        "tcp" | "http" | "https" | "ws" | "wss" => unsupported(scheme, Some("unix")),
+        "file" => unsupported(scheme, Some("sqlite")),
+        _ => unsupported(scheme, None),
+    }
+}
+
+/// Split `url` into `(scheme, rest, separator)`.
+///
+/// Prefers `scheme://...` (the standard form for all four backends). Falls
+/// back to single-colon `scheme:...` only for sqlx-backed schemes — sqlx
+/// accepts both prefixes natively and needs the single-colon form for its
+/// in-memory URLs (`sqlite:file::memory:?cache=shared`). `unix:` and
+/// `memory:` intentionally don't get the fallback so their slash-typo
+/// hints (`unix:/run/sock`) keep firing.
+fn split_scheme(url: &str) -> Option<(&str, &str, &'static str)> {
+    if let Some((s, r)) = url.split_once("://") {
+        return Some((s, r, "://"));
+    }
+    let (s, r) = url.split_once(':')?;
+    matches!(
+        s.to_ascii_lowercase().as_str(),
+        "sqlite" | "postgres" | "postgresql"
+    )
+    .then_some((s, r, ":"))
+}
+
+fn missing_scheme_error(url: &str) -> crate::Error {
+    // Common typo: `unix:/path` (single slash) or just a bare path.
+    // Match case-insensitively so `UNIX:/path` still gets the hint.
+    let lower = url.to_ascii_lowercase();
+    let hint = if let Some(stripped) = lower.strip_prefix("unix:") {
+        format!(
+            "`unix://` requires two slashes plus an absolute path; did you mean `unix://{stripped}`?"
+        )
+    } else if url.starts_with('/') || url.starts_with("./") || url.ends_with(".db") {
+        format!("missing scheme; did you mean `sqlite://{url}`?")
+    } else {
+        "URL is missing the `scheme://` separator (expected `sqlite://`, `postgres://`, \
+         `unix://`, or `memory://`)"
+            .to_string()
+    };
+    InstanceError::InvalidUrl {
+        url: url.to_string(),
+        reason: hint,
+    }
+    .into()
+}
+
+fn unsupported(scheme: String, suggested: Option<&'static str>) -> Result<ConnectionUrl> {
+    Err(InstanceError::UnsupportedScheme { scheme, suggested }.into())
+}
+
+/// Shared validation for the absolute-path schemes (`unix://`, `memory://`).
+///
+/// Rejects query strings and fragments — both schemes describe a local path
+/// and have no use for HTTP-style decorations.
+fn reject_query_or_fragment(scheme: &'static str, original: &str, rest: &str) -> Result<()> {
+    if rest.contains('?') {
+        return Err(InstanceError::InvalidUrl {
+            url: original.to_string(),
+            reason: format!("`{scheme}://` does not support query strings"),
+        }
+        .into());
+    }
+    if rest.contains('#') {
+        return Err(InstanceError::InvalidUrl {
+            url: original.to_string(),
+            reason: format!("`{scheme}://` does not support fragments"),
+        }
+        .into());
+    }
+    Ok(())
+}
+
+fn parse_unix(original: &str, rest: &str) -> Result<ConnectionUrl> {
+    // `unix://` only describes a local absolute path to a Unix socket file.
+    // No hostname, no query, no fragment.
+    if rest.is_empty() {
+        return Err(InstanceError::InvalidUrl {
+            url: original.to_string(),
+            reason: "`unix://` requires an absolute socket path (e.g. \
+                     `unix:///run/eidetica/service.sock`)"
+                .into(),
+        }
+        .into());
+    }
+    if !rest.starts_with('/') {
+        // Ambiguous: `unix://run/sock` could be either a slash typo (meant
+        // `unix:///run/sock`) or an RFC-3986-style attempt at an authority
+        // (meant `unix:///sock`, treating `run` as a hostname). Unix
+        // sockets have no hostname concept — the kernel identifies them
+        // by filesystem path — so we surface both interpretations and
+        // explain rather than guess.
+        let forgot_slash_hint = format!("unix:///{rest}");
+        let dropped_host_hint = match rest.split_once('/') {
+            Some((_, after)) if !after.is_empty() => format!("unix:///{after}"),
+            _ => "unix:///path/to/sock".to_string(),
+        };
+        return Err(InstanceError::InvalidUrl {
+            url: original.to_string(),
+            reason: format!(
+                "`unix://` path must be absolute (start with `/`); got `{rest}`. \
+                 Two common causes: (1) a slash typo — if you meant the socket file \
+                 at `/{rest}`, use `{forgot_slash_hint}`; (2) treating `unix://` like \
+                 an HTTP URL with an authority — Unix sockets have no hostname (the \
+                 kernel identifies them by filesystem path only), so drop the host \
+                 segment and use `{dropped_host_hint}` instead."
+            ),
+        }
+        .into());
+    }
+    reject_query_or_fragment("unix", original, rest)?;
+    Ok(ConnectionUrl::Unix {
+        socket_path: PathBuf::from(rest),
+    })
+}
+
+fn parse_memory(original: &str, rest: &str) -> Result<ConnectionUrl> {
+    // `memory://` (no path) → ephemeral.
+    // `memory:///absolute/path.json` → load-on-start + snapshot target.
+    if rest.is_empty() {
+        return Ok(ConnectionUrl::Memory {
+            snapshot_path: None,
+        });
+    }
+    if !rest.starts_with('/') {
+        return Err(InstanceError::InvalidUrl {
+            url: original.to_string(),
+            reason: format!(
+                "`memory://` snapshot path must be absolute (start with `/`); got `{rest}`. \
+                 Use `memory://` for ephemeral state, or `memory:///{rest}` for a snapshot path."
+            ),
+        }
+        .into());
+    }
+    // `memory:///` and `memory:////...` aren't usable snapshot targets —
+    // the path resolves to `/` (a directory) and the I/O failure later
+    // would be cryptic. Reject up front.
+    if rest == "/" || rest.starts_with("//") {
+        return Err(InstanceError::InvalidUrl {
+            url: original.to_string(),
+            reason: "`memory://` snapshot path must name a file (e.g. \
+                     `memory:///var/lib/eidetica/snap.json`); got an empty or root path. \
+                     Use `memory://` for an ephemeral in-memory instance with no snapshot."
+                .into(),
+        }
+        .into());
+    }
+    reject_query_or_fragment("memory", original, rest)?;
+    Ok(ConnectionUrl::Memory {
+        snapshot_path: Some(PathBuf::from(rest)),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_sqlite() {
+        match parse("sqlite://./app.db").unwrap() {
+            ConnectionUrl::Sqlite { url } => assert_eq!(url, "sqlite://./app.db"),
+            other => panic!("expected sqlite, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_sqlite_single_colon_uri_form() {
+        // sqlx's native in-memory URL uses single-colon URI form because the
+        // `://` variant triggers URL authority parsing in sqlx and rejects
+        // `:memory:` as an invalid port. We pass these through unchanged.
+        match parse("sqlite:file::memory:?cache=shared").unwrap() {
+            ConnectionUrl::Sqlite { url } => {
+                assert_eq!(url, "sqlite:file::memory:?cache=shared")
+            }
+            other => panic!("expected sqlite, got {other:?}"),
+        }
+        match parse("sqlite:./app.db").unwrap() {
+            ConnectionUrl::Sqlite { url } => assert_eq!(url, "sqlite:./app.db"),
+            other => panic!("expected sqlite, got {other:?}"),
+        }
+        match parse("postgres:user@host/db").unwrap() {
+            ConnectionUrl::Postgres { url } => assert_eq!(url, "postgres:user@host/db"),
+            other => panic!("expected postgres, got {other:?}"),
+        }
+        // Case-insensitive scheme even on the single-colon form.
+        match parse("SQLITE:file::memory:?cache=shared").unwrap() {
+            ConnectionUrl::Sqlite { url } => {
+                assert_eq!(url, "sqlite:file::memory:?cache=shared")
+            }
+            other => panic!("expected sqlite, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_postgres_and_postgresql_aliases() {
+        match parse("postgres://u@h/db").unwrap() {
+            ConnectionUrl::Postgres { url } => assert_eq!(url, "postgres://u@h/db"),
+            other => panic!("expected postgres, got {other:?}"),
+        }
+        match parse("postgresql://u@h/db").unwrap() {
+            ConnectionUrl::Postgres { url } => assert_eq!(url, "postgresql://u@h/db"),
+            other => panic!("expected postgres, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn scheme_is_case_insensitive() {
+        // Upper- and mixed-case scheme names should match and be
+        // normalised to lowercase in the URL handed through to sqlx.
+        match parse("SQLITE://./app.db").unwrap() {
+            ConnectionUrl::Sqlite { url } => assert_eq!(url, "sqlite://./app.db"),
+            other => panic!("expected sqlite, got {other:?}"),
+        }
+        match parse("Postgres://u@h/db").unwrap() {
+            ConnectionUrl::Postgres { url } => assert_eq!(url, "postgres://u@h/db"),
+            other => panic!("expected postgres, got {other:?}"),
+        }
+        match parse("UNIX:///run/sock").unwrap() {
+            ConnectionUrl::Unix { socket_path } => {
+                assert_eq!(socket_path, PathBuf::from("/run/sock"));
+            }
+            other => panic!("expected unix, got {other:?}"),
+        }
+        match parse("Memory://").unwrap() {
+            ConnectionUrl::Memory { snapshot_path } => assert!(snapshot_path.is_none()),
+            other => panic!("expected memory, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn path_case_is_preserved_when_scheme_is_lowercased() {
+        // The scheme is case-insensitive (RFC 3986) but paths, hostnames,
+        // query strings, and filenames are case-sensitive on most
+        // filesystems and on the wire. Only the scheme prefix should
+        // change when we normalise.
+        match parse("SQLITE://./MyApp.DB").unwrap() {
+            ConnectionUrl::Sqlite { url } => assert_eq!(url, "sqlite://./MyApp.DB"),
+            other => panic!("expected sqlite, got {other:?}"),
+        }
+        // Single-colon URI form: same rule — only the scheme prefix
+        // changes, the rest passes through verbatim.
+        match parse("SQLITE:file:Mixed-Case.db?Cache=Shared").unwrap() {
+            ConnectionUrl::Sqlite { url } => {
+                assert_eq!(url, "sqlite:file:Mixed-Case.db?Cache=Shared")
+            }
+            other => panic!("expected sqlite, got {other:?}"),
+        }
+        match parse("Postgres://User:Pass@Host.Example/MyDB").unwrap() {
+            ConnectionUrl::Postgres { url } => {
+                assert_eq!(url, "postgres://User:Pass@Host.Example/MyDB")
+            }
+            other => panic!("expected postgres, got {other:?}"),
+        }
+        match parse("UNIX:///Run/MyDaemon.SOCK").unwrap() {
+            ConnectionUrl::Unix { socket_path } => {
+                assert_eq!(socket_path, PathBuf::from("/Run/MyDaemon.SOCK"));
+            }
+            other => panic!("expected unix, got {other:?}"),
+        }
+        match parse("MEMORY:///Var/Lib/MyApp/Snap.JSON").unwrap() {
+            ConnectionUrl::Memory { snapshot_path } => {
+                assert_eq!(
+                    snapshot_path,
+                    Some(PathBuf::from("/Var/Lib/MyApp/Snap.JSON"))
+                );
+            }
+            other => panic!("expected memory, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_unix_absolute_path() {
+        match parse("unix:///run/eidetica/sock").unwrap() {
+            ConnectionUrl::Unix { socket_path } => {
+                assert_eq!(socket_path, PathBuf::from("/run/eidetica/sock"));
+            }
+            other => panic!("expected unix, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_unix_relative_path() {
+        // The hint should surface both interpretations: the slash-typo
+        // form (`unix:///run/sock`) and the dropped-host form
+        // (`unix:///sock`). Either could be what the user meant.
+        let err = parse("unix://run/sock").unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("unix:///run/sock"), "{msg}");
+        assert!(msg.contains("unix:///sock"), "{msg}");
+        assert!(msg.contains("no hostname"), "{msg}");
+    }
+
+    #[test]
+    fn rejects_unix_relative_no_subpath() {
+        // `unix://host` has no `/` after the host, so the dropped-host
+        // suggestion falls back to a generic placeholder.
+        let err = parse("unix://host").unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("unix:///host"), "{msg}");
+        assert!(msg.contains("/path/to/sock"), "{msg}");
+    }
+
+    #[test]
+    fn rejects_unix_empty_path() {
+        let err = parse("unix://").unwrap_err();
+        assert!(format!("{err}").contains("requires an absolute"), "{err}");
+    }
+
+    #[test]
+    fn rejects_unix_query_and_fragment() {
+        assert!(parse("unix:///s?foo=bar").is_err());
+        assert!(parse("unix:///s#frag").is_err());
+    }
+
+    #[test]
+    fn parses_memory_ephemeral() {
+        match parse("memory://").unwrap() {
+            ConnectionUrl::Memory { snapshot_path } => assert!(snapshot_path.is_none()),
+            other => panic!("expected memory, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_memory_with_snapshot_path() {
+        match parse("memory:///var/lib/snap.json").unwrap() {
+            ConnectionUrl::Memory { snapshot_path } => {
+                assert_eq!(snapshot_path, Some(PathBuf::from("/var/lib/snap.json")));
+            }
+            other => panic!("expected memory, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_memory_relative_snapshot() {
+        let err = parse("memory://./snap.json").unwrap_err();
+        assert!(format!("{err}").contains("absolute"), "{err}");
+    }
+
+    #[test]
+    fn rejects_memory_root_snapshot() {
+        // `memory:///` resolves to `/` — a directory, not a snapshot file.
+        let err = parse("memory:///").unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("must name a file"), "{msg}");
+        // The double-slash form is a common mistake; reject the same way.
+        let err = parse("memory:////etc/passwd").unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("must name a file"), "{msg}");
+    }
+
+    #[test]
+    fn empty_url_errors_with_hint() {
+        let err = parse("").unwrap_err();
+        assert!(format!("{err}").contains("sqlite://"), "{err}");
+    }
+
+    #[test]
+    fn missing_scheme_hints_at_sqlite() {
+        let err = parse("./app.db").unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("sqlite://"), "{msg}");
+    }
+
+    #[test]
+    fn unix_single_slash_hints_at_double() {
+        let err = parse("unix:/run/sock").unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("unix://"), "{msg}");
+    }
+
+    #[test]
+    fn unix_single_slash_uppercase_still_hints() {
+        // The missing-scheme hint should match `UNIX:` case-insensitively.
+        let err = parse("UNIX:/run/sock").unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("unix://"), "{msg}");
+    }
+
+    #[test]
+    fn mysql_suggests_postgres() {
+        let err = parse("mysql://u@h/db").unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("postgres"), "{msg}");
+    }
+
+    #[test]
+    fn file_suggests_sqlite() {
+        let err = parse("file:///app.db").unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("sqlite"), "{msg}");
+    }
+
+    #[test]
+    fn tcp_suggests_unix() {
+        let err = parse("tcp://host:1234").unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("unix"), "{msg}");
+    }
+}

--- a/crates/lib/src/service/mod.rs
+++ b/crates/lib/src/service/mod.rs
@@ -77,9 +77,19 @@ use std::path::PathBuf;
 
 /// Default socket path for the Eidetica service.
 ///
-/// Uses `$XDG_RUNTIME_DIR/eidetica/service.sock` if available,
-/// falling back to `/tmp/eidetica-$USER/service.sock`.
+/// Resolution order:
+/// 1. `EIDETICA_SOCKET` environment variable, if set.
+/// 2. `$XDG_RUNTIME_DIR/eidetica/service.sock`, if `XDG_RUNTIME_DIR` is set
+///    (the standard Linux convention).
+/// 3. `/tmp/eidetica-$USER/service.sock` as a last-resort fallback.
+///
+/// Used by the daemon CLI to choose where to bind and by
+/// [`default_socket_url`] to construct the equivalent `unix://` URL for
+/// `Instance::connect`.
 pub fn default_socket_path() -> PathBuf {
+    if let Ok(socket) = std::env::var("EIDETICA_SOCKET") {
+        return PathBuf::from(socket);
+    }
     if let Ok(runtime_dir) = std::env::var("XDG_RUNTIME_DIR") {
         PathBuf::from(runtime_dir)
             .join("eidetica")
@@ -88,4 +98,17 @@ pub fn default_socket_path() -> PathBuf {
         let user = std::env::var("USER").unwrap_or_else(|_| "unknown".to_string());
         PathBuf::from(format!("/tmp/eidetica-{user}")).join("service.sock")
     }
+}
+
+/// Default `unix://` URL for `Instance::connect`, derived from
+/// [`default_socket_path`].
+///
+/// Convenience for apps that want to connect to the local daemon's socket
+/// without writing the env / `$XDG_RUNTIME_DIR` resolution themselves:
+///
+/// ```ignore
+/// let instance = Instance::connect(eidetica::service::default_socket_url()).await?;
+/// ```
+pub fn default_socket_url() -> String {
+    format!("unix://{}", default_socket_path().display())
 }

--- a/crates/lib/src/service/server.rs
+++ b/crates/lib/src/service/server.rs
@@ -841,7 +841,7 @@ mod tests {
     async fn start_test_server() -> (PathBuf, watch::Sender<()>, Instance) {
         let dir = tempfile::tempdir().unwrap();
         let socket_path = dir.keep().join("test.sock");
-        let (instance, _admin) = Instance::create(
+        let (instance, _admin) = Instance::create_backend(
             Box::new(InMemory::new()),
             crate::NewUser::passwordless("admin"),
         )
@@ -1079,7 +1079,7 @@ mod tests {
         tokio::fs::write(&socket_path, "stale").await.unwrap();
         assert!(socket_path.exists());
 
-        let (instance, _admin) = Instance::create(
+        let (instance, _admin) = Instance::create_backend(
             Box::new(InMemory::new()),
             crate::NewUser::passwordless("admin"),
         )
@@ -1118,7 +1118,7 @@ mod tests {
     async fn test_gate_require_existing_fails_closed_on_absent_db() {
         use crate::auth::crypto::generate_keypair;
 
-        let (instance, _admin) = Instance::create(
+        let (instance, _admin) = Instance::create_backend(
             Box::new(InMemory::new()),
             crate::NewUser::passwordless("admin"),
         )

--- a/crates/lib/src/store/password_store.rs
+++ b/crates/lib/src/store/password_store.rs
@@ -481,7 +481,7 @@ impl Encryptor for PasswordEncryptor {
 /// # use eidetica::auth::generate_keypair;
 /// # async fn example() -> eidetica::Result<()> {
 /// # let backend = InMemory::new();
-/// # let instance = Instance::open(Box::new(backend)).await?;
+/// # let instance = Instance::open_backend(Box::new(backend)).await?;
 /// # let (private_key, _) = generate_keypair();
 /// # let db = Database::create(&instance, private_key, Doc::new()).await?;
 /// let tx = db.new_transaction().await?;
@@ -503,7 +503,7 @@ impl Encryptor for PasswordEncryptor {
 /// # use eidetica::auth::generate_keypair;
 /// # async fn example() -> eidetica::Result<()> {
 /// # let backend = InMemory::new();
-/// # let instance = Instance::open(Box::new(backend)).await?;
+/// # let instance = Instance::open_backend(Box::new(backend)).await?;
 /// # let (private_key, _) = generate_keypair();
 /// # let db = Database::create(&instance, private_key, Doc::new()).await?;
 /// let tx = db.new_transaction().await?;
@@ -674,7 +674,7 @@ impl<S: Store> PasswordStore<S> {
     /// # use eidetica::auth::generate_keypair;
     /// # async fn example() -> eidetica::Result<()> {
     /// # let backend = InMemory::new();
-    /// # let instance = Instance::open(Box::new(backend)).await?;
+    /// # let instance = Instance::open_backend(Box::new(backend)).await?;
     /// # let (private_key, _) = generate_keypair();
     /// # let db = Database::create(&instance, private_key, Doc::new()).await?;
     /// let tx = db.new_transaction().await?;
@@ -990,7 +990,7 @@ impl<S: Store> PasswordStore<S> {
     /// # use eidetica::auth::generate_keypair;
     /// # async fn example() -> eidetica::Result<()> {
     /// # let backend = InMemory::new();
-    /// # let instance = Instance::open(Box::new(backend)).await?;
+    /// # let instance = Instance::open_backend(Box::new(backend)).await?;
     /// # let (private_key, _) = generate_keypair();
     /// # let db = Database::create(&instance, private_key, Doc::new()).await?;
     /// # let tx = db.new_transaction().await?;

--- a/crates/lib/src/store/settings_store.rs
+++ b/crates/lib/src/store/settings_store.rs
@@ -310,7 +310,7 @@ mod tests {
 
     async fn create_test_database() -> (Instance, Database) {
         // Bootstrap "test" as the initial user, who is automatically Admin.
-        let (instance, mut user) = Instance::create(
+        let (instance, mut user) = Instance::create_backend(
             Box::new(InMemory::new()),
             crate::NewUser::passwordless("test"),
         )

--- a/crates/lib/src/sync/bootstrap_request_manager.rs
+++ b/crates/lib/src/sync/bootstrap_request_manager.rs
@@ -207,7 +207,7 @@ mod tests {
 
     async fn create_test_sync_tree() -> (Instance, Database, Arc<FixedClock>) {
         let clock = Arc::new(FixedClock::default());
-        let (instance, mut user) = Instance::create_with_clock(
+        let (instance, mut user) = Instance::create_backend_with_clock(
             Box::new(InMemory::new()),
             clock.clone(),
             crate::NewUser::passwordless("test"),

--- a/crates/lib/src/sync/state.rs
+++ b/crates/lib/src/sync/state.rs
@@ -552,7 +552,7 @@ mod tests {
         use std::sync::Arc;
 
         let clock = Arc::new(FixedClock::default());
-        let (instance, mut user) = Instance::create_with_clock(
+        let (instance, mut user) = Instance::create_backend_with_clock(
             Box::new(InMemory::new()),
             clock.clone(),
             crate::NewUser::passwordless("test"),

--- a/crates/lib/src/transaction/tests.rs
+++ b/crates/lib/src/transaction/tests.rs
@@ -13,7 +13,7 @@ use crate::{
 async fn test_prevent_auth_corruption() {
     let backend = InMemory::new();
     let (instance, _admin) =
-        Instance::create(Box::new(backend), crate::NewUser::passwordless("admin"))
+        Instance::create_backend(Box::new(backend), crate::NewUser::passwordless("admin"))
             .await
             .unwrap();
     let (private_key, _) = generate_keypair();

--- a/crates/lib/src/user/session/tests.rs
+++ b/crates/lib/src/user/session/tests.rs
@@ -4,7 +4,7 @@ use super::*;
 use crate::{NewUser, backend::database::InMemory};
 
 async fn create_test_user_session() -> (Instance, User) {
-    Instance::create(
+    Instance::create_backend(
         Box::new(InMemory::new()),
         NewUser::with_password("test_user", "test_password"),
     )

--- a/crates/lib/src/user/system_databases.rs
+++ b/crates/lib/src/user/system_databases.rs
@@ -170,7 +170,7 @@ pub async fn create_databases_tracking(
 /// # Returns
 /// A tuple of `(user_uuid, UserInfo, root_private_key)`. The private key is
 /// the one just generated for this user; callers (e.g.
-/// [`Instance::create`](crate::Instance::create) or
+/// [`Instance::create_backend`](crate::Instance::create_backend) or
 /// [`InstanceAdmin::create_user`](crate::user::InstanceAdmin::create_user))
 /// can hand it straight to [`build_user_session`] to materialise a logged-in
 /// [`User`](crate::user::User) without re-decrypting the key from storage.
@@ -682,7 +682,7 @@ mod tests {
     async fn setup_instance() -> (Instance, PrivateKey, crate::user::User) {
         use crate::clock::FixedClock;
 
-        let (instance, admin) = Instance::create_with_clock(
+        let (instance, admin) = Instance::create_backend_with_clock(
             Box::new(InMemory::new()),
             Arc::new(FixedClock::default()),
             crate::NewUser::passwordless("admin"),

--- a/crates/lib/tests/it/backend/save_load.rs
+++ b/crates/lib/tests/it/backend/save_load.rs
@@ -7,8 +7,8 @@ use eidetica::{
     backend::{BackendImpl, database::InMemory},
 };
 
-async fn save_backend(backend: &InMemory, path: &Path) -> Result<()> {
-    backend.save_to_file(path).await
+fn save_backend(backend: &InMemory, path: &Path) -> Result<()> {
+    backend.save_to_file(path)
 }
 
 async fn load_backend(path: &Path) -> Result<InMemory> {
@@ -31,7 +31,7 @@ async fn test_in_memory_backend_save_and_load() {
         backend.put_verified(entry).await.unwrap();
 
         // Save to file
-        let save_result = save_backend(&backend, &file_path).await;
+        let save_result = save_backend(&backend, &file_path);
         assert!(save_result.is_ok());
     }
 
@@ -133,7 +133,7 @@ async fn test_save_load_with_various_entries() {
     backend.put_verified(entry_with_subtree).await.unwrap();
 
     // Save to file
-    save_backend(&backend, &file_path).await.unwrap();
+    save_backend(&backend, &file_path).unwrap();
 
     // Load back into a new backend
     let loaded_backend = load_backend(&file_path).await.unwrap();

--- a/crates/lib/tests/it/backend/verification.rs
+++ b/crates/lib/tests/it/backend/verification.rs
@@ -215,7 +215,6 @@ async fn test_verification_status_serialization() {
     let temp_file = "/tmp/test_verification_status.json";
     backend
         .save_to_file(temp_file)
-        .await
         .expect("Failed to save backend");
 
     let loaded_backend = InMemory::load_from_file(temp_file)

--- a/crates/lib/tests/it/database/api_methods.rs
+++ b/crates/lib/tests/it/database/api_methods.rs
@@ -1019,7 +1019,7 @@ async fn test_verify_uses_pinned_not_current_settings() {
 async fn test_genesis_verifies_after_persist_reload() {
     // Bootstrap "u" as the initial user (also Admin), avoiding the
     // service-mode admin login dance — this is a local persist/reload test.
-    let (instance, mut user) = Instance::create(
+    let (instance, mut user) = Instance::create_backend(
         Box::new(InMemory::new()),
         eidetica::NewUser::passwordless("u"),
     )
@@ -1047,12 +1047,11 @@ async fn test_genesis_verifies_after_persist_reload() {
         .downcast_ref::<InMemory>()
         .expect("test backend is InMemory")
         .save_to_file(&path)
-        .await
         .unwrap();
     let reloaded = InMemory::load_from_file(&path).await.unwrap();
     std::fs::remove_file(&path).ok();
-    // Reload an already-initialised backend — Instance::open is load-only.
-    let instance2 = Instance::open(Box::new(reloaded)).await.unwrap();
+    // Reload an already-initialised backend — Instance::open_backend is load-only.
+    let instance2 = Instance::open_backend(Box::new(reloaded)).await.unwrap();
     let backend2 = instance2.backend();
 
     // Force the whole history Unverified on the reloaded backend.

--- a/crates/lib/tests/it/helpers.rs
+++ b/crates/lib/tests/it/helpers.rs
@@ -147,7 +147,7 @@ pub async fn test_instance() -> Instance {
 #[allow(dead_code)]
 pub async fn test_local_instance() -> Instance {
     let clock = Arc::new(FixedClock::default());
-    let (instance, _admin) = Instance::create_with_clock(
+    let (instance, _admin) = Instance::create_backend_with_clock(
         Box::new(InMemory::new()),
         clock,
         NewUser::passwordless("admin"),
@@ -247,7 +247,7 @@ async fn test_remote_instance() -> Instance {
     let socket_path = dir.path().join("test.sock");
 
     let (server, _admin) =
-        Instance::create(Box::new(InMemory::new()), NewUser::passwordless("admin"))
+        Instance::create_backend(Box::new(InMemory::new()), NewUser::passwordless("admin"))
             .await
             .expect("Failed to create server-side Instance");
     let service = ServiceServer::new(server.clone(), socket_path.clone());
@@ -270,7 +270,7 @@ async fn test_remote_instance() -> Instance {
         "daemon socket did not appear within 500ms"
     );
 
-    let instance = Instance::connect(&socket_path)
+    let instance = Instance::connect(format!("unix://{}", socket_path.display()))
         .await
         .expect("Failed to connect to test daemon");
     instance
@@ -318,7 +318,7 @@ async fn test_remote_instance_with_user(username: &str) -> (Instance, User) {
     let socket_path = dir.path().join("test.sock");
 
     let (server, _admin) =
-        Instance::create(Box::new(InMemory::new()), NewUser::passwordless("admin"))
+        Instance::create_backend(Box::new(InMemory::new()), NewUser::passwordless("admin"))
             .await
             .expect("Failed to create server-side Instance");
     let service = ServiceServer::new(server.clone(), socket_path.clone());
@@ -344,7 +344,7 @@ async fn test_remote_instance_with_user(username: &str) -> (Instance, User) {
         .await
         .expect("Failed to create user server-side");
 
-    let instance = Instance::connect(&socket_path)
+    let instance = Instance::connect(format!("unix://{}", socket_path.display()))
         .await
         .expect("Failed to connect to test daemon");
     let user = instance
@@ -404,7 +404,7 @@ async fn test_remote_instance_with_user_and_key(
     let socket_path = dir.path().join("test.sock");
 
     let (server, _admin) =
-        Instance::create(Box::new(InMemory::new()), NewUser::passwordless("admin"))
+        Instance::create_backend(Box::new(InMemory::new()), NewUser::passwordless("admin"))
             .await
             .expect("Failed to create server-side Instance");
     let service = ServiceServer::new(server.clone(), socket_path.clone());
@@ -439,7 +439,7 @@ async fn test_remote_instance_with_user_and_key(
         .expect("Failed to add key server-side");
 
     // Connect and authenticate as the user.
-    let instance = Instance::connect(&socket_path)
+    let instance = Instance::connect(format!("unix://{}", socket_path.display()))
         .await
         .expect("Failed to connect to test daemon");
     let user = instance

--- a/crates/lib/tests/it/service.rs
+++ b/crates/lib/tests/it/service.rs
@@ -29,7 +29,7 @@ use tokio::sync::watch;
 async fn start_test_server() -> (PathBuf, watch::Sender<()>, Instance, TempDir) {
     let dir = tempfile::tempdir().unwrap();
     let socket_path = dir.path().join("test.sock");
-    let (instance, _admin) = Instance::create(
+    let (instance, _admin) = Instance::create_backend(
         Box::new(InMemory::new()),
         eidetica::NewUser::passwordless("admin"),
     )
@@ -65,15 +65,17 @@ async fn create_user_via_admin(server: &Instance, username: &str) {
 /// key as Admin(0). The client authenticates via the remote connection.
 async fn setup_db(
     server: &Instance,
-    socket_path: &PathBuf,
+    socket_path: &std::path::Path,
     username: &str,
 ) -> (Instance, eidetica::entry::ID, eidetica::auth::types::SigKey) {
-    // Admin was created by Instance::open bootstrap — use it to create the test user.
+    // Admin was created by Instance::open_backend bootstrap — use it to create the test user.
     crate::helpers::create_user(server, username, None)
         .await
         .unwrap();
 
-    let instance = Instance::connect(socket_path).await.unwrap();
+    let instance = Instance::connect(format!("unix://{}", socket_path.display()))
+        .await
+        .unwrap();
     let user = instance.login_user(username, None).await.unwrap();
     let pubkey = user.get_default_key().unwrap();
 
@@ -102,7 +104,9 @@ async fn setup_db(
 #[tokio::test]
 async fn test_connect_and_create_instance() {
     let (socket_path, _tx, server, _dir) = start_test_server().await;
-    let _instance = Instance::connect(&socket_path).await.unwrap();
+    let _instance = Instance::connect(format!("unix://{}", socket_path.display()))
+        .await
+        .unwrap();
     let users = crate::helpers::list_users(&server).await.unwrap();
     // Admin user bootstrapped at Instance creation
     assert_eq!(users.len(), 1);
@@ -117,7 +121,9 @@ async fn test_user_lifecycle() {
         .await
         .unwrap();
 
-    let instance = Instance::connect(&socket_path).await.unwrap();
+    let instance = Instance::connect(format!("unix://{}", socket_path.display()))
+        .await
+        .unwrap();
 
     let user = instance.login_user("alice", None).await.unwrap();
     assert_eq!(user.username(), "alice");
@@ -141,7 +147,9 @@ async fn test_user_lifecycle() {
 async fn test_error_propagation() {
     let (socket_path, _tx, server, _dir) = start_test_server().await;
     create_user_via_admin(&server, "err-test").await;
-    let instance = Instance::connect(&socket_path).await.unwrap();
+    let instance = Instance::connect(format!("unix://{}", socket_path.display()))
+        .await
+        .unwrap();
     let user = instance.login_user("err-test", None).await.unwrap();
 
     let pubkey = user.get_default_key().unwrap();
@@ -162,7 +170,9 @@ async fn test_error_propagation() {
 #[tokio::test]
 async fn test_unauthenticated_backend_op_rejected() {
     let (socket_path, _tx, _server, _dir) = start_test_server().await;
-    let instance = Instance::connect(&socket_path).await.unwrap();
+    let instance = Instance::connect(format!("unix://{}", socket_path.display()))
+        .await
+        .unwrap();
 
     let conn = remote_conn(&instance);
     let result = conn
@@ -184,8 +194,12 @@ async fn test_concurrent_clients() {
     let (socket_path, _tx, server, _dir) = start_test_server().await;
     create_user_via_admin(&server, "bob").await;
 
-    let instance1 = Instance::connect(&socket_path).await.unwrap();
-    let instance2 = Instance::connect(&socket_path).await.unwrap();
+    let instance1 = Instance::connect(format!("unix://{}", socket_path.display()))
+        .await
+        .unwrap();
+    let instance2 = Instance::connect(format!("unix://{}", socket_path.display()))
+        .await
+        .unwrap();
 
     let _user1 = instance1.login_user("bob", None).await.unwrap();
     let user2 = instance2.login_user("bob", None).await.unwrap();
@@ -197,7 +211,9 @@ async fn test_instance_connect_convenience() {
     let (socket_path, _tx, server, _dir) = start_test_server().await;
     create_user_via_admin(&server, "charlie").await;
 
-    let _instance = Instance::connect(&socket_path).await.unwrap();
+    let _instance = Instance::connect(format!("unix://{}", socket_path.display()))
+        .await
+        .unwrap();
     let mut users = crate::helpers::list_users(&server).await.unwrap();
     // `list_users` returns users in UUID order (random per run), so sort
     // before comparing — the set is what matters, not iteration order.
@@ -208,7 +224,9 @@ async fn test_instance_connect_convenience() {
 #[tokio::test]
 async fn test_instance_identity_round_trip() {
     let (socket_path, _tx, server, _dir) = start_test_server().await;
-    let client = Instance::connect(&socket_path).await.unwrap();
+    let client = Instance::connect(format!("unix://{}", socket_path.display()))
+        .await
+        .unwrap();
 
     assert_eq!(client.id(), server.id());
 }
@@ -333,7 +351,9 @@ async fn test_database_begin_transaction() {
         .unwrap();
     let root_id = server_db.root_id().clone();
 
-    let instance = Instance::connect(&socket_path).await.unwrap();
+    let instance = Instance::connect(format!("unix://{}", socket_path.display()))
+        .await
+        .unwrap();
     let user = instance.login_user("alice", None).await.unwrap();
 
     let pubkey = user.get_default_key().unwrap();
@@ -427,7 +447,9 @@ async fn test_database_get_store_state() {
         .await
         .unwrap();
 
-    let instance = Instance::connect(&socket_path).await.unwrap();
+    let instance = Instance::connect(format!("unix://{}", socket_path.display()))
+        .await
+        .unwrap();
     let user = instance.login_user("alice", None).await.unwrap();
 
     let pubkey = user.get_default_key().unwrap();
@@ -655,7 +677,9 @@ async fn test_backend_get_tips_denied_for_unauthorised_user() {
 
     // Create bob and try to read alice's database.
     create_user_via_admin(&server, "bob").await;
-    let bob_inst = Instance::connect(&socket_path).await.unwrap();
+    let bob_inst = Instance::connect(format!("unix://{}", socket_path.display()))
+        .await
+        .unwrap();
     let bob_user = bob_inst.login_user("bob", None).await.unwrap();
     let bob_key = bob_user.get_default_key().unwrap();
     let bob_identity = eidetica::auth::types::SigKey::from_pubkey(&bob_key);
@@ -688,7 +712,9 @@ async fn test_backend_get_denied_cross_tree() {
 
     // Bob is logged in but has no access.
     create_user_via_admin(&server, "bob").await;
-    let bob_inst = Instance::connect(&socket_path).await.unwrap();
+    let bob_inst = Instance::connect(format!("unix://{}", socket_path.display()))
+        .await
+        .unwrap();
     let bob_user = bob_inst.login_user("bob", None).await.unwrap();
     let bob_key = bob_user.get_default_key().unwrap();
     let bob_identity = eidetica::auth::types::SigKey::from_pubkey(&bob_key);
@@ -710,7 +736,9 @@ async fn test_backend_get_denied_cross_tree() {
 async fn test_set_instance_metadata_allowed_for_admin() {
     let (socket_path, _tx, _server, _dir) = start_test_server().await;
 
-    let instance = Instance::connect(&socket_path).await.unwrap();
+    let instance = Instance::connect(format!("unix://{}", socket_path.display()))
+        .await
+        .unwrap();
     let _admin = instance.login_user("admin", None).await.unwrap();
 
     let current = instance
@@ -732,7 +760,9 @@ async fn test_set_instance_metadata_denied_for_non_admin() {
     let (socket_path, _tx, server, _dir) = start_test_server().await;
     create_user_via_admin(&server, "bob").await;
 
-    let bob_inst = Instance::connect(&socket_path).await.unwrap();
+    let bob_inst = Instance::connect(format!("unix://{}", socket_path.display()))
+        .await
+        .unwrap();
     let _bob = bob_inst.login_user("bob", None).await.unwrap();
 
     let current = bob_inst
@@ -893,7 +923,9 @@ async fn test_submit_cross_session_signed_by_tree_admin_becomes_verified() {
 
     // The bootstrap admin (NOT bob) connects over the wire. Admin holds
     // Admin on `_users`/`_databases` but is *not* a member of bob's tree.
-    let admin_inst = Instance::connect(&socket_path).await.unwrap();
+    let admin_inst = Instance::connect(format!("unix://{}", socket_path.display()))
+        .await
+        .unwrap();
     let _admin_user = admin_inst.login_user("admin", None).await.unwrap();
     let conn = remote_conn(&admin_inst);
 
@@ -996,7 +1028,9 @@ async fn test_submit_unauthorized_signer_stays_invisible_in_default_reads() {
 
     // Admin connects and signs an entry with the *admin* key, which has no
     // auth on bob's tree.
-    let admin_inst = Instance::connect(&socket_path).await.unwrap();
+    let admin_inst = Instance::connect(format!("unix://{}", socket_path.display()))
+        .await
+        .unwrap();
     let admin_user = admin_inst.login_user("admin", None).await.unwrap();
     let admin_pub = admin_user.get_default_key().unwrap();
     let admin_sk = admin_user.get_signing_key(&admin_pub).unwrap();
@@ -1048,7 +1082,9 @@ async fn test_daemon_survives_abrupt_client_disconnect() {
 
     // Client A connects, logs in, then is dropped without any teardown.
     {
-        let instance = Instance::connect(&socket_path).await.unwrap();
+        let instance = Instance::connect(format!("unix://{}", socket_path.display()))
+            .await
+            .unwrap();
         let _user = instance.login_user("alice", None).await.unwrap();
         // Drop instance — the underlying UnixStream tears down without the
         // server ever seeing an EOF-after-request boundary.
@@ -1057,7 +1093,9 @@ async fn test_daemon_survives_abrupt_client_disconnect() {
     // Daemon must still answer fresh connections. Anything else (a `connect`
     // hang, an authentication failure, a server crash) means abrupt drops are
     // poisoning shared state.
-    let instance = Instance::connect(&socket_path).await.unwrap();
+    let instance = Instance::connect(format!("unix://{}", socket_path.display()))
+        .await
+        .unwrap();
     let user = instance.login_user("alice", None).await.unwrap();
     assert_eq!(user.username(), "alice");
 }
@@ -1092,7 +1130,9 @@ async fn test_daemon_survives_malformed_frame_from_client() {
     }
 
     // Daemon should still serve a fresh connection.
-    let instance = Instance::connect(&socket_path).await.unwrap();
+    let instance = Instance::connect(format!("unix://{}", socket_path.display()))
+        .await
+        .unwrap();
     let user = instance.login_user("alice", None).await.unwrap();
     assert_eq!(user.username(), "alice");
 }
@@ -1121,7 +1161,9 @@ async fn test_daemon_survives_half_written_request_frame() {
         drop(writer);
     }
 
-    let instance = Instance::connect(&socket_path).await.unwrap();
+    let instance = Instance::connect(format!("unix://{}", socket_path.display()))
+        .await
+        .unwrap();
     let user = instance.login_user("alice", None).await.unwrap();
     assert_eq!(user.username(), "alice");
 }
@@ -1208,7 +1250,9 @@ async fn test_cache_survives_reconnect() {
 
     // Fresh connection + login = fresh tier 1, but the daemon's ServiceCache
     // still has the entry. Verify it.
-    let instance2 = Instance::connect(&socket_path).await.unwrap();
+    let instance2 = Instance::connect(format!("unix://{}", socket_path.display()))
+        .await
+        .unwrap();
     let _user2 = instance2.login_user("alice", None).await.unwrap();
     let conn2 = remote_conn(&instance2);
 

--- a/crates/lib/tests/it/transaction/height_strategy.rs
+++ b/crates/lib/tests/it/transaction/height_strategy.rs
@@ -20,7 +20,7 @@ async fn create_test_database() -> (Instance, Database) {
 
 /// Helper to create a test instance and database with a custom clock
 async fn create_test_database_with_clock(clock: Arc<dyn Clock>) -> (Instance, Database) {
-    let (instance, mut user) = Instance::create_with_clock(
+    let (instance, mut user) = Instance::create_backend_with_clock(
         Box::new(InMemory::new()),
         clock,
         eidetica::NewUser::passwordless("test"),

--- a/docs/README.md
+++ b/docs/README.md
@@ -61,12 +61,14 @@ Template for examples that should be compiled and validated (it might be best to
 
 ```rust
 # extern crate eidetica;
-# use eidetica::{backend::database::Sqlite, Instance};
+# extern crate tokio;
+# use eidetica::{Instance, NewUser};
 #
-# fn create_database() -> eidetica::Result<()> {
-// Create an in-memory SQLite database
-let database = Sqlite::in_memory()?;
-let _db = Instance::new(Box::new(database));
+# #[tokio::main]
+# async fn main() -> eidetica::Result<()> {
+// Open an Instance by URL — `memory://` is an ephemeral in-process backend.
+let (_instance, _) =
+    Instance::connect_or_create("memory://", NewUser::passwordless("alice")).await?;
 
 // Your example code here
 # Ok(())

--- a/docs/src/design/subtree_index.md
+++ b/docs/src/design/subtree_index.md
@@ -162,7 +162,7 @@ Access via `Transaction::get_index()`.
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
 # let backend = Box::new(Sqlite::in_memory().await?);
-# let (instance, mut user) = eidetica::Instance::create(
+# let (instance, mut user) = eidetica::Instance::create_backend(
 #     backend,
 #     eidetica::NewUser::passwordless("alice"),
 # ).await?;
@@ -201,7 +201,7 @@ assert!(info.config.is_empty());
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
 # let backend = Box::new(Sqlite::in_memory().await?);
-# let (instance, mut user) = eidetica::Instance::create(
+# let (instance, mut user) = eidetica::Instance::create_backend(
 #     backend,
 #     eidetica::NewUser::passwordless("alice"),
 # ).await?;
@@ -247,7 +247,7 @@ assert!(info.config.contains_key("compression"));
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
 # let backend = Box::new(Sqlite::in_memory().await?);
-# let (instance, mut user) = eidetica::Instance::create(
+# let (instance, mut user) = eidetica::Instance::create_backend(
 #     backend,
 #     eidetica::NewUser::passwordless("alice"),
 # ).await?;

--- a/docs/src/design/users.md
+++ b/docs/src/design/users.md
@@ -345,7 +345,7 @@ Users are created by administrators or self-registration:
 
 **User Lifecycle:**
 
-1. The **initial** user is created at instance bootstrap via `Instance::create(backend, NewUser::…)` (or `Instance::open_or_create` on a fresh backend) and is automatically granted Admin on the system databases — there is no separate hidden admin account.
+1. The **initial** user is created at instance bootstrap via `Instance::create_backend(backend, NewUser::…)` (or `Instance::connect_or_create` on a fresh backend) and is automatically granted Admin on the system databases — there is no separate hidden admin account.
 2. Subsequent users are created by an existing admin via `admin.admin().await?.create_user(NewUser::…)` and land as non-admins until promoted.
 3. Any user logs in via `Instance::login_user()`.
 4. User session provides access to keys and preferences.
@@ -410,7 +410,7 @@ For embedded/single-user scenarios, users can be created without passwords:
 ```rust,ignore
 // Create the instance with Alice as the initial passwordless user.
 // First user becomes Admin automatically.
-let (instance, mut user) = Instance::create(
+let (instance, mut user) = Instance::create_backend(
     backend,
     NewUser::passwordless("alice"),
 ).await?;
@@ -434,7 +434,7 @@ For multi-user scenarios, users have password-based authentication:
 
 ```rust,ignore
 // Bootstrap with Bob as the initial password-protected admin user.
-let (instance, _user) = Instance::create(
+let (instance, _user) = Instance::create_backend(
     backend,
     NewUser::with_password("bob", "password123"),
 ).await?;
@@ -627,7 +627,7 @@ See [key_management.md](./key_management.md) for detailed implementation.
 
 **Password-Protected User:**
 
-1. Admin calls `admin.create_user(NewUser::with_password(username, password))` (or, for the initial admin on a fresh instance, `Instance::create(backend, NewUser::with_password(username, password))`)
+1. Admin calls `admin.create_user(NewUser::with_password(username, password))` (or, for the initial admin on a fresh instance, `Instance::create_backend(backend, NewUser::with_password(username, password))`)
 2. System searches `_users` Table for existing username (race condition possible)
 3. System hashes password with Argon2id and random salt
 4. Generates default Ed25519 keypair for the user (kept in memory only)
@@ -640,7 +640,7 @@ See [key_management.md](./key_management.md) for detailed implementation.
 
 **Passwordless User:**
 
-1. Admin calls `admin.create_user(NewUser::passwordless(username))` (or, for the initial admin, `Instance::create(backend, NewUser::passwordless(username))`)
+1. Admin calls `admin.create_user(NewUser::passwordless(username))` (or, for the initial admin, `Instance::create_backend(backend, NewUser::passwordless(username))`)
 2. System searches `_users` Table for existing username (race condition possible)
 3. Generates default Ed25519 keypair for the user (kept in memory only)
 4. Uses instance `signing_key` from InstanceSecrets

--- a/docs/src/internal/service.md
+++ b/docs/src/internal/service.md
@@ -12,7 +12,7 @@ graph LR
     I --> B[Backend: SQLite/InMemory]
 ```
 
-The server wraps a full `Instance` (not just a backend) so it can handle both storage operations and write notifications. A client calls `Instance::connect(path)`, which establishes a `RemoteConnection`, wraps it as a `RemoteBackend`, fetches `InstanceMetadata` over the wire, and constructs an Instance with **no local secrets** (`secrets: None`) — signing keys are derived client-side after login, never held by the constructed Instance until a user logs in.
+The server wraps a full `Instance` (not just a backend) so it can handle both storage operations and write notifications. A client calls `Instance::connect("unix://...")`, which establishes a `RemoteConnection`, wraps it as a `RemoteBackend`, fetches `InstanceMetadata` over the wire, and constructs an Instance with **no local secrets** (`secrets: None`) — signing keys are derived client-side after login, never held by the constructed Instance until a user logs in.
 
 ### Module Structure
 
@@ -361,7 +361,7 @@ The full suite passes 1:1 against the service backend. Tests that exercise _proc
 - `test_local_instance_with_user(username)` and `test_local_instance_with_user_and_key(username, key_name)` — counterparts to the wire-aware versions.
 - `setup_tree_with_user_key_local()` and `TestContext::with_local_database()` — for tests that poke at local-only backend state.
 
-The architectural seam — wire-path tests vs. subsystem tests — is explicit at the helper level. The test harness bootstraps the server-side Instance with a passwordless `admin` user via `Instance::create(..., NewUser::passwordless("admin"))`, then logs in over the wire as that user. (The old `admin`/`admin` auto-bootstrap is gone; production deployments now run `eidetica daemon init --username <NAME>` with explicit credentials, and the test harness mirrors that shape.)
+The architectural seam — wire-path tests vs. subsystem tests — is explicit at the helper level. The test harness bootstraps the server-side Instance with a passwordless `admin` user via `Instance::create_backend(..., NewUser::passwordless("admin"))`, then logs in over the wire as that user. (The old `admin`/`admin` auto-bootstrap is gone; production deployments now run `eidetica daemon init --username <NAME>` with explicit credentials, and the test harness mirrors that shape.)
 
 ## V1 Limitations
 

--- a/docs/src/user_guide/authentication_guide.md
+++ b/docs/src/user_guide/authentication_guide.md
@@ -15,7 +15,7 @@ Every Eidetica database requires authentication. Here's the minimal setup:
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
 # let backend = Sqlite::in_memory().await?;
-# let (instance, _) = Instance::open_or_create(
+# let (instance, _) = Instance::connect_or_create_backend(
 #     Box::new(backend),
 #     eidetica::NewUser::passwordless("admin"),
 # ).await?;
@@ -44,8 +44,9 @@ txn.commit().await?;  // Automatically signed
 
 **Mandatory Authentication**: Every entry must be signed - no exceptions.
 
-**First User Becomes Admin**: Whoever is named in the [`NewUser`] passed to `Instance::create` (or `open_or_create` on a fresh backend) is the instance's first user **and** is automatically granted `Admin(0)` on the system databases (`_users`, `_databases`). There is no hidden default account: production deployments run `eidetica daemon init --username <NAME> [--password PASS | --passwordless]` with explicit credentials. Subsequent users are created by an existing admin via `admin.admin().await?.create_user(NewUser::…)` and land as non-admins until promoted.
+**First User Becomes Admin**: Whoever is named in the [`NewUser`] passed to `Instance::connect_or_create` (URL-based) or [`Instance::create_backend`] (pre-built backend) is the instance's first user **and** is automatically granted `Admin(0)` on the system databases (`_users`, `_databases`). There is no hidden default account: production deployments run `eidetica daemon init --username <NAME> [--password PASS | --passwordless]` with explicit credentials. Subsequent users are created by an existing admin via `admin.admin().await?.create_user(NewUser::…)` and land as non-admins until promoted.
 
+[`Instance::create_backend`]: https://docs.rs/eidetica/latest/eidetica/struct.Instance.html#method.create_backend
 [`NewUser`]: https://docs.rs/eidetica/latest/eidetica/instance/struct.NewUser.html
 
 **Permission Levels**:
@@ -72,7 +73,7 @@ Give other users access to your database:
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
 # // Setup database for testing
-# let (instance, mut user) = eidetica::Instance::create(
+# let (instance, mut user) = eidetica::Instance::create_backend(
 #     Box::new(Sqlite::in_memory().await?),
 #     eidetica::NewUser::passwordless("alice"),
 # ).await?;
@@ -108,7 +109,7 @@ Allow anyone to read your database:
 #
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
-# let (instance, mut user) = eidetica::Instance::create(
+# let (instance, mut user) = eidetica::Instance::create_backend(
 #     Box::new(Sqlite::in_memory().await?),
 #     eidetica::NewUser::passwordless("alice"),
 # ).await?;
@@ -143,7 +144,7 @@ Create a collaborative database where anyone can read and write without individu
 #
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
-# let (instance, mut user) = eidetica::Instance::create(
+# let (instance, mut user) = eidetica::Instance::create_backend(
 #     Box::new(Sqlite::in_memory().await?),
 #     eidetica::NewUser::passwordless("alice"),
 # ).await?;
@@ -181,7 +182,7 @@ transaction.commit().await?;
 ```rust,ignore
 use eidetica::{Instance, backend::database::Sqlite};
 
-let instance = Instance::open(Box::new(Sqlite::in_memory().await?)).await?;
+let instance = Instance::open_backend(Box::new(Sqlite::in_memory().await?)).await?;
 
 // Log in as an existing user
 let mut user = instance.login_user("bob", None).await?;
@@ -221,7 +222,7 @@ Remove a user's access:
 #
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
-# let (instance, mut user) = eidetica::Instance::create(
+# let (instance, mut user) = eidetica::Instance::create_backend(
 #     Box::new(Sqlite::in_memory().await?),
 #     eidetica::NewUser::passwordless("alice"),
 # ).await?;
@@ -262,7 +263,7 @@ Note: Historical entries created by revoked keys remain valid.
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
 # // Setup database for testing
-# let (instance, mut user) = eidetica::Instance::create(
+# let (instance, mut user) = eidetica::Instance::create_backend(
 #     Box::new(Sqlite::in_memory().await?),
 #     eidetica::NewUser::passwordless("alice"),
 # ).await?;
@@ -330,7 +331,7 @@ When you delegate to another database:
 #
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
-# let (instance, mut user) = eidetica::Instance::create(
+# let (instance, mut user) = eidetica::Instance::create_backend(
 #     Box::new(Sqlite::in_memory().await?),
 #     eidetica::NewUser::passwordless("alice"),
 # ).await?;
@@ -387,7 +388,7 @@ Delegations are stored in the **delegating database's** auth settings by the del
 #
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
-# let (instance, mut user) = eidetica::Instance::create(
+# let (instance, mut user) = eidetica::Instance::create_backend(
 #     Box::new(Sqlite::in_memory().await?),
 #     eidetica::NewUser::passwordless("alice"),
 # ).await?;
@@ -432,7 +433,7 @@ These are names in the **delegated database's** auth settings that point to **pu
 #
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
-# let (instance, mut user) = eidetica::Instance::create(
+# let (instance, mut user) = eidetica::Instance::create_backend(
 #     Box::new(Sqlite::in_memory().await?),
 #     eidetica::NewUser::passwordless("alice"),
 # ).await?;
@@ -474,7 +475,7 @@ A delegation path is a sequence of steps that traverses from the delegating data
 #
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
-# let (instance, mut user) = eidetica::Instance::create(
+# let (instance, mut user) = eidetica::Instance::create_backend(
 #     Box::new(Sqlite::in_memory().await?),
 #     eidetica::NewUser::passwordless("alice"),
 # ).await?;
@@ -708,7 +709,7 @@ The simplest approach for collaborative databases is to use global wildcard perm
 #
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
-# let (instance, mut user) = eidetica::Instance::create(
+# let (instance, mut user) = eidetica::Instance::create_backend(
 #     Box::new(Sqlite::in_memory().await?),
 #     eidetica::NewUser::passwordless("alice"),
 # ).await?;

--- a/docs/src/user_guide/cli.md
+++ b/docs/src/user_guide/cli.md
@@ -108,7 +108,7 @@ eidetica daemon [OPTIONS]
 | `--data-dir`     | `-d`  | current dir   | `EIDETICA_DATA_DIR`     | Data directory for storage files                                |
 | `--postgres-url` |       | —             | `EIDETICA_POSTGRES_URL` | PostgreSQL connection URL (required when backend is `postgres`) |
 
-The daemon runs until interrupted with SIGINT or SIGTERM. Clients connect using `Instance::connect(socket_path)`. See [Service (Daemon) Mode](service.md) for full documentation.
+The daemon runs until interrupted with SIGINT or SIGTERM. Clients connect using `Instance::connect("unix://...")`. See [Service (Daemon) Mode](service.md) for full documentation.
 
 ### `db list`
 

--- a/docs/src/user_guide/concepts/backends.md
+++ b/docs/src/user_guide/concepts/backends.md
@@ -13,7 +13,26 @@ Key responsibilities of a Database:
 - Calculating tips (latest entries) for databases and stores
 - Managing the graph-like structure of entry history
 
-## Available Database Implementations
+## Selecting a Backend via URL
+
+The recommended way to open an Instance is by URL — `Instance::connect(url)` and `Instance::connect_or_create(url, NewUser::…)` dispatch to the right backend based on the URL scheme:
+
+| URL form                            | Backend                                                  | Feature flag       |
+| ----------------------------------- | -------------------------------------------------------- | ------------------ |
+| `sqlite://./my_data.db`             | Embedded SQLite (passed through to `sqlx::sqlite`)       | `sqlite`           |
+| `sqlite:file::memory:?cache=shared` | Embedded SQLite, in-memory (see note)                    | `sqlite`           |
+| `postgres://user:pwd@host/db`       | Embedded PostgreSQL (passed through to `sqlx::postgres`) | `postgres`         |
+| `unix:///run/eidetica/service.sock` | Thin client to a running [daemon](../service.md)         | `service` (unix)   |
+| `memory://`                         | Ephemeral in-process backend (tests/dev only)            | (always available) |
+| `memory:///abs/path/snap.json`      | In-process backend with a JSON snapshot file (tests/dev) | (always available) |
+
+The in-memory sqlite URL requires sqlx's single-colon URI form (`sqlite:` rather than `sqlite://`) due to limitations in sqlx. The `file:` prefix + `cache=shared` are what make the database visible across the connection pool. Without them each pooled connection gets its own isolated database.
+
+Backends whose Cargo feature isn't compiled in return `InstanceError::BackendUnavailable { scheme, missing_feature }` at runtime — no link-time surprise.
+
+For escape-hatch construction (custom sqlx pool config, custom clock, etc.) the per-backend constructors below remain `pub`; see [`Instance::open_backend`](https://docs.rs/eidetica/latest/eidetica/struct.Instance.html#method.open_backend), [`connect_or_create_backend`](https://docs.rs/eidetica/latest/eidetica/struct.Instance.html#method.connect_or_create_backend), and [`create_backend`](https://docs.rs/eidetica/latest/eidetica/struct.Instance.html#method.create_backend) for the URL-less entry points.
+
+## Available Backend Implementations
 
 ### SQLite
 
@@ -22,13 +41,18 @@ SQLite is the default and recommended backend. It provides embedded persistent s
 <!-- Code block ignored: Requires async runtime context -->
 
 ```rust,ignore
+use eidetica::{Instance, NewUser};
+
+// Recommended: by URL.
+let (instance, _) = Instance::connect_or_create(
+    "sqlite://./my_data.db",
+    NewUser::passwordless("alice"),
+).await?;
+
+// Escape-hatch: build the backend manually for custom configuration.
 use eidetica::backend::database::Sqlite;
-
-// File-based storage (async) - recommended for persistent data
 let backend = Sqlite::open("my_data.db").await?;
-
-// In-memory - useful for testing
-let backend = Sqlite::in_memory().await?;
+let instance = Instance::open_backend(Box::new(backend)).await?;
 ```
 
 ### PostgreSQL
@@ -38,58 +62,79 @@ PostgreSQL provides production-grade persistent storage for larger deployments. 
 <!-- Code block ignored: Requires PostgreSQL server -->
 
 ```rust,ignore
-use eidetica::backend::database::Postgres;
+use eidetica::{Instance, NewUser};
 
-let backend = Postgres::connect("postgres://user:pass@localhost/mydb")?;
+// By URL — passed through to sqlx unchanged, so any sqlx-accepted query
+// string works (sslmode, application_name, etc.).
+let (instance, _) = Instance::connect_or_create(
+    "postgres://user:pass@localhost/mydb?sslmode=require",
+    NewUser::passwordless("alice"),
+).await?;
 ```
 
 ### InMemory
 
-The `InMemory` database is a simple in-memory storage implementation:
+The in-process backend is intended for tests, examples, and embedded apps that don't need durable storage. It can optionally serialize to and load from a JSON file via the `memory:///abs/path` URL form.
 
-- Stores all entries in memory
-- Can load from and save to a JSON file
-- Well-suited for development and testing
-- Simple to use and requires no external dependencies
+**Prefer sqlite's in-memory mode when the `sqlite` feature is enabled.** The `sqlite:file::memory:?cache=shared` URL exercises the same backend used in production, so integration tests stay closer to deployed behaviour. Reach for `memory://` only when you've built without the `sqlite` feature or specifically want the JSON-snapshot story.
 
-Example usage:
+**Not for production.** Prefer `sqlite://` (file-backed) or `postgres://` for any deployed workload. Specifically:
+
+- The JSON snapshot format is unstable (`_v: 0`); compatibility may break between versions.
+- The snapshot serializes the device signing key **in plaintext**. For `memory:///path.json`, that key ends up on disk in cleartext — fine for tests, unsafe for production.
+- Every `flush()` rewrites the full backend state; there's no incremental persistence, MVCC, or multi-process access.
+
+The ephemeral sqlite form uses `Instance::connect_or_create` like every other URL:
+
+<!-- Code block ignored: Requires async runtime context -->
+
+```rust,ignore
+use eidetica::{Instance, NewUser};
+
+let (instance, _) = Instance::connect_or_create(
+    "sqlite:file::memory:?cache=shared",
+    NewUser::passwordless("alice"),
+).await?;
+```
+
+The `memory://` URL forms remain useful for tests and short-lived embedded scenarios:
 
 <!-- Code block ignored: Requires file system access during testing -->
 
 ```rust,ignore
-// Create a new in-memory database
-use eidetica::backend::database::InMemory;
-let database = InMemory::new();
-let db = Instance::open(Box::new(database)).await?;
+use eidetica::{Instance, NewUser};
 
-// ... use the database ...
+// Ephemeral (state dies with the process).
+let (instance, _) =
+    Instance::connect_or_create("memory://", NewUser::passwordless("alice")).await?;
 
-// Save to a file (optional)
-let path = PathBuf::from("my_database.json");
-let database_guard = db.backend().lock().await;
-if let Some(in_memory) = database_guard.as_any().downcast_ref::<InMemory>() {
-    in_memory.save_to_file(&path).await?;
-}
-
-// Load from a file
-let database = InMemory::load_from_file(&path).await?;
-let db = Instance::open(Box::new(database)).await?;
+// With a JSON snapshot — loaded on construction, written by flush() or
+// (best-effort) by Drop. The snapshot path must be absolute.
+let (instance, _) = Instance::connect_or_create(
+    "memory:///var/lib/myapp/snap.json",
+    NewUser::passwordless("alice"),
+).await?;
+// ... do work ...
+instance.flush()?; // checkpoint the snapshot to disk atomically; instance keeps running
 ```
+
+`Instance::flush()` is the canonical way to checkpoint an in-memory snapshot. It's reentrant, sync, and takes `&self`, so call it as often as you like — the snapshot path stays armed and the instance keeps working after every flush. The signature is sync because the write itself is sync (`std::fs::write` + atomic rename); from a tokio task it briefly blocks the worker, negligible for small snapshots. The `Drop` impl falls back to a best-effort save on the last handle (errors are logged via `tracing::error!`, not surfaced) — apps that care about snapshot durability should call `flush()` at checkpoints and inspect the `Result`.
 
 ### Remote (Service Daemon)
 
-The `RemoteBackend` connects to an Eidetica [service daemon](../service.md) over a Unix domain socket. All storage operations are forwarded as RPCs to the daemon, which holds the actual backend. This enables multiple processes to share the same storage.
+A `unix://` URL connects to an Eidetica [service daemon](../service.md). All storage operations are forwarded as RPCs to the daemon, which holds the actual backend. This enables multiple client processes to share the same storage.
 
 <!-- Code block ignored: Requires a running daemon -->
 
 ```rust,ignore
 use eidetica::Instance;
 
-// Connect to a running daemon (uses RemoteBackend internally)
-let instance = Instance::connect("/tmp/eidetica.sock").await?;
+let instance = Instance::connect("unix:///run/eidetica/service.sock").await?;
+// Or, with env / default resolution:
+let instance = Instance::connect(eidetica::service::default_socket_url()).await?;
 ```
 
-The `service` feature must be enabled (included in the default `full` feature set). See [Service (Daemon) Mode](../service.md) for setup details.
+The `service` feature must be enabled (included in the default `full` feature set). `connect_or_create` against a `unix://` URL degrades to `connect` — the daemon owns its own initialisation. See [Service (Daemon) Mode](../service.md) for setup details.
 
 ## Database Trait Responsibilities
 

--- a/docs/src/user_guide/concepts/entries_databases.md
+++ b/docs/src/user_guide/concepts/entries_databases.md
@@ -58,7 +58,7 @@ You interact with Databases through Transactions:
 # #[tokio::main]
 # async fn main() -> Result<()> {
 #     let backend = Sqlite::in_memory().await?;
-#     let (instance, mut user) = eidetica::Instance::create(
+#     let (instance, mut user) = eidetica::Instance::create_backend(
 #         Box::new(backend),
 #         eidetica::NewUser::passwordless("alice"),
 #     ).await?;
@@ -90,7 +90,7 @@ Each Database maintains its settings as a key-value store in a special "settings
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
 # // Setup database for testing
-# let (instance, mut user) = eidetica::Instance::create(
+# let (instance, mut user) = eidetica::Instance::create_backend(
 #     Box::new(Sqlite::in_memory().await?),
 #     eidetica::NewUser::passwordless("alice"),
 # ).await?;

--- a/docs/src/user_guide/concepts/stores.md
+++ b/docs/src/user_guide/concepts/stores.md
@@ -49,7 +49,7 @@ The `DocStore` store provides a document-oriented interface for storing and retr
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
 # let backend = Box::new(Sqlite::in_memory().await?);
-# let (instance, mut user) = eidetica::Instance::create(
+# let (instance, mut user) = eidetica::Instance::create_backend(
 #     backend,
 #     eidetica::NewUser::passwordless("alice"),
 # ).await?;
@@ -91,7 +91,7 @@ When using `set_path("a.b.c", value)`, DocStore creates **nested maps**, not fla
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
 # let backend = Box::new(Sqlite::in_memory().await?);
-# let (instance, mut user) = eidetica::Instance::create(
+# let (instance, mut user) = eidetica::Instance::create_backend(
 #     backend,
 #     eidetica::NewUser::passwordless("alice"),
 # ).await?;
@@ -141,7 +141,7 @@ The `Table<T>` store manages collections of serializable items, similar to a tab
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
 # let backend = Box::new(Sqlite::in_memory().await?);
-# let (instance, mut user) = eidetica::Instance::create(
+# let (instance, mut user) = eidetica::Instance::create_backend(
 #     backend,
 #     eidetica::NewUser::passwordless("alice"),
 # ).await?;
@@ -217,7 +217,7 @@ The `SettingsStore` provides a specialized, type-safe interface for managing dat
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
 # let backend = Box::new(Sqlite::in_memory().await?);
-# let (instance, mut user) = eidetica::Instance::create(
+# let (instance, mut user) = eidetica::Instance::create_backend(
 #     backend,
 #     eidetica::NewUser::passwordless("alice"),
 # ).await?;
@@ -255,7 +255,7 @@ transaction.commit().await?;
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
 # // Setup database for testing
-# let (instance, mut user) = eidetica::Instance::create(
+# let (instance, mut user) = eidetica::Instance::create_backend(
 #     Box::new(Sqlite::in_memory().await?),
 #     eidetica::NewUser::passwordless("alice"),
 # ).await?;
@@ -299,7 +299,7 @@ Multiple auth operations within a transaction are accumulated in a single entry:
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
 # // Setup database for testing
-# let (instance, mut user) = eidetica::Instance::create(
+# let (instance, mut user) = eidetica::Instance::create_backend(
 #     Box::new(Sqlite::in_memory().await?),
 #     eidetica::NewUser::passwordless("alice"),
 # ).await?;
@@ -375,7 +375,7 @@ The `YDoc` store provides integration with Y-CRDT (Yjs) for real-time collaborat
 # async fn main() -> eidetica::Result<()> {
 # // Setup database for testing
 # let backend = Sqlite::in_memory().await?;
-# let (instance, mut user) = eidetica::Instance::create(
+# let (instance, mut user) = eidetica::Instance::create_backend(
 #     Box::new(backend),
 #     eidetica::NewUser::passwordless("alice"),
 # ).await?;
@@ -456,7 +456,7 @@ When you first access a Store using `Transaction::get_store()`, it's automatical
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
 # let backend = Box::new(Sqlite::in_memory().await?);
-# let (instance, mut user) = eidetica::Instance::create(
+# let (instance, mut user) = eidetica::Instance::create_backend(
 #     backend,
 #     eidetica::NewUser::passwordless("alice"),
 # ).await?;
@@ -493,7 +493,7 @@ Use `get_index()` to query information about registered subtrees:
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
 # let backend = Box::new(Sqlite::in_memory().await?);
-# let (instance, mut user) = eidetica::Instance::create(
+# let (instance, mut user) = eidetica::Instance::create_backend(
 #     backend,
 #     eidetica::NewUser::passwordless("alice"),
 # ).await?;

--- a/docs/src/user_guide/encryption_guide.md
+++ b/docs/src/user_guide/encryption_guide.md
@@ -12,7 +12,7 @@
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
 # let backend = Box::new(Sqlite::in_memory().await?);
-# let (instance, mut user) = eidetica::Instance::create(
+# let (instance, mut user) = eidetica::Instance::create_backend(
 #     backend,
 #     eidetica::NewUser::passwordless("alice"),
 # ).await?;
@@ -43,7 +43,7 @@ tx.commit().await?;
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
 # let backend = Box::new(Sqlite::in_memory().await?);
-# let (instance, mut user) = eidetica::Instance::create(
+# let (instance, mut user) = eidetica::Instance::create_backend(
 #     backend,
 #     eidetica::NewUser::passwordless("alice"),
 # ).await?;
@@ -85,7 +85,7 @@ tx.commit().await?;
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
 # let backend = Box::new(Sqlite::in_memory().await?);
-# let (instance, mut user) = eidetica::Instance::create(
+# let (instance, mut user) = eidetica::Instance::create_backend(
 #     backend,
 #     eidetica::NewUser::passwordless("alice"),
 # ).await?;

--- a/docs/src/user_guide/examples_snippets.md
+++ b/docs/src/user_guide/examples_snippets.md
@@ -6,28 +6,28 @@ _Assumes basic setup like `use eidetica::{Instance, Database, Error, ...};` and 
 
 ## 1. Initializing the Database (`Instance`)
 
+`Instance::connect_or_create` dispatches by URL scheme. See the [backends concepts page](concepts/backends.md) for the full URL grammar.
+
 <!-- Code block ignored: Requires file system access during testing -->
 
 ```rust,ignore
-use eidetica::{backend::database::Sqlite, Instance};
-use std::path::PathBuf;
+use eidetica::{Instance, NewUser};
 
 #[tokio::main]
 async fn main() -> eidetica::Result<()> {
-    let db_path = PathBuf::from("my_data.db");
+    // Option A: ephemeral in-memory backend (for tests / short-lived processes)
+    let (_instance, _) =
+        Instance::connect_or_create("memory://", NewUser::passwordless("alice")).await?;
 
-    // Option A: Create an in-memory database (for testing)
-    let backend = Sqlite::in_memory().await?;
-    let _instance = Instance::open(Box::new(backend)).await?;
+    // Option B: persistent SQLite database — created on first run, loaded on
+    // subsequent runs. The URL is passed through to sqlx, so any sqlx form
+    // works.
+    let (instance, _) = Instance::connect_or_create(
+        "sqlite://./my_data.db",
+        NewUser::passwordless("alice"),
+    ).await?;
 
-    // Option B: Create or open a persistent SQLite database
-    // SQLite automatically creates the file if it doesn't exist
-    let backend = Sqlite::open(&db_path).await?;
-    let instance = Instance::open(Box::new(backend)).await?;
-
-    // Data persists automatically with SQLite file backend
-    println!("Database opened at {:?}", db_path);
-
+    println!("Database opened at sqlite://./my_data.db");
     Ok(())
 }
 ```
@@ -41,7 +41,7 @@ async fn main() -> eidetica::Result<()> {
 #
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
-# let (instance, mut user) = eidetica::Instance::create(
+# let (instance, mut user) = eidetica::Instance::create_backend(
 #     Box::new(Sqlite::in_memory().await?),
 #     eidetica::NewUser::passwordless("alice"),
 # ).await?;
@@ -76,7 +76,7 @@ println!("Using Database with root ID: {}", database.root_id());
 #
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
-# let (instance, mut user) = eidetica::Instance::create(
+# let (instance, mut user) = eidetica::Instance::create_backend(
 #     Box::new(Sqlite::in_memory().await?),
 #     eidetica::NewUser::passwordless("alice"),
 # ).await?;
@@ -127,7 +127,7 @@ struct Task {
 
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
-# let (instance, mut user) = eidetica::Instance::create(
+# let (instance, mut user) = eidetica::Instance::create_backend(
 #     Box::new(Sqlite::in_memory().await?),
 #     eidetica::NewUser::passwordless("alice"),
 # ).await?;
@@ -182,7 +182,7 @@ println!("Table changes committed in entry: {}", entry_id);
 #
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
-# let (instance, mut user) = eidetica::Instance::create(
+# let (instance, mut user) = eidetica::Instance::create_backend(
 #     Box::new(Sqlite::in_memory().await?),
 #     eidetica::NewUser::passwordless("alice"),
 # ).await?;
@@ -232,7 +232,7 @@ match config_viewer.get("retry_count").await {
 #
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
-# let (instance, mut user) = eidetica::Instance::create(
+# let (instance, mut user) = eidetica::Instance::create_backend(
 #     Box::new(Sqlite::in_memory().await?),
 #     eidetica::NewUser::passwordless("alice"),
 # ).await?;
@@ -279,7 +279,7 @@ match tasks_viewer.search(|_| true).await {
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
 # // Setup database for testing
-# let (instance, mut user) = eidetica::Instance::create(
+# let (instance, mut user) = eidetica::Instance::create_backend(
 #     Box::new(Sqlite::in_memory().await?),
 #     eidetica::NewUser::passwordless("alice"),
 # ).await?;
@@ -350,7 +350,7 @@ The `YDoc` store provides access to Y-CRDT (Yrs) documents for collaborative dat
 # async fn main() -> eidetica::Result<()> {
 # // Setup database for testing
 # let backend = Sqlite::in_memory().await?;
-# let (instance, mut user) = eidetica::Instance::create(
+# let (instance, mut user) = eidetica::Instance::create_backend(
 #     Box::new(backend),
 #     eidetica::NewUser::passwordless("alice"),
 # ).await?;
@@ -474,14 +474,15 @@ use std::path::PathBuf;
 
 #[tokio::main]
 async fn main() -> eidetica::Result<()> {
-    let db_path = PathBuf::from("my_database.db");
+    // Create or open a persistent SQLite database by URL. The URL is
+    // passed through to sqlx, so any sqlx-accepted form works.
+    let (instance, _maybe_user) = Instance::connect_or_create(
+        "sqlite://./my_database.db",
+        eidetica::NewUser::passwordless("admin"),
+    ).await?;
 
-    // Create or open a SQLite database file
-    // Data is automatically persisted on each commit
-    let backend = Sqlite::open(&db_path).await?;
-    let instance = Instance::open(Box::new(backend)).await?;
-
-    // Create user via the bootstrapped admin, then log in as the new user
+    // Subsequent runs land on the load arm (`_maybe_user` is `None`); the
+    // operator creates and logs in additional users through the admin path.
     let admin = instance.login_user("admin", None).await?;
     admin.admin().await?.create_user(eidetica::NewUser::passwordless("alice")).await?;
     let mut user = instance.login_user("alice", None).await?;
@@ -490,18 +491,17 @@ async fn main() -> eidetica::Result<()> {
     let default_key = user.get_default_key()?;
     let _database = user.create_database(settings, &default_key).await?;
 
-    // All changes are automatically saved to my_database.db
-    println!("Database created/opened at {:?}", db_path);
-
+    println!("Database created/opened at sqlite://./my_database.db");
     Ok(())
 }
 ```
 
 **Key Points:**
 
-- SQLite automatically handles persistence - no manual save needed
-- Use `Sqlite::in_memory()?` for testing without disk I/O
-- Use `Sqlite::open(&path).await?` for persistent storage
+- SQLite automatically handles persistence — no manual save needed.
+- Use `memory://` for ephemeral state (tests, throwaway processes).
+- Use `sqlite://./path.db` (or any sqlx-accepted URL) for persistent storage.
+- Use `memory:///abs/path/snap.json` if you want in-memory speed plus an opt-in JSON snapshot.
 
 ---
 
@@ -520,7 +520,7 @@ from the default (Verified-frontier) view until this node validates them.
 #
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
-# let (instance, mut user) = eidetica::Instance::create(
+# let (instance, mut user) = eidetica::Instance::create_backend(
 #     Box::new(Sqlite::in_memory().await?),
 #     eidetica::NewUser::passwordless("alice"),
 # ).await?;
@@ -578,9 +578,9 @@ The chat example demonstrates several advanced patterns:
 
 ```rust,ignore
 // Initialize instance with sync enabled
-let backend = Sqlite::in_memory().await?;
-let instance = Instance::create(Box::new(backend))?;
-instance.enable_sync()?;
+let (instance, _) =
+    Instance::connect_or_create("memory://", NewUser::passwordless("admin")).await?;
+instance.enable_sync().await?;
 
 // Create passwordless user (or use existing) via the bootstrapped admin
 let username = "alice";

--- a/docs/src/user_guide/getting_started.md
+++ b/docs/src/user_guide/getting_started.md
@@ -34,20 +34,19 @@ Here's a simple example:
 ```rust
 # extern crate eidetica;
 # extern crate tokio;
-# use eidetica::{backend::database::Sqlite, Instance, crdt::Doc};
+# use eidetica::{Instance, NewUser, crdt::Doc};
 #
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
-    // Create a new in-memory backend
-    let backend = Sqlite::in_memory().await?;
-
-    // Initialise the Instance with Alice as the initial admin user.
-    // The first user created on an instance is automatically granted
+    // Open or initialise an Instance from a URL. `memory://` is an
+    // ephemeral in-process backend — great for tests and embedded use.
+    // The first user created on a fresh instance is automatically granted
     // Admin on the system databases.
-    let (_instance, mut user) = Instance::create(
-        Box::new(backend),
-        eidetica::NewUser::passwordless("alice"),
+    let (_instance, maybe_user) = Instance::connect_or_create(
+        "memory://",
+        NewUser::passwordless("alice"),
     ).await?;
+    let mut user = maybe_user.expect("memory:// is always fresh");
 
     // Create a database in the user's context
     let mut settings = Doc::new();
@@ -61,45 +60,53 @@ Here's a simple example:
 }
 ```
 
-**Note**: This example uses a passwordless user (password is `None`) for simplicity, which is perfect for embedded applications and CLI tools. For multi-user scenarios, you can create password-protected users by passing `Some("password")` instead.
+**Note**: This example uses a passwordless user for simplicity, which is perfect for embedded applications and CLI tools. For multi-user scenarios, create password-protected users with `NewUser::with_password("alice", "pwd")` instead.
 
-The backend determines how your data is stored. The example above uses `Sqlite::in_memory()`, which keeps everything in memory. For persistent storage, use a file-based SQLite database:
+The URL passed to [`Instance::connect_or_create`](https://docs.rs/eidetica/latest/eidetica/struct.Instance.html#method.connect_or_create) selects the backend. Some other common forms:
+
+- `memory://` — ephemeral in-process backend (above).
+- `memory:///abs/path/snap.json` — in-process backend with a JSON snapshot file (load-on-start, writes via [`Instance::flush`](https://docs.rs/eidetica/latest/eidetica/struct.Instance.html#method.flush)).
+- `sqlite://./my_data.db` — embedded SQLite database, persisted automatically. The URL is passed through to `sqlx`, so any sqlx-accepted form works (`?journal_mode=WAL`, `?busy_timeout=5000`, etc.).
+- `postgres://user:pwd@host/db` — embedded PostgreSQL backend.
+- `unix:///run/eidetica/service.sock` — connect to a running [daemon](service.md).
+
+For persistent storage, swap the URL:
 
 <!-- Code block ignored: Requires file system access during testing -->
 
 ```rust,ignore
-use eidetica::{Instance, backend::database::Sqlite, crdt::Doc};
+use eidetica::{Instance, NewUser, crdt::Doc};
 
 #[tokio::main]
 async fn main() -> eidetica::Result<()> {
-    // Create a persistent SQLite backend (data is saved automatically)
-    let backend = Sqlite::open("my_data.db").await?;
-    let instance = Instance::open(Box::new(backend)).await?;
+    // First run: bootstrap a fresh persistent instance.
+    // Subsequent runs: load the existing instance (Option<User> is None).
+    let (instance, maybe_user) = Instance::connect_or_create(
+        "sqlite://./my_data.db",
+        NewUser::passwordless("alice"),
+    ).await?;
 
-    // Create user via the bootstrapped admin
-    let admin = instance.login_user("admin", None).await?;
-    admin.admin().await?.create_user(eidetica::NewUser::passwordless("alice")).await?;
-    let mut user = instance.login_user("alice", None).await?;
+    let mut user = match maybe_user {
+        Some(u) => u,
+        None => instance.login_user("alice", None).await?,
+    };
     // ... all changes are automatically persisted to my_data.db
 
     Ok(())
 }
 ```
 
-You can reopen a previously created database:
+When you only want to load an already-initialised database (strict — errors if missing), use [`Instance::connect`](https://docs.rs/eidetica/latest/eidetica/struct.Instance.html#method.connect):
 
 <!-- Code block ignored: Requires file system access during testing -->
 
 ```rust,ignore
-use eidetica::{Instance, backend::database::Sqlite};
+use eidetica::Instance;
 
 #[tokio::main]
 async fn main() -> eidetica::Result<()> {
-    // Reopen existing SQLite database
-    let backend = Sqlite::open("my_data.db").await?;
-    let instance = Instance::open(Box::new(backend)).await?;
-
-    // Login to existing user
+    // Strict load — errors if the database isn't initialised yet.
+    let instance = Instance::connect("sqlite://./my_data.db").await?;
     let user = instance.login_user("alice", None).await?;
     // ... data persists across restarts
 
@@ -167,7 +174,7 @@ All operations in Eidetica happen within an atomic **Transaction**:
 #
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
-# let (instance, mut user) = eidetica::Instance::create(
+# let (instance, mut user) = eidetica::Instance::create_backend(
 #     Box::new(Sqlite::in_memory().await?),
 #     eidetica::NewUser::passwordless("alice"),
 # ).await?;
@@ -209,7 +216,7 @@ txn.commit().await?;
 #
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
-# let (instance, mut user) = eidetica::Instance::create(
+# let (instance, mut user) = eidetica::Instance::create_backend(
 #     Box::new(Sqlite::in_memory().await?),
 #     eidetica::NewUser::passwordless("alice"),
 # ).await?;
@@ -258,7 +265,7 @@ for (id, person) in all_people {
 #
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
-# let (instance, mut user) = eidetica::Instance::create(
+# let (instance, mut user) = eidetica::Instance::create_backend(
 #     Box::new(Sqlite::in_memory().await?),
 #     eidetica::NewUser::passwordless("alice"),
 # ).await?;
@@ -304,7 +311,7 @@ txn.commit().await?;
 #
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
-# let (instance, mut user) = eidetica::Instance::create(
+# let (instance, mut user) = eidetica::Instance::create_backend(
 #     Box::new(Sqlite::in_memory().await?),
 #     eidetica::NewUser::passwordless("alice"),
 # ).await?;

--- a/docs/src/user_guide/index.md
+++ b/docs/src/user_guide/index.md
@@ -45,7 +45,7 @@ Here's a quick example showing creating a user, database, and writing new data.
 # extern crate eidetica;
 # extern crate tokio;
 # extern crate serde;
-# use eidetica::{backend::database::Sqlite, Instance, crdt::Doc, store::{DocStore, Table}};
+# use eidetica::{Instance, NewUser, crdt::Doc, store::{DocStore, Table}};
 # use serde::{Serialize, Deserialize};
 #
 # #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -55,11 +55,11 @@ Here's a quick example showing creating a user, database, and writing new data.
 #
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
-let backend = Sqlite::in_memory().await?;
-let (instance, mut user) = Instance::create(
-    Box::new(backend),
-    eidetica::NewUser::passwordless("alice"),
-).await?;
+// Open an Instance by URL — `memory://` is ephemeral; use `sqlite://./app.db`
+// for persistent storage. See the backends concepts page for the URL grammar.
+let (instance, maybe_user) =
+    Instance::connect_or_create("memory://", NewUser::passwordless("alice")).await?;
+let mut user = maybe_user.expect("memory:// is always fresh");
 
 
 // Create a database

--- a/docs/src/user_guide/logging.md
+++ b/docs/src/user_guide/logging.md
@@ -84,7 +84,7 @@ Once you've initialized a tracing subscriber, all Eidetica operations will autom
 # async fn main() -> eidetica::Result<()> {
 let backend = Box::new(Sqlite::in_memory().await?);
 // Initialise with alice as the first/admin user — this logs at INFO level.
-let (instance, mut user) = Instance::create(
+let (instance, mut user) = Instance::create_backend(
     backend,
     eidetica::NewUser::passwordless("alice"),
 ).await?;

--- a/docs/src/user_guide/service.md
+++ b/docs/src/user_guide/service.md
@@ -11,7 +11,7 @@ Daemon mode is useful when:
 - **Background sync** should persist across short-lived client sessions
 - A **long-running process** manages storage while lightweight clients connect on demand
 
-For single-process applications, `Instance::open()` with a local backend is simpler and has no IPC overhead.
+For single-process applications, `Instance::open_backend()` with a local backend is simpler and has no IPC overhead.
 
 ## Starting the Daemon
 
@@ -48,12 +48,13 @@ To start a daemon from Rust code:
 <!-- Code block ignored: Requires async runtime and Unix socket -->
 
 ```rust,ignore
-use eidetica::{Instance, backend::database::Sqlite};
+use eidetica::Instance;
 use eidetica::service::ServiceServer;
 use tokio::sync::watch;
 
-let backend = Sqlite::open("my_data.db").await?;
-let instance = Instance::open(Box::new(backend)).await?;
+// `Instance::connect` accepts a URL describing the backend; here the
+// daemon serves a sqlite file. See the rustdoc for the full URL grammar.
+let instance = Instance::connect("sqlite://./my_data.db").await?;
 
 let (shutdown_tx, shutdown_rx) = watch::channel(());
 let server = ServiceServer::new(instance, "/tmp/eidetica.sock");
@@ -65,7 +66,7 @@ server.run(shutdown_rx).await?;
 
 ## Connecting Clients
 
-Use `Instance::connect()` to create a client-side Instance that communicates with the daemon:
+Clients reach the daemon by passing a `unix://` URL to `Instance::connect`:
 
 <!-- Code block ignored: Requires a running daemon -->
 
@@ -73,7 +74,7 @@ Use `Instance::connect()` to create a client-side Instance that communicates wit
 use eidetica::Instance;
 
 // Connect to a running daemon
-let instance = Instance::connect("/tmp/eidetica.sock").await?;
+let instance = Instance::connect("unix:///tmp/eidetica.sock").await?;
 
 // Use it exactly like a local Instance. The daemon was initialised with
 // an initial admin user via `eidetica daemon init --username ops`
@@ -131,12 +132,12 @@ Multiple clients can connect to the same daemon simultaneously. Each client main
 
 ```rust,ignore
 // Client 1: an admin session creates the new user via the InstanceAdmin path.
-let instance1 = Instance::connect("/tmp/eidetica.sock").await?;
+let instance1 = Instance::connect("unix:///tmp/eidetica.sock").await?;
 let admin = instance1.login_user("ops", None).await?;
 admin.admin().await?.create_user(eidetica::NewUser::passwordless("alice")).await?;
 
 // Client 2 (separate process or task): log in as the user that was just created.
-let instance2 = Instance::connect("/tmp/eidetica.sock").await?;
+let instance2 = Instance::connect("unix:///tmp/eidetica.sock").await?;
 let user = instance2.login_user("alice", None).await?;
 ```
 

--- a/docs/src/user_guide/sync_quick_reference.md
+++ b/docs/src/user_guide/sync_quick_reference.md
@@ -14,7 +14,7 @@ use eidetica::sync::transports::http::HttpTransport;
 
 // Create database with sync enabled
 let backend = Box::new(Sqlite::in_memory().await?);
-let (instance, mut user) = Instance::create(
+let (instance, mut user) = Instance::create_backend(
     backend,
     eidetica::NewUser::passwordless("alice"),
 ).await?;
@@ -39,7 +39,7 @@ sync.accept_connections().await?;
 # async fn main() -> eidetica::Result<()> {
 # // Setup database instance with sync capability
 # let backend = Box::new(Sqlite::in_memory().await?);
-# let (db, _) = Instance::open_or_create(
+# let (db, _) = Instance::connect_or_create_backend(
 #     backend,
 #     eidetica::NewUser::passwordless("admin"),
 # ).await?;
@@ -77,7 +77,7 @@ Declare sync intent with automatic background synchronization:
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
 # let backend = Box::new(Sqlite::in_memory().await?);
-# let (instance, _) = Instance::open_or_create(
+# let (instance, _) = Instance::connect_or_create_backend(
 #     backend,
 #     eidetica::NewUser::passwordless("admin"),
 # ).await?;
@@ -251,7 +251,7 @@ db.sync()?.update_peer_status(&peer_key, PeerStatus::Inactive)?;
 # async fn main() -> eidetica::Result<()> {
 # use eidetica::sync::transports::http::HttpTransport;
 # let backend = Box::new(Sqlite::in_memory().await?);
-# let (instance, _) = Instance::open_or_create(
+# let (instance, _) = Instance::connect_or_create_backend(
 #     backend,
 #     eidetica::NewUser::passwordless("admin"),
 # ).await?;
@@ -606,12 +606,12 @@ let peer = db.sync()?.connect_to_peer(&addr).await?;
 use eidetica::sync::transports::http::HttpTransport;
 
 // Run multiple sync-enabled databases
-let db1 = Instance::open(Box::new(Sqlite::in_memory().await?)).await?;
+let db1 = Instance::open_backend(Box::new(Sqlite::in_memory().await?)).await?;
 db1.enable_sync().await?;
 db1.sync()?.register_transport("http", HttpTransport::builder().bind("127.0.0.1:8080")).await?;
 db1.sync()?.accept_connections().await?;
 
-let db2 = Instance::open(Box::new(Sqlite::in_memory().await?)).await?;
+let db2 = Instance::open_backend(Box::new(Sqlite::in_memory().await?)).await?;
 db2.enable_sync().await?;
 db2.sync()?.register_transport("http", HttpTransport::builder().bind("127.0.0.1:8081")).await?;
 db2.sync()?.accept_connections().await?;
@@ -634,14 +634,14 @@ async fn test_iroh_sync_local() -> Result<()> {
     use eidetica::sync::transports::iroh::IrohTransport;
 
     // Setup databases with local Iroh transport (no relay servers)
-    let db1 = Instance::open(Box::new(Sqlite::in_memory().await?)).await?;
+    let db1 = Instance::open_backend(Box::new(Sqlite::in_memory().await?)).await?;
     db1.enable_sync().await?;
     db1.sync()?.register_transport("iroh", IrohTransport::builder()
         .relay_mode(RelayMode::Disabled)
     ).await?;
     db1.sync()?.accept_connections().await?;
 
-    let db2 = Instance::open(Box::new(Sqlite::in_memory().await?)).await?;
+    let db2 = Instance::open_backend(Box::new(Sqlite::in_memory().await?)).await?;
     db2.enable_sync().await?;
     db2.sync()?.register_transport("iroh", IrohTransport::builder()
         .relay_mode(RelayMode::Disabled)
@@ -670,8 +670,8 @@ use eidetica::sync::transports::http::HttpTransport;
 
 #[tokio::test]
 async fn test_sync_between_peers() -> Result<()> {
-    // Setup first peer (Instance::create bootstraps the first user as admin)
-    let (instance1, mut user1) = Instance::create(
+    // Setup first peer (Instance::create_backend bootstraps the first user as admin)
+    let (instance1, mut user1) = Instance::create_backend(
         Box::new(Sqlite::in_memory().await?),
         eidetica::NewUser::passwordless("peer1"),
     ).await?;
@@ -682,7 +682,7 @@ async fn test_sync_between_peers() -> Result<()> {
     let addr1 = instance1.sync()?.get_server_address_async().await?;
 
     // Setup second peer
-    let (instance2, mut user2) = Instance::create(
+    let (instance2, mut user2) = Instance::create_backend(
         Box::new(Sqlite::in_memory().await?),
         eidetica::NewUser::passwordless("peer2"),
     ).await?;

--- a/docs/src/user_guide/synchronization_guide.md
+++ b/docs/src/user_guide/synchronization_guide.md
@@ -14,7 +14,7 @@ Eidetica's sync system enables real-time data synchronization between distribute
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
 # let backend = Box::new(Sqlite::in_memory().await?);
-let (instance, mut user) = Instance::create(
+let (instance, mut user) = Instance::create_backend(
     backend,
     eidetica::NewUser::passwordless("alice"),
 ).await?;
@@ -170,7 +170,7 @@ For persistent sync relationships:
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
 # let backend = Box::new(Sqlite::in_memory().await?);
-# let (instance, _) = Instance::open_or_create(
+# let (instance, _) = Instance::connect_or_create_backend(
 #     backend,
 #     eidetica::NewUser::passwordless("admin"),
 # ).await?;
@@ -213,7 +213,7 @@ Configure per-database sync behavior:
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
 # let backend = Box::new(Sqlite::in_memory().await?);
-# let (instance, _) = Instance::open_or_create(
+# let (instance, _) = Instance::connect_or_create_backend(
 #     backend,
 #     eidetica::NewUser::passwordless("admin"),
 # ).await?;

--- a/docs/src/user_guide/transactions.md
+++ b/docs/src/user_guide/transactions.md
@@ -31,7 +31,7 @@ Using a `Transaction` follows a distinct lifecycle:
     # async fn main() -> eidetica::Result<()> {
     # // Setup database
     # let backend = Sqlite::in_memory().await?;
-    # let (instance, mut user) = Instance::create(
+    # let (instance, mut user) = Instance::create_backend(
     #     Box::new(backend),
     #     eidetica::NewUser::passwordless("alice"),
     # ).await?;
@@ -63,7 +63,7 @@ Using a `Transaction` follows a distinct lifecycle:
     # async fn main() -> eidetica::Result<()> {
     # // Setup database and transaction
     # let backend = Sqlite::in_memory().await?;
-    # let (instance, mut user) = Instance::create(
+    # let (instance, mut user) = Instance::create_backend(
     #     Box::new(backend),
     #     eidetica::NewUser::passwordless("alice"),
     # ).await?;
@@ -101,7 +101,7 @@ Using a `Transaction` follows a distinct lifecycle:
     # async fn main() -> eidetica::Result<()> {
     # // Setup database and transaction
     # let backend = Sqlite::in_memory().await?;
-    # let (instance, mut user) = Instance::create(
+    # let (instance, mut user) = Instance::create_backend(
     #     Box::new(backend),
     #     eidetica::NewUser::passwordless("alice"),
     # ).await?;
@@ -138,7 +138,7 @@ Using a `Transaction` follows a distinct lifecycle:
     # async fn main() -> eidetica::Result<()> {
     # // Setup database
     # let backend = Sqlite::in_memory().await?;
-    # let (instance, mut user) = Instance::create(
+    # let (instance, mut user) = Instance::create_backend(
     #     Box::new(backend),
     #     eidetica::NewUser::passwordless("alice"),
     # ).await?;
@@ -176,7 +176,7 @@ For the common pattern of "create a transaction, do some work, commit," `Databas
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
 # let backend = Sqlite::in_memory().await?;
-# let (instance, mut user) = eidetica::Instance::create(
+# let (instance, mut user) = eidetica::Instance::create_backend(
 #     Box::new(backend),
 #     eidetica::NewUser::passwordless("alice"),
 # ).await?;
@@ -220,7 +220,7 @@ Within transactions, you can manage database settings using `SettingsStore`. Thi
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
 # // Setup database for testing
-# let (instance, mut user) = eidetica::Instance::create(
+# let (instance, mut user) = eidetica::Instance::create_backend(
 #     Box::new(Sqlite::in_memory().await?),
 #     eidetica::NewUser::passwordless("alice"),
 # ).await?;
@@ -283,7 +283,7 @@ Configure the height strategy for the entire database via `SettingsStore`:
 #
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
-# let (instance, mut user) = eidetica::Instance::create(
+# let (instance, mut user) = eidetica::Instance::create_backend(
 #     Box::new(Sqlite::in_memory().await?),
 #     eidetica::NewUser::passwordless("alice"),
 # ).await?;
@@ -313,7 +313,7 @@ Individual stores can override the database strategy for independent height trac
 #
 # #[tokio::main]
 # async fn main() -> eidetica::Result<()> {
-# let (instance, mut user) = eidetica::Instance::create(
+# let (instance, mut user) = eidetica::Instance::create_backend(
 #     Box::new(Sqlite::in_memory().await?),
 #     eidetica::NewUser::passwordless("alice"),
 # ).await?;
@@ -366,7 +366,7 @@ While `Transaction`s are essential for writes, you can perform reads without an 
 # async fn main() -> eidetica::Result<()> {
 # // Setup database with some data
 # let backend = Sqlite::in_memory().await?;
-# let (instance, mut user) = eidetica::Instance::create(
+# let (instance, mut user) = eidetica::Instance::create_backend(
 #     Box::new(backend),
 #     eidetica::NewUser::passwordless("alice"),
 # ).await?;

--- a/docs/src/user_guide/tutorial_todo_app.md
+++ b/docs/src/user_guide/tutorial_todo_app.md
@@ -10,37 +10,40 @@ The Todo example demonstrates Eidetica's key components working together in a re
 
 The `Instance` is your main entry point. It wraps a storage backend and manages users and databases.
 
-The Todo example implements `load_or_create_instance()` to handle loading existing backends or creating new ones:
+The Todo example loads or initialises an instance by URL. `connect_or_create` handles both the first-run and reopen cases:
 
 ```rust,ignore
-async fn load_or_create_instance(path: &PathBuf) -> Result<Instance> {
-    // SQLite handles both creation and loading automatically
-    let backend = Sqlite::open(path).await?;
-    let instance = Instance::open(Box::new(backend)).await?;
+async fn load_or_create_instance(path: &Path) -> Result<Instance> {
+    // SQLite handles both creation and loading automatically.
+    // The URL is passed through to sqlx — `mode=rwc` tells sqlx to
+    // create the database file on first run if it doesn't exist.
+    let url = format!("sqlite://{}?mode=rwc", path.display());
+    let (instance, _maybe_user) =
+        Instance::connect_or_create(&url, NewUser::passwordless("todo-user")).await?;
 
     println!("✓ Instance initialized");
-
     Ok(instance)
 }
 ```
 
-This shows how the `Sqlite` backend provides persistent storage. Data is automatically saved to the SQLite file. Authentication is managed through the User system (see below).
+Data is automatically saved to the SQLite file. Authentication is managed through the User system (see below).
 
 ### 2. Users (`User`)
 
-Users provide authenticated access to databases. A `User` manages signing keys and database access. The Todo example creates a passwordless user for simplicity, bootstrapping it as the initial admin on a fresh data file via `Instance::open_or_create`:
+Users provide authenticated access to databases. A `User` manages signing keys and database access. The Todo example creates a passwordless user for simplicity, bootstrapping it as the initial admin on a fresh data file via `Instance::connect_or_create`:
 
 ```rust,ignore
-async fn load_or_create_instance_and_user(
-    backend: Box<dyn BackendImpl>,
-) -> Result<(Instance, User)> {
+async fn load_or_create_instance_and_user(path: &Path) -> Result<(Instance, User)> {
     let username = "todo-user";
+    // SQLite via the URL surface — `sqlite://<path>` is handed through to
+    // sqlx, and `mode=rwc` tells sqlx to create the file on first run.
+    let url = format!("sqlite://{}?mode=rwc", path.display());
 
-    // open_or_create returns Some(user) only when bootstrapping a fresh
-    // backend — on subsequent runs it loads the existing instance and
-    // returns None for the user, so we log back in.
+    // connect_or_create returns Some(user) only when bootstrapping a
+    // fresh backend — on subsequent runs it loads the existing instance
+    // and returns None for the user, so we log back in.
     let (instance, maybe_user) =
-        Instance::open_or_create(backend, NewUser::passwordless(username)).await?;
+        Instance::connect_or_create(&url, NewUser::passwordless(username)).await?;
 
     let user = match maybe_user {
         Some(u) => {

--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -10,7 +10,7 @@ use crossterm::{
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
-use eidetica::{Instance, Result, backend::database::InMemory};
+use eidetica::{Instance, Result};
 use handlers::handle_key_event;
 use ratatui::{Terminal, backend::CrosstermBackend};
 use std::io;
@@ -56,22 +56,18 @@ async fn main() -> Result<()> {
         .or_else(|| std::env::var("USER").ok())
         .unwrap_or_else(|| "Anonymous".to_string());
 
-    // Initialise Eidetica with sync enabled. `open_or_create` matches the
-    // "first run is your first run" UX of an embedded chat client:
-    // whoever launches the example becomes their own admin on first
-    // launch, and the same data dir loads them on subsequent runs.
+    // Initialise Eidetica with sync enabled. `memory://` is ephemeral —
+    // state lives only for the lifetime of this process. Switch to
+    // `sqlite://./chat.db` or `memory:///abs/path/snapshot.json` to keep
+    // history across runs; this example deliberately stays stateless so
+    // each launch is its own room.
     use eidetica::NewUser;
-    let backend = InMemory::new();
     let (instance, maybe_user) =
-        Instance::open_or_create(Box::new(backend), NewUser::passwordless(&username)).await?;
+        Instance::connect_or_create("memory://", NewUser::passwordless(&username)).await?;
     instance.enable_sync().await?;
 
-    // Use the just-created session on first run, or log back in on
-    // subsequent runs.
-    let user = match maybe_user {
-        Some(u) => u,
-        None => instance.login_user(&username, None).await?,
-    };
+    // `memory://` is always a fresh backend
+    let user = maybe_user.expect("memory:// is always fresh on first run");
 
     // Validate and parse transport
     let transport = match args.transport.to_lowercase().as_str() {

--- a/examples/todo/src/main.rs
+++ b/examples/todo/src/main.rs
@@ -1,21 +1,20 @@
 use chrono::{DateTime, Utc};
 use clap::{Parser, Subcommand};
 use eidetica::{
-    Database, Error, Instance, Result,
-    backend::database::InMemory,
+    Database, Instance, Result,
     crdt::Doc,
     store::{StoreError, Table, YDoc},
     user::User,
     y_crdt::{Map as YMap, Transact},
 };
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 struct Cli {
-    /// Path to the database file to use
-    #[arg(short, long, default_value = "todo_db.json")]
+    /// Path to the SQLite database file to use.
+    #[arg(short, long, default_value = "todo.db")]
     database_path: PathBuf,
 
     #[command(subcommand)]
@@ -94,7 +93,7 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     // Load or create the instance + the single application user.
-    let (instance, mut user) = load_or_create_instance_and_user(&cli.database_path).await?;
+    let (_instance, mut user) = load_or_create_instance_and_user(&cli.database_path).await?;
 
     // Load or create the todo database
     let todo_database = load_or_create_todo_database(&mut user).await?;
@@ -138,29 +137,28 @@ async fn main() -> Result<()> {
         return Err(e);
     }
 
-    // Save the instance
-    save_instance(&instance, &cli.database_path).await
+    // SQLite handles persistence inline — every committed transaction is
+    // durable, so there's no explicit save step.
+    Ok(())
 }
 
 /// Open (or bootstrap) the embedded instance and return it together with
 /// the single application user.
 ///
-/// On a fresh data file, [`Instance::open_or_create`] mints the
+/// On a fresh data file, [`Instance::connect_or_create`] mints the
 /// `todo-user` as the initial admin (the example is single-user). On
 /// subsequent runs the file already has metadata, so the call loads the
 /// existing instance and we log back in.
-async fn load_or_create_instance_and_user(path: &PathBuf) -> Result<(Instance, User)> {
+async fn load_or_create_instance_and_user(path: &Path) -> Result<(Instance, User)> {
     use eidetica::NewUser;
 
     let username = "todo-user";
-    let backend: Box<dyn eidetica::backend::BackendImpl> = if path.exists() {
-        Box::new(InMemory::load_from_file(path).await?)
-    } else {
-        Box::new(InMemory::new())
-    };
+    // SQLite via the URL surface — `sqlite://<path>` is handed through to
+    // sqlx, and `mode=rwc` tells sqlx to create the file on first run.
+    let url = format!("sqlite://{}?mode=rwc", path.display());
 
     let (instance, maybe_user) =
-        Instance::open_or_create(backend, NewUser::passwordless(username)).await?;
+        Instance::connect_or_create(&url, NewUser::passwordless(username)).await?;
 
     let user = match maybe_user {
         Some(u) => {
@@ -175,26 +173,6 @@ async fn load_or_create_instance_and_user(path: &PathBuf) -> Result<(Instance, U
     };
 
     Ok((instance, user))
-}
-
-async fn save_instance(instance: &Instance, path: &PathBuf) -> Result<()> {
-    // Reach the in-process storage engine; this example always runs against a
-    // local backend.
-    let engine = instance.backend().local_engine().ok_or_else(|| {
-        Error::Io(std::io::Error::other(
-            "Cannot save a remote-backed instance",
-        ))
-    })?;
-
-    // Cast the engine to InMemory to access save_to_file
-    let in_memory_database = engine.as_any().downcast_ref::<InMemory>().ok_or_else(|| {
-        Error::Io(std::io::Error::other(
-            "Failed to downcast database to InMemory",
-        ))
-    })?;
-
-    in_memory_database.save_to_file(path).await?;
-    Ok(())
 }
 
 async fn load_or_create_todo_database(user: &mut User) -> Result<Database> {


### PR DESCRIPTION
Replace the per-backend Instance constructors with a single URL-string entry point that dispatches across all supported backends, and add optional JSON snapshot persistence for the in-memory backend.

New API:

- Instance::connect(url) — strict load; errors NotInitialized on empty embedded backends.
- Instance::connect_or_create(url, NewUser) — load-or-bootstrap. The unix:// arm degrades to plain connect (daemons own their own initialisation); the initial user is logged at debug and ignored.

Supported URL schemes (instance/url.rs):

- sqlite://… (or sqlite:…) — passed through to sqlx::sqlite (any sqlx-accepted form). The single-colon URI form is required for sqlx's in-memory URLs because the `://` variant triggers URL authority parsing in sqlx and rejects `:memory:` as a port number; both prefixes are otherwise interchangeable.
- postgres://… (alias: postgresql://; single-colon also accepted) — passed through to sqlx::postgres.
- unix:///abs/path/sock — thin client to a running daemon.
- memory:// — ephemeral in-process backend.
- memory:///abs/path/snap.json — in-process backend with a JSON snapshot file (load-on-start, write via flush/Drop).

Schemes are matched case-insensitively per RFC 3986; paths and query strings retain their original case. \`unix:\` and \`memory:\` keep the strict \`://\` requirement so their slash-typo hints (\`unix:/run/sock\`) keep firing. Unknown / typoed schemes return InstanceError::UnsupportedScheme with a typo hint where possible (mysql:// → postgres, file:// → sqlite, tcp:// → unix). Backends compiled out at the feature flag surface as
InstanceError::BackendUnavailable rather than a link-time error.

SQLite in-memory detection (sql/mod.rs) matches both \`mode=memory\` (sqlx's explicit query flag) and \`:memory:\` (SQLite's classic magic filename embedded in URI-filename forms), so the pool's keep-alive config fires for either convention — without it the in-memory database vaporises when the only pool connection idles out.

Memory snapshot path:

- Instance::flush() — sync; atomic JSON write (<path>.tmp + rename) gated by the armed snapshot path; reentrant, Result-bearing, leaves the instance fully usable. The signature is sync because the underlying I/O is sync (std::fs::write + rename); from a tokio task it briefly blocks the worker, negligible for small snapshots.
- Instance::snapshot_to_path() — sync; explicit alternate-target save.
- InMemory::save_to_file() (sync) is the shared entry point for Instance::flush, snapshot_to_path, and the Drop safety net. Drop logs errors via tracing::error! rather than surfacing them — Drop can't return Result.
- A single Mutex<Option<PathBuf>> on InstanceInternal serves double duty: it guards the path slot (for set_snapshot_path) AND serializes the actual write so concurrent flush / snapshot_to_path / Drop callers don't race on the shared \`<path>.tmp\` staging file. Held across sync I/O only — never across an .await.
- Atomic write in in_memory/persistence.rs replaces the prior raw fs::write; documented Windows non-atomicity is called out.

Renames (breaking):

- Instance::open               → Instance::open_backend
- Instance::create             → Instance::create_backend
- Instance::open_with_clock    → Instance::open_backend_with_clock
- Instance::create_with_clock  → Instance::create_backend_with_clock
- Instance::open_or_create     → Instance::connect_or_create_backend
- Instance::connect(Path)      → Instance::connect(\"unix://…\")

service/mod.rs gains EIDETICA_SOCKET env var resolution (priority over \$XDG_RUNTIME_DIR) and a default_socket_url() convenience that returns the equivalent unix:// URL for Instance::connect.

User-facing backend docs (docs/src/user_guide/concepts/backends.md) flag memory:// / memory:///snap.json as tests/dev only — the JSON snapshot format is unstable, the device key is serialized in plaintext, and every flush rewrites the full state. The InMemory section points production workloads at sqlite://./path.db or postgres://, and ephemeral integration tests at
sqlite:file::memory:?cache=shared via Instance::connect_or_create (the URI-filename form is what makes cache=shared visible across the connection pool).

All 392 lib tests pass; new tests cover the URL roundtrip, the single-colon URI form, sqlite in-memory via URL, case-insensitive schemes with case-preserved paths, Drop fallback, flush error surfacing, and concurrent-flush serialization (via spawn_blocking, to get real thread-level contention on the merged lock). docs/, examples/, and CLI commands are migrated to the new API.