### PR TITLE
refactor: Database/Store initialization ergonomics

### DIFF
--- a/crates/lib/src/database/mod.rs
+++ b/crates/lib/src/database/mod.rs
@@ -1032,7 +1032,7 @@ impl Database {
         T: Store,
     {
         let txn = self.new_transaction().await?;
-        T::new(&txn, name.into()).await
+        T::load(&txn, name.into()).await
     }
 
     /// Get the current tips (leaf entries) of the main database branch.

--- a/crates/lib/src/database/mod.rs
+++ b/crates/lib/src/database/mod.rs
@@ -230,6 +230,38 @@ impl Database {
         signing_key: PrivateKey,
         initial_settings: Doc,
     ) -> Result<Self> {
+        Self::create_with_init(instance, signing_key, initial_settings, async |_| Ok(())).await
+    }
+
+    /// Creates a new database with an initialization callback that runs inside
+    /// the genesis transaction.
+    ///
+    /// This is the underlying constructor used by [`Self::create`] and by
+    /// `User::new_database()` (the builder API). The callback receives the
+    /// genesis transaction after `_settings` and `_root` have been staged but
+    /// before commit, allowing additional subtrees — stores, initial doc data,
+    /// records — to be written into the same entry that establishes the
+    /// database root.
+    ///
+    /// All writes performed in the callback become part of the single genesis
+    /// entry: one signed entry, one backend write, atomic. If the callback
+    /// returns an error, the transaction is dropped without committing and no
+    /// database is created.
+    ///
+    /// # Arguments
+    /// * `instance` - Instance handle for storage and coordination
+    /// * `signing_key` - The private key for this database (becomes Admin(0))
+    /// * `initial_settings` - Initial settings document (must not contain auth)
+    /// * `init` - Callback run against the genesis transaction before commit
+    pub async fn create_with_init<F>(
+        instance: &Instance,
+        signing_key: PrivateKey,
+        initial_settings: Doc,
+        init: F,
+    ) -> Result<Self>
+    where
+        F: AsyncFnOnce(&Transaction) -> Result<()>,
+    {
         let mut initial_settings = initial_settings;
         let pubkey = signing_key.public_key();
 
@@ -282,6 +314,18 @@ impl Database {
 
         // Add entropy to the entry metadata to ensure unique database IDs even with identical settings
         txn.set_metadata_entropy(rand::thread_rng().next_u64())?;
+
+        // Lock system subtrees (`_settings`, `_root`, `_index`) for the
+        // duration of the init callback. The callback gets a `&Transaction`
+        // that rejects `_*` opens via `get_store` / `Store::open`, so callers
+        // can't accidentally clobber subtrees that `create_with_init` itself
+        // manages. Internal paths (Registry, Store::register's `_index`
+        // writes) bypass `get_store` and remain functional. The guard releases
+        // on drop, so the lock lifts on both early-return and panic-unwind.
+        {
+            let _lock = txn.lock_system_subtrees();
+            init(&txn).await?;
+        }
 
         // Commit the initial entry
         let new_root_id = txn.commit().await?;

--- a/crates/lib/src/store/docstore.rs
+++ b/crates/lib/src/store/docstore.rs
@@ -1144,3 +1144,39 @@ impl DocStore {
         self.contains_path(&pathbuf).await
     }
 }
+
+/// Builder extension for DocStore: ergonomic, non-generic ways to register a
+/// DocStore inside a [`DatabaseBuilder`] chain.
+///
+/// Each Store module ships its own extension trait so the builder's core API
+/// stays minimal — only the generic
+/// [`DatabaseBuilder::initialize_store`](crate::user::DatabaseBuilder::initialize_store)
+/// primitive. User-defined Stores follow the same pattern.
+pub trait DocStoreInit<'u> {
+    /// Register a DocStore prepopulated with the contents of `doc`.
+    ///
+    /// Each top-level key in `doc` is written into the DocStore via
+    /// [`DocStore::set`]. The caller picks the storage layout — flat fields,
+    /// a single `set_json("data", ...)` blob, nested values, whatever the
+    /// downstream use case wants — by how they build the Doc before passing
+    /// it in.
+    fn initialize_doc(self, name: impl Into<String>, doc: Doc) -> crate::user::DatabaseBuilder<'u>;
+
+    /// Register an empty DocStore.
+    fn empty_doc(self, name: impl Into<String>) -> crate::user::DatabaseBuilder<'u>;
+}
+
+impl<'u> DocStoreInit<'u> for crate::user::DatabaseBuilder<'u> {
+    fn initialize_doc(self, name: impl Into<String>, doc: Doc) -> crate::user::DatabaseBuilder<'u> {
+        self.initialize_store::<DocStore, _, _>(name, move |s| async move {
+            for (key, value) in doc.iter() {
+                s.set(key.clone(), value.clone()).await?;
+            }
+            Ok(())
+        })
+    }
+
+    fn empty_doc(self, name: impl Into<String>) -> crate::user::DatabaseBuilder<'u> {
+        self.initialize_store::<DocStore, _, _>(name, |_| async { Ok(()) })
+    }
+}

--- a/crates/lib/src/store/docstore.rs
+++ b/crates/lib/src/store/docstore.rs
@@ -39,7 +39,7 @@ impl Registered for DocStore {
 impl Store for DocStore {
     type Data = Doc;
 
-    async fn new(txn: &Transaction, subtree_name: String) -> Result<Self> {
+    async fn load(txn: &Transaction, subtree_name: String) -> Result<Self> {
         Ok(Self {
             name: subtree_name,
             txn: txn.clone(),

--- a/crates/lib/src/store/mod.rs
+++ b/crates/lib/src/store/mod.rs
@@ -118,6 +118,27 @@ pub trait Store: Sized + Registered + Send + Sync {
         Ok(store)
     }
 
+    /// Opens this Store on a transaction, registering the subtree if it does not
+    /// yet exist.
+    ///
+    /// This is the consumer-facing entry point for attaching a Store to a
+    /// transaction. The default implementation delegates to
+    /// `Transaction::get_store`, which checks `_index` and dispatches to either
+    /// [`Self::load`] (for an existing subtree) or [`Self::register`] (for a new
+    /// one). Stores with construction needs that do not fit the load/register
+    /// split — cross-subtree merge, external state, conditional initialization —
+    /// may override this method directly.
+    ///
+    /// # Arguments
+    /// * `txn` - The transaction this Store will operate within.
+    /// * `name` - The subtree name identifying this data partition.
+    ///
+    /// # Returns
+    /// A `Result<Self>` containing the opened Store.
+    async fn open(txn: &Transaction, name: impl Into<String> + Send) -> Result<Self> {
+        txn.get_store::<Self>(name).await
+    }
+
     /// Gets the current configuration for this Store from the `_index` subtree.
     ///
     /// # Returns

--- a/crates/lib/src/store/mod.rs
+++ b/crates/lib/src/store/mod.rs
@@ -70,7 +70,7 @@ pub trait Store: Sized + Registered + Send + Sync {
 
     /// Returns a reference to the transaction this Store is associated with.
     ///
-    /// This is used by the default implementations of `init()`, `get_config()`,
+    /// This is used by the default implementations of `register()`, `get_config()`,
     /// and `set_config()` to access the index store.
     fn transaction(&self) -> &Transaction;
 
@@ -101,7 +101,7 @@ pub trait Store: Sized + Registered + Send + Sync {
     /// its type and default configuration in the index.
     ///
     /// The default implementation:
-    /// 1. Creates the Store using `Self::new()`
+    /// 1. Creates the Store using `Self::load()`
     /// 2. Registers it in `_index` with `Self::type_id()` and `Self::default_config()`
     ///
     /// Store implementations can override this to customize initialization behavior.
@@ -112,7 +112,7 @@ pub trait Store: Sized + Registered + Send + Sync {
     ///
     /// # Returns
     /// A `Result<Self>` containing the initialized Store.
-    async fn init(txn: &Transaction, subtree_name: String) -> Result<Self> {
+    async fn register(txn: &Transaction, subtree_name: String) -> Result<Self> {
         let store = Self::load(txn, subtree_name).await?;
         store.set_config(Self::default_config()).await?;
         Ok(store)
@@ -134,7 +134,7 @@ pub trait Store: Sized + Registered + Send + Sync {
     /// Sets the configuration for this Store in the `_index` subtree.
     ///
     /// This method updates the `_index` with the Store's type ID and the provided
-    /// configuration. It's called automatically by `init()` and can be used to
+    /// configuration. It's called automatically by `register()` and can be used to
     /// update configuration during a transaction.
     ///
     /// # Arguments

--- a/crates/lib/src/store/mod.rs
+++ b/crates/lib/src/store/mod.rs
@@ -63,7 +63,7 @@ pub trait Store: Sized + Registered + Send + Sync {
     /// # Arguments
     /// * `txn` - The `Transaction` this `Store` instance will read from and potentially write to.
     /// * `subtree_name` - The name identifying this specific data partition within the `Database`.
-    async fn new(txn: &Transaction, subtree_name: String) -> Result<Self>;
+    async fn load(txn: &Transaction, subtree_name: String) -> Result<Self>;
 
     /// Returns the name of this subtree.
     fn name(&self) -> &str;
@@ -113,7 +113,7 @@ pub trait Store: Sized + Registered + Send + Sync {
     /// # Returns
     /// A `Result<Self>` containing the initialized Store.
     async fn init(txn: &Transaction, subtree_name: String) -> Result<Self> {
-        let store = Self::new(txn, subtree_name).await?;
+        let store = Self::load(txn, subtree_name).await?;
         store.set_config(Self::default_config()).await?;
         Ok(store)
     }

--- a/crates/lib/src/store/mod.rs
+++ b/crates/lib/src/store/mod.rs
@@ -7,7 +7,7 @@ mod errors;
 pub use errors::StoreError;
 
 mod docstore;
-pub use docstore::DocStore;
+pub use docstore::{DocStore, DocStoreInit};
 
 mod value_editor;
 pub use value_editor::ValueEditor;

--- a/crates/lib/src/store/password_store.rs
+++ b/crates/lib/src/store/password_store.rs
@@ -619,7 +619,7 @@ impl<S: Store> Store for PasswordStore<S> {
         }
     }
 
-    async fn init(txn: &Transaction, subtree_name: String) -> Result<Self> {
+    async fn register(txn: &Transaction, subtree_name: String) -> Result<Self> {
         // Register in _index with empty config (marks as uninitialized)
         let index_store = txn.get_index().await?;
         index_store

--- a/crates/lib/src/store/password_store.rs
+++ b/crates/lib/src/store/password_store.rs
@@ -552,7 +552,7 @@ impl<S: Store> Registered for PasswordStore<S> {
 impl<S: Store> Store for PasswordStore<S> {
     type Data = S::Data;
 
-    async fn new(txn: &Transaction, subtree_name: String) -> Result<Self> {
+    async fn load(txn: &Transaction, subtree_name: String) -> Result<Self> {
         // Try to load config from _index to determine state
         let index_store = txn.get_index().await?;
         let info = index_store.get_entry(&subtree_name).await?;
@@ -1018,8 +1018,8 @@ impl<S: Store> PasswordStore<S> {
 
         // Create the wrapped store. The transaction has an encryptor registered,
         // so it transparently decrypts on read and encrypts on commit.
-        // We call S::new() directly, bypassing Transaction::get_store() type
+        // We call S::load() directly, bypassing Transaction::get_store() type
         // checking, since type consistency was already verified in open().
-        S::new(&self.transaction, self.name.clone()).await
+        S::load(&self.transaction, self.name.clone()).await
     }
 }

--- a/crates/lib/src/store/registry.rs
+++ b/crates/lib/src/store/registry.rs
@@ -144,7 +144,7 @@ impl Registry {
         // get_store -> get_index -> Registry::new -> get_store cycle
         transaction.init_subtree_parents(&name).await?;
         // Create DocStore directly instead of going through get_store
-        let inner = DocStore::new(transaction, name).await?;
+        let inner = DocStore::load(transaction, name).await?;
         Ok(Self { inner })
     }
 

--- a/crates/lib/src/store/settings_store.rs
+++ b/crates/lib/src/store/settings_store.rs
@@ -41,7 +41,7 @@ impl SettingsStore {
     /// # Returns
     /// A Result containing the SettingsStore or an error if creation fails
     pub(crate) fn new(transaction: &Transaction) -> Result<Self> {
-        // Note: We create DocStore directly here instead of using Store::new()
+        // Note: We create DocStore directly here instead of using Store::load()
         // because SettingsStore is a wrapper that doesn't implement the Store trait itself.
         // This avoids the async requirement for this simple internal construction.
         let inner = DocStore {

--- a/crates/lib/src/store/settings_store.rs
+++ b/crates/lib/src/store/settings_store.rs
@@ -317,8 +317,7 @@ mod tests {
         .await
         .expect("Failed to create test instance");
 
-        let key_id = user.add_private_key(None).await.unwrap();
-        let database = user.create_database(Doc::new(), &key_id).await.unwrap();
+        let (database, _) = user.new_database().build().await.unwrap();
 
         // Set initial database name using transaction
         let transaction = database.new_transaction().await.unwrap();

--- a/crates/lib/src/store/table.rs
+++ b/crates/lib/src/store/table.rs
@@ -53,7 +53,7 @@ where
 {
     type Data = Doc;
 
-    async fn new(txn: &Transaction, subtree_name: String) -> Result<Self> {
+    async fn load(txn: &Transaction, subtree_name: String) -> Result<Self> {
         Ok(Self {
             name: subtree_name,
             txn: txn.clone(),

--- a/crates/lib/src/store/ydoc.rs
+++ b/crates/lib/src/store/ydoc.rs
@@ -213,7 +213,7 @@ impl Registered for YDoc {
 impl Store for YDoc {
     type Data = YrsBinary;
 
-    async fn new(txn: &Transaction, subtree_name: String) -> Result<Self> {
+    async fn load(txn: &Transaction, subtree_name: String) -> Result<Self> {
         Ok(Self {
             name: subtree_name,
             txn: txn.clone(),

--- a/crates/lib/src/sync/bootstrap_request_manager.rs
+++ b/crates/lib/src/sync/bootstrap_request_manager.rs
@@ -215,13 +215,16 @@ mod tests {
         .await
         .expect("Failed to create test instance");
 
-        let key_id = user.add_private_key(None).await.unwrap();
-
         let mut sync_settings = Doc::new();
         sync_settings.set("name", "_sync");
         sync_settings.set("type", "sync_settings");
 
-        let database = user.create_database(sync_settings, &key_id).await.unwrap();
+        let (database, _) = user
+            .new_database()
+            .settings(sync_settings)
+            .build()
+            .await
+            .unwrap();
 
         (instance, database, clock)
     }

--- a/crates/lib/src/sync/state.rs
+++ b/crates/lib/src/sync/state.rs
@@ -492,7 +492,7 @@ impl<'a> SyncStateManager<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Entry, Instance, backend::database::InMemory, crdt::Doc};
+    use crate::{Entry, Instance, backend::database::InMemory};
 
     #[test]
     fn test_sync_cursor() {
@@ -561,8 +561,7 @@ mod tests {
         .expect("Failed to create test instance");
         instance.enable_sync().await.unwrap();
 
-        let key_id = user.add_private_key(None).await.unwrap();
-        let user_tree = user.create_database(Doc::new(), &key_id).await.unwrap();
+        let (user_tree, _) = user.new_database().build().await.unwrap();
         let tree_id = user_tree.root_id().clone();
 
         // Get the sync instance and its tree

--- a/crates/lib/src/transaction/errors.rs
+++ b/crates/lib/src/transaction/errors.rs
@@ -72,6 +72,15 @@ pub enum TransactionError {
     /// Backend operation failed during commit
     #[error("Backend operation failed during commit: {reason}")]
     BackendOperationFailed { reason: String },
+
+    /// Attempt to open a system subtree (`_settings`, `_root`, `_index`, …) at
+    /// a moment when the transaction has locked them. Currently used by
+    /// `Database::create_with_init` to prevent its init callback from
+    /// clobbering the system subtrees that `create_with_init` itself manages.
+    #[error(
+        "System subtree '{name}' is locked for this transaction (init callbacks may not open `_`-prefixed subtrees directly)"
+    )]
+    SystemSubtreeLocked { name: String },
 }
 
 impl TransactionError {

--- a/crates/lib/src/transaction/mod.rs
+++ b/crates/lib/src/transaction/mod.rs
@@ -541,8 +541,8 @@ impl Transaction {
             // Type supported - create the Store
             T::load(self, subtree_name).await
         } else {
-            // New subtree - init registers it in _index
-            T::init(self, subtree_name).await
+            // New subtree - register adds it to _index
+            T::register(self, subtree_name).await
         }
     }
 

--- a/crates/lib/src/transaction/mod.rs
+++ b/crates/lib/src/transaction/mod.rs
@@ -22,7 +22,10 @@ mod tests;
 
 use std::{
     collections::HashMap,
-    sync::{Arc, Mutex},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
+    },
 };
 
 pub use errors::TransactionError;
@@ -168,6 +171,25 @@ pub struct Transaction {
     /// When an encryptor is registered, the transaction automatically encrypts writes
     /// and decrypts reads for that subtree
     encryptors: Arc<Mutex<HashMap<String, Box<dyn Encryptor>>>>,
+    /// When true, `get_store` rejects any `_`-prefixed subtree name. Used by
+    /// `Database::create_with_init` to keep its init callback from opening the
+    /// system subtrees (`_settings`, `_root`, `_index`) that `create_with_init`
+    /// itself manages. Legitimate internal paths — `get_index()` (via
+    /// `Registry::new` → `DocStore::load`) and `Store::register`'s own
+    /// `_index` updates — bypass `get_store` and remain unaffected.
+    system_subtrees_locked: Arc<AtomicBool>,
+}
+
+/// RAII guard returned by [`Transaction::lock_system_subtrees`]. Releases the
+/// lock on drop, covering early-return-via-`?` and panic-unwind alike.
+pub(crate) struct SystemSubtreeLockGuard {
+    flag: Arc<AtomicBool>,
+}
+
+impl Drop for SystemSubtreeLockGuard {
+    fn drop(&mut self) {
+        self.flag.store(false, Ordering::Release);
+    }
 }
 
 impl Transaction {
@@ -221,7 +243,30 @@ impl Transaction {
             db: database.clone(),
             provided_signing_key: None,
             encryptors: Arc::new(Mutex::new(HashMap::new())),
+            system_subtrees_locked: Arc::new(AtomicBool::new(false)),
         })
+    }
+
+    /// Lock the system subtrees (`_settings`, `_root`, `_index`) for the
+    /// returned guard's lifetime.
+    ///
+    /// While the guard is live, [`Self::get_store`] rejects any subtree name
+    /// beginning with `_` (the system-subtree prefix). Used by
+    /// [`Database::create_with_init`] to guard its init callback against
+    /// clobbering `_settings`/`_root`/`_index`, all of which `create_with_init`
+    /// manages itself or via a dedicated accessor. The lock releases on the
+    /// guard's `Drop`, so it covers both early-return-via-`?` and panic-unwind
+    /// paths.
+    ///
+    /// The lock is process-local state on the (cloned-by-Arc) transaction;
+    /// clones share the same flag. Legitimate internal paths — `get_index()`
+    /// (via `Registry::new` → `DocStore::load`) and `Store::register`'s own
+    /// `_index` writes — bypass `get_store` and are unaffected.
+    pub(crate) fn lock_system_subtrees(&self) -> SystemSubtreeLockGuard {
+        self.system_subtrees_locked.store(true, Ordering::Release);
+        SystemSubtreeLockGuard {
+            flag: self.system_subtrees_locked.clone(),
+        }
     }
 
     /// Set signing key directly for user context (internal API).
@@ -511,12 +556,16 @@ impl Transaction {
     {
         let subtree_name = subtree_name.into();
 
-        // Initialize subtree parents before checking _index
-        self.init_subtree_parents(&subtree_name).await?;
-
         // Skip special system subtrees to avoid circular dependencies
         let is_system_subtree =
             subtree_name == INDEX || subtree_name == SETTINGS || subtree_name == ROOT;
+
+        if is_system_subtree && self.system_subtrees_locked.load(Ordering::Acquire) {
+            return Err(TransactionError::SystemSubtreeLocked { name: subtree_name }.into());
+        }
+
+        // Initialize subtree parents before checking _index
+        self.init_subtree_parents(&subtree_name).await?;
 
         if is_system_subtree {
             // System subtrees don't use _index registration

--- a/crates/lib/src/transaction/mod.rs
+++ b/crates/lib/src/transaction/mod.rs
@@ -520,7 +520,7 @@ impl Transaction {
 
         if is_system_subtree {
             // System subtrees don't use _index registration
-            return T::new(self, subtree_name).await;
+            return T::load(self, subtree_name).await;
         }
 
         // Check _index to determine if this is a new or existing subtree
@@ -539,7 +539,7 @@ impl Transaction {
             }
 
             // Type supported - create the Store
-            T::new(self, subtree_name).await
+            T::load(self, subtree_name).await
         } else {
             // New subtree - init registers it in _index
             T::init(self, subtree_name).await

--- a/crates/lib/src/user/errors.rs
+++ b/crates/lib/src/user/errors.rs
@@ -69,6 +69,9 @@ pub enum UserError {
 
     #[error("No keys available for user")]
     NoKeysAvailable,
+
+    #[error("Duplicate store name in DatabaseBuilder: {name}")]
+    DuplicateBuilderStore { name: String },
 }
 
 impl UserError {

--- a/crates/lib/src/user/mod.rs
+++ b/crates/lib/src/user/mod.rs
@@ -43,5 +43,5 @@ pub mod types;
 pub use admin::InstanceAdmin;
 pub use errors::UserError;
 pub use key_manager::UserKeyManager;
-pub use session::User;
+pub use session::{DatabaseBuilder, User};
 pub use types::*;

--- a/crates/lib/src/user/session/builder.rs
+++ b/crates/lib/src/user/session/builder.rs
@@ -1,0 +1,177 @@
+//! Builder for creating a fully-initialized Database in a single genesis entry.
+//!
+//! See [`User::new_database`] for the entry point. The builder collects
+//! settings, key policy, and a list of store initializers, then folds them all
+//! into one signed entry at [`DatabaseBuilder::build`] time so the new
+//! database is atomically constructed with its full initial shape.
+
+use std::collections::HashSet;
+use std::future::Future;
+use std::pin::Pin;
+
+use super::User;
+use crate::{
+    Database, Result, Store, Transaction, auth::crypto::PublicKey, crdt::Doc,
+    user::errors::UserError,
+};
+
+/// Type-erased per-store initialization closure. The HRTB lets the closure
+/// borrow the genesis `Transaction` for the duration of the returned future.
+type StoreInit = Box<
+    dyn for<'a> FnOnce(&'a Transaction) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>
+        + Send,
+>;
+
+enum KeyPolicy {
+    AutoGenerate { label: Option<String> },
+    UseExisting(PublicKey),
+}
+
+/// Chainable builder for constructing a new Database with all of its initial
+/// shape — settings, signing key, registered stores, and seed data — folded
+/// into one genesis entry.
+///
+/// Obtained via [`User::new_database`]. Terminal method is
+/// [`DatabaseBuilder::build`].
+///
+/// # Auto-generated keys on failure
+///
+/// When no key policy is set (or only [`Self::key_label`] is used), the
+/// builder generates a fresh signing key via [`User::add_private_key`]
+/// **before** running store initializers. If a store initializer or the
+/// genesis commit then fails, the generated key remains in the user's
+/// key store. `UserKeyManager` does not currently expose a key-removal
+/// API, so this leak is by design — it matches the semantics of the
+/// pre-existing `add_private_key` + `create_database` flow.
+///
+/// If avoiding the leak matters, call [`User::add_private_key`] yourself
+/// and pass the result via [`Self::with_key`]; the key persists either way
+/// but you keep ownership of when it was created.
+///
+/// # Example
+///
+/// ```ignore
+/// use eidetica::store::DocStoreInit;
+///
+/// let (db, key) = user.new_database()
+///     .name("agent:demo")
+///     .key_label("agent:demo")
+///     .empty_doc("config")
+///     .initialize_doc("meta", meta)
+///     .build()
+///     .await?;
+/// ```
+pub struct DatabaseBuilder<'u> {
+    user: &'u mut User,
+    settings: Doc,
+    key_policy: KeyPolicy,
+    store_inits: Vec<(String, StoreInit)>,
+}
+
+impl<'u> DatabaseBuilder<'u> {
+    pub(super) fn new(user: &'u mut User) -> Self {
+        Self {
+            user,
+            settings: Doc::new(),
+            key_policy: KeyPolicy::AutoGenerate { label: None },
+            store_inits: Vec::new(),
+        }
+    }
+
+    /// Set the database's display name (the `name` field in `_settings`).
+    /// Shortcut for the common case; for full control over the settings Doc
+    /// use [`Self::settings`] instead.
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.settings.set("name", name.into());
+        self
+    }
+
+    /// Replace the entire settings Doc. Overrides any prior [`Self::name`] call.
+    pub fn settings(mut self, settings: Doc) -> Self {
+        self.settings = settings;
+        self
+    }
+
+    /// Generate a fresh signing key with the given display label when
+    /// [`Self::create`] runs. Default behavior (no label) is also available by
+    /// not calling either key method.
+    pub fn key_label(mut self, label: impl Into<String>) -> Self {
+        self.key_policy = KeyPolicy::AutoGenerate {
+            label: Some(label.into()),
+        };
+        self
+    }
+
+    /// Use an existing key from the user's key manager rather than generating
+    /// a fresh one. `key` must already have been added to the user via
+    /// [`User::add_private_key`]; otherwise [`Self::create`] will fail when
+    /// resolving the signing key.
+    pub fn with_key(mut self, key: PublicKey) -> Self {
+        self.key_policy = KeyPolicy::UseExisting(key);
+        self
+    }
+
+    /// Register a store named `name` and run `init` against it inside the
+    /// genesis transaction. The closure body uses the Store's normal write
+    /// API. Pass a no-op closure to register an empty store.
+    ///
+    /// This is the generic primitive. Each Store module ships its own
+    /// extension trait providing ergonomic non-generic variants (for example
+    /// [`DocStoreInit::initialize_doc`](crate::store::DocStoreInit::initialize_doc)).
+    pub fn initialize_store<S, F, Fut>(mut self, name: impl Into<String>, init: F) -> Self
+    where
+        S: Store + Send + 'static,
+        F: FnOnce(S) -> Fut + Send + 'static,
+        Fut: Future<Output = Result<()>> + Send + 'static,
+    {
+        let name = name.into();
+        let name_for_open = name.clone();
+        let init_box: StoreInit = Box::new(move |txn| {
+            Box::pin(async move {
+                let store = S::open(txn, name_for_open).await?;
+                init(store).await
+            })
+        });
+        self.store_inits.push((name, init_box));
+        self
+    }
+
+    /// Resolve the key, run every store initializer inside a single genesis
+    /// transaction, commit, then perform the user-side tracking write.
+    /// Returns the new database and the public key it was created with.
+    pub async fn build(self) -> Result<(Database, PublicKey)> {
+        let DatabaseBuilder {
+            user,
+            settings,
+            key_policy,
+            store_inits,
+        } = self;
+
+        // Reject duplicate store names before doing any work.
+        let mut seen: HashSet<&str> = HashSet::new();
+        for (name, _) in &store_inits {
+            if !seen.insert(name.as_str()) {
+                return Err(UserError::DuplicateBuilderStore { name: name.clone() }.into());
+            }
+        }
+
+        // Resolve the signing key.
+        let key_id = match key_policy {
+            KeyPolicy::AutoGenerate { label } => user.add_private_key(label.as_deref()).await?,
+            KeyPolicy::UseExisting(k) => k,
+        };
+
+        // Fold all per-store initializers into one async callback for the
+        // genesis transaction. Each `init` is invoked once and consumed.
+        let database = user
+            .create_database_with_init(settings, &key_id, async move |txn| {
+                for (_, init) in store_inits {
+                    init(txn).await?;
+                }
+                Ok(())
+            })
+            .await?;
+
+        Ok((database, key_id))
+    }
+}

--- a/crates/lib/src/user/session/mod.rs
+++ b/crates/lib/src/user/session/mod.rs
@@ -53,8 +53,11 @@ use crate::{
     user::{SyncSettings, TrackedDatabase, UserError},
 };
 
+mod builder;
 #[cfg(test)]
 mod tests;
+
+pub use builder::DatabaseBuilder;
 
 /// User session object, returned after successful login
 ///
@@ -262,6 +265,17 @@ impl User {
 
     // === Database Operations (User Context) ===
 
+    /// Start building a new database via the chainable [`DatabaseBuilder`] API.
+    ///
+    /// The builder collects settings, key policy, and store initializers, then
+    /// produces a fully-initialized database in a single genesis entry when
+    /// [`DatabaseBuilder::build`] is called.
+    ///
+    /// For the lower-level direct constructor see [`Self::create_database`].
+    pub fn new_database(&mut self) -> DatabaseBuilder<'_> {
+        DatabaseBuilder::new(self)
+    }
+
     /// Create a new database with explicit key selection.
     ///
     /// This method requires you to specify which key should be used to create and manage
@@ -290,6 +304,32 @@ impl User {
     /// let database = user.new_database(settings, key_id)?;
     /// ```
     pub async fn create_database(&mut self, settings: Doc, key_id: &PublicKey) -> Result<Database> {
+        self.create_database_with_init(settings, key_id, async |_| Ok(()))
+            .await
+    }
+
+    /// Creates a new database with an initialization callback that runs inside
+    /// the genesis transaction.
+    ///
+    /// This is the underlying constructor used by [`Self::create_database`] and by
+    /// [`Self::new_database`] (the builder API). The callback receives the
+    /// genesis transaction after `_settings` and `_root` have been staged but
+    /// before commit, allowing additional subtrees to be written into the same
+    /// entry that establishes the database root. See
+    /// [`Database::create_with_init`] for details on the atomicity guarantee.
+    ///
+    /// After the genesis entry commits, this method performs the standard
+    /// user-side tracking write (key-database mapping, `TrackedDatabase` entry)
+    /// in a separate transaction on the user's own system database.
+    pub async fn create_database_with_init<F>(
+        &mut self,
+        settings: Doc,
+        key_id: &PublicKey,
+        init: F,
+    ) -> Result<Database>
+    where
+        F: AsyncFnOnce(&Transaction) -> Result<()>,
+    {
         use crate::user::types::{SyncSettings, UserKey};
 
         // Get the signing key from UserKeyManager
@@ -302,7 +342,8 @@ impl User {
             .clone();
 
         // Create the database with the provided key directly
-        let database = Database::create(&self.instance, signing_key, settings).await?;
+        let database =
+            Database::create_with_init(&self.instance, signing_key, settings, init).await?;
 
         // Store the mapping in UserKey and track the database
         let tx = self.user_database.new_transaction().await?;

--- a/crates/lib/tests/it/database/create_with_init.rs
+++ b/crates/lib/tests/it/database/create_with_init.rs
@@ -1,0 +1,194 @@
+//! Tests for `Database::create_with_init` — the constructor that runs a
+//! caller-supplied initialization callback inside the genesis transaction so
+//! initial subtree writes fold into the same entry that establishes the
+//! database root.
+
+use eidetica::{Database, Store, auth::crypto::generate_keypair, crdt::Doc, store::DocStore};
+
+use crate::helpers::test_local_instance;
+
+#[tokio::test]
+async fn test_init_callback_runs_and_writes_persist() {
+    let instance = test_local_instance().await;
+    let (signing_key, _) = generate_keypair();
+
+    let database = Database::create_with_init(&instance, signing_key, Doc::new(), async |txn| {
+        let store = DocStore::open(txn, "config").await?;
+        store.set("name", "agent_db").await?;
+        store.set("version", "1").await?;
+        Ok(())
+    })
+    .await
+    .expect("create_with_init failed");
+
+    // Read back through a fresh transaction — the writes from the init callback
+    // should be persisted in the genesis entry.
+    let txn = database.new_transaction().await.unwrap();
+    let store = DocStore::open(&txn, "config").await.unwrap();
+    assert_eq!(store.get("name").await.unwrap(), "agent_db");
+    assert_eq!(store.get("version").await.unwrap(), "1");
+}
+
+#[tokio::test]
+async fn test_genesis_entry_carries_all_initialized_subtrees() {
+    let instance = test_local_instance().await;
+    let (signing_key, _) = generate_keypair();
+
+    let database = Database::create_with_init(&instance, signing_key, Doc::new(), async |txn| {
+        DocStore::open(txn, "config").await?.set("a", "1").await?;
+        DocStore::open(txn, "meta").await?.set("b", "2").await?;
+        Ok(())
+    })
+    .await
+    .unwrap();
+
+    // The genesis entry (the database root) should itself contain the
+    // initialized subtrees — this is the load-bearing atomicity claim:
+    // initial stores live in the same entry as _settings and _root.
+    let root_id = database.root_id();
+    let genesis = database.get_entry(root_id).await.unwrap();
+    let subtrees = genesis.subtrees();
+
+    assert!(subtrees.iter().any(|s| s == "_settings"));
+    assert!(subtrees.iter().any(|s| s == "config"));
+    assert!(subtrees.iter().any(|s| s == "meta"));
+    // _index gets registered when the first non-system subtree is opened with
+    // register; it should also be in the genesis entry.
+    assert!(subtrees.iter().any(|s| s == "_index"));
+}
+
+#[tokio::test]
+async fn test_init_callback_error_aborts_create() {
+    let instance = test_local_instance().await;
+    let (signing_key, _) = generate_keypair();
+
+    let result = Database::create_with_init(&instance, signing_key, Doc::new(), async |_txn| {
+        Err(std::io::Error::other("init failed").into())
+    })
+    .await;
+
+    assert!(
+        result.is_err(),
+        "create_with_init should propagate init errors"
+    );
+}
+
+#[tokio::test]
+async fn test_create_delegates_to_create_with_init() {
+    // Plain `Database::create` should behave identically to
+    // `create_with_init` with a no-op callback: only `_settings` and `_root`
+    // in the genesis entry, no `_index` (since no subtrees were touched).
+    let instance = test_local_instance().await;
+    let (signing_key, _) = generate_keypair();
+
+    let database = Database::create(&instance, signing_key, Doc::new())
+        .await
+        .unwrap();
+
+    let root_id = database.root_id();
+    let genesis = database.get_entry(root_id).await.unwrap();
+    let subtrees = genesis.subtrees();
+
+    assert!(subtrees.iter().any(|s| s == "_settings"));
+    assert!(!subtrees.iter().any(|s| s == "_index"));
+}
+
+#[tokio::test]
+async fn test_init_callback_cannot_open_settings() {
+    // The init callback runs with system subtrees locked, so any attempt to
+    // open `_settings` via the public Store API must fail. This prevents an
+    // init closure from clobbering the settings Doc that `create_with_init`
+    // staged from its `initial_settings` argument.
+    let instance = test_local_instance().await;
+    let (signing_key, _) = generate_keypair();
+
+    let result = Database::create_with_init(&instance, signing_key, Doc::new(), async |txn| {
+        let _ = DocStore::open(txn, "_settings").await?;
+        Ok(())
+    })
+    .await;
+
+    assert!(
+        result.is_err(),
+        "create_with_init should reject _settings opens inside init callback"
+    );
+}
+
+#[tokio::test]
+async fn test_init_callback_cannot_open_root() {
+    let instance = test_local_instance().await;
+    let (signing_key, _) = generate_keypair();
+
+    let result = Database::create_with_init(&instance, signing_key, Doc::new(), async |txn| {
+        let _ = DocStore::open(txn, "_root").await?;
+        Ok(())
+    })
+    .await;
+
+    assert!(
+        result.is_err(),
+        "create_with_init should reject _root opens inside init callback"
+    );
+}
+
+#[tokio::test]
+async fn test_init_callback_cannot_open_index() {
+    // `_index` is touched legitimately by `Store::register` via `Registry`
+    // (which constructs DocStore directly via `DocStore::load`, bypassing
+    // `get_store`). The public `get_store`/`Store::open` path must still
+    // reject `_index` so callers can't manipulate the index directly.
+    let instance = test_local_instance().await;
+    let (signing_key, _) = generate_keypair();
+
+    let result = Database::create_with_init(&instance, signing_key, Doc::new(), async |txn| {
+        let _ = DocStore::open(txn, "_index").await?;
+        Ok(())
+    })
+    .await;
+
+    assert!(
+        result.is_err(),
+        "create_with_init should reject _index opens inside init callback"
+    );
+}
+
+#[tokio::test]
+async fn test_init_callback_can_register_normal_stores_while_locked() {
+    // The lock only blocks `_*` names. Registering a normal store still
+    // writes to `_index` internally (via `Registry::set_entry` →
+    // `DocStore::set` → `update_subtree("_index", ...)`), but that path
+    // bypasses `get_store` and is unaffected by the lock.
+    let instance = test_local_instance().await;
+    let (signing_key, _) = generate_keypair();
+
+    let database = Database::create_with_init(&instance, signing_key, Doc::new(), async |txn| {
+        DocStore::open(txn, "config").await?.set("k", "v").await?;
+        Ok(())
+    })
+    .await
+    .expect("normal store registration must work despite the lock");
+
+    let genesis = database.get_entry(database.root_id()).await.unwrap();
+    let subtrees = genesis.subtrees();
+    assert!(subtrees.iter().any(|s| s == "config"));
+    assert!(subtrees.iter().any(|s| s == "_index"));
+}
+
+#[tokio::test]
+async fn test_system_subtree_lock_released_after_init() {
+    // After `create_with_init` returns, transactions opened on the resulting
+    // Database are unlocked: callers can still open `_settings` via
+    // `get_store::<DocStore>` (relied on by tests and helpers throughout the
+    // crate). The lock is scoped strictly to the init callback.
+    let instance = test_local_instance().await;
+    let (signing_key, _) = generate_keypair();
+
+    let database = Database::create_with_init(&instance, signing_key, Doc::new(), async |_| Ok(()))
+        .await
+        .unwrap();
+
+    let txn = database.new_transaction().await.unwrap();
+    let _settings = DocStore::open(&txn, "_settings")
+        .await
+        .expect("post-init transactions must not be locked");
+}

--- a/crates/lib/tests/it/database/mod.rs
+++ b/crates/lib/tests/it/database/mod.rs
@@ -14,6 +14,7 @@
 
 mod api_methods;
 mod core_operations;
+mod create_with_init;
 mod helpers;
 mod merge_algorithms;
 mod settings_metadata;

--- a/crates/lib/tests/it/user/builder_tests.rs
+++ b/crates/lib/tests/it/user/builder_tests.rs
@@ -1,0 +1,459 @@
+//! Tests for `User::new_database()` — the chainable `DatabaseBuilder` API.
+//!
+//! Covers builder ergonomics, atomic multi-store initialization, the
+//! extension-trait pattern (`DocStoreInit::initialize_doc` / `empty_doc`),
+//! collision detection, and the user-side tracking write.
+
+use eidetica::{
+    Store,
+    crdt::Doc,
+    store::{DocStore, DocStoreInit, PasswordStore},
+};
+
+use super::helpers::*;
+
+#[tokio::test]
+async fn test_builder_creates_basic_database() {
+    let (instance, username) = setup_instance_with_user("alice", None).await;
+    let mut user = login_user(&instance, &username, None).await;
+
+    let (db, _key) = user
+        .new_database()
+        .name("test-builder-db")
+        .build()
+        .await
+        .expect("builder.build failed");
+
+    assert!(!db.root_id().to_string().is_empty());
+}
+
+#[tokio::test]
+async fn test_builder_empty_doc_registers_store() {
+    let (instance, username) = setup_instance_with_user("alice", None).await;
+    let mut user = login_user(&instance, &username, None).await;
+
+    let (db, _) = user
+        .new_database()
+        .name("with-empty-store")
+        .empty_doc("config")
+        .build()
+        .await
+        .unwrap();
+
+    // The genesis entry should include `config` as a subtree even though no
+    // data was written into it — empty_doc registers the store.
+    let genesis = db.get_entry(db.root_id()).await.unwrap();
+    let subtrees = genesis.subtrees();
+    assert!(subtrees.iter().any(|s| s == "config"));
+}
+
+#[tokio::test]
+async fn test_builder_initialize_doc_persists_value() {
+    let (instance, username) = setup_instance_with_user("alice", None).await;
+    let mut user = login_user(&instance, &username, None).await;
+
+    let mut meta = Doc::new();
+    meta.set("name", "agent");
+    meta.set("version", "1");
+
+    let (db, _) = user
+        .new_database()
+        .name("with-meta")
+        .initialize_doc("meta", meta)
+        .build()
+        .await
+        .unwrap();
+
+    // Each top-level key from the input Doc lands as a DocStore key.
+    let txn = db.new_transaction().await.unwrap();
+    let store = DocStore::open(&txn, "meta").await.unwrap();
+    assert_eq!(store.get_string("name").await.unwrap(), "agent");
+    assert_eq!(store.get_string("version").await.unwrap(), "1");
+}
+
+#[tokio::test]
+async fn test_builder_initialize_doc_preserves_nested_values() {
+    // Per-key Value cloning in `initialize_doc` should preserve branch values
+    // (nested Doc, List) as well as scalars — the contract is "each top-level
+    // key of the input Doc becomes a top-level key of the DocStore, with the
+    // original Value variant intact".
+    let (instance, username) = setup_instance_with_user("alice", None).await;
+    let mut user = login_user(&instance, &username, None).await;
+
+    let mut nested = Doc::new();
+    nested.set("inner", "deep");
+    nested.set("count", 42i64);
+
+    let mut meta = Doc::new();
+    meta.set("scalar", "top-level");
+    meta.set("nested", nested);
+
+    let (db, _) = user
+        .new_database()
+        .name("nested-doc")
+        .initialize_doc("meta", meta)
+        .build()
+        .await
+        .unwrap();
+
+    let txn = db.new_transaction().await.unwrap();
+    let store = DocStore::open(&txn, "meta").await.unwrap();
+
+    // Top-level scalar round-trips.
+    assert_eq!(store.get_string("scalar").await.unwrap(), "top-level");
+
+    // Nested Doc round-trips: walk the path to confirm the branch wasn't
+    // flattened or stringified by `initialize_doc`.
+    let inner = store.get_path("nested.inner").await.unwrap();
+    assert_eq!(inner, "deep");
+    let count = store.get_path("nested.count").await.unwrap();
+    assert_eq!(count, 42i64);
+}
+
+#[tokio::test]
+async fn test_builder_multiple_stores_in_single_genesis_entry() {
+    let (instance, username) = setup_instance_with_user("alice", None).await;
+    let mut user = login_user(&instance, &username, None).await;
+
+    let (db, _) = user
+        .new_database()
+        .name("multi-store")
+        .empty_doc("config")
+        .empty_doc("logs")
+        .initialize_store::<DocStore, _, _>("custom", |s| async move { s.set("k", "v").await })
+        .build()
+        .await
+        .unwrap();
+
+    // Atomicity proof: all three stores live in the single genesis entry.
+    let genesis = db.get_entry(db.root_id()).await.unwrap();
+    let subtrees = genesis.subtrees();
+    assert!(subtrees.iter().any(|s| s == "config"));
+    assert!(subtrees.iter().any(|s| s == "logs"));
+    assert!(subtrees.iter().any(|s| s == "custom"));
+    assert!(subtrees.iter().any(|s| s == "_settings"));
+    assert!(subtrees.iter().any(|s| s == "_index"));
+}
+
+#[tokio::test]
+async fn test_builder_name_after_settings_overrides_name_in_doc() {
+    // Order-dependent contract: `.settings(d)` REPLACES the in-progress
+    // settings, so a prior `.name("x")` is discarded; a subsequent `.name("y")`
+    // mutates the freshly-installed settings.
+    let (instance, username) = setup_instance_with_user("alice", None).await;
+    let mut user = login_user(&instance, &username, None).await;
+
+    // Case 1: settings AFTER name → settings wins (name dropped).
+    let mut d = Doc::new();
+    d.set("name", "from-doc");
+    d.set("extra", "kept");
+    let (db1, _) = user
+        .new_database()
+        .name("from-builder")
+        .settings(d)
+        .build()
+        .await
+        .unwrap();
+    assert_eq!(db1.get_name().await.unwrap(), "from-doc");
+
+    // Case 2: name AFTER settings → name mutates the installed Doc.
+    let mut d2 = Doc::new();
+    d2.set("name", "from-doc-2");
+    d2.set("extra", "still-kept");
+    let (db2, _) = user
+        .new_database()
+        .settings(d2)
+        .name("late-name")
+        .build()
+        .await
+        .unwrap();
+    assert_eq!(db2.get_name().await.unwrap(), "late-name");
+    // Non-name fields installed via settings() survive the name() call.
+    let settings = db2.get_settings().await.unwrap();
+    assert_eq!(settings.get_string("extra").await.unwrap(), "still-kept");
+}
+
+#[tokio::test]
+async fn test_builder_with_key_rejects_key_not_in_user_keystore() {
+    // `with_key` accepts a PublicKey but doesn't verify ownership at build
+    // time; the failure surfaces inside `build()` when the underlying
+    // `create_database_with_init` tries to resolve the signing key.
+    let (instance, username) = setup_instance_with_user("alice", None).await;
+    let mut user = login_user(&instance, &username, None).await;
+
+    // Generate a key OUTSIDE the user's key manager.
+    let (_, foreign_key) = eidetica::auth::crypto::generate_keypair();
+
+    let result = user
+        .new_database()
+        .name("foreign-key")
+        .with_key(foreign_key)
+        .build()
+        .await;
+
+    assert!(
+        result.is_err(),
+        "builder.build should reject a key not in the user's key manager"
+    );
+}
+
+#[tokio::test]
+async fn test_builder_with_existing_key() {
+    let (instance, username) = setup_instance_with_user("alice", None).await;
+    let mut user = login_user(&instance, &username, None).await;
+
+    // Pre-generate a key
+    let key_id = user.add_private_key(Some("explicit-key")).await.unwrap();
+    let key_id_clone = key_id.clone();
+
+    let (_db, returned_key) = user
+        .new_database()
+        .name("with-explicit-key")
+        .with_key(key_id)
+        .build()
+        .await
+        .unwrap();
+
+    // The builder should return the same key it was given.
+    assert_eq!(returned_key, key_id_clone);
+}
+
+#[tokio::test]
+async fn test_builder_auto_generated_key_uses_label() {
+    let (instance, username) = setup_instance_with_user("alice", None).await;
+    let mut user = login_user(&instance, &username, None).await;
+
+    let initial_keys = user.list_keys().expect("list_keys").len();
+
+    let (_db, _key) = user
+        .new_database()
+        .name("with-labeled-key")
+        .key_label("labeled-builder-key")
+        .build()
+        .await
+        .unwrap();
+
+    // The builder generated exactly one new key.
+    let after_keys = user.list_keys().expect("list_keys").len();
+    assert_eq!(after_keys, initial_keys + 1);
+}
+
+#[tokio::test]
+async fn test_builder_duplicate_store_name_errors() {
+    let (instance, username) = setup_instance_with_user("alice", None).await;
+    let mut user = login_user(&instance, &username, None).await;
+
+    let result = user
+        .new_database()
+        .name("dup-store")
+        .empty_doc("config")
+        .empty_doc("config")
+        .build()
+        .await;
+
+    assert!(
+        result.is_err(),
+        "builder.build should reject duplicate store names"
+    );
+}
+
+#[tokio::test]
+async fn test_builder_init_callback_failure_aborts() {
+    let (instance, username) = setup_instance_with_user("alice", None).await;
+    let mut user = login_user(&instance, &username, None).await;
+
+    let initial_dbs = user.databases().await.expect("databases").len();
+
+    let result = user
+        .new_database()
+        .name("doomed")
+        .initialize_store::<DocStore, _, _>("config", |_s| async move {
+            Err(std::io::Error::other("init failed").into())
+        })
+        .build()
+        .await;
+
+    assert!(result.is_err());
+
+    // No database should have been tracked for the user.
+    let after_dbs = user.databases().await.expect("databases").len();
+    assert_eq!(after_dbs, initial_dbs);
+}
+
+#[tokio::test]
+async fn test_builder_auto_generated_key_persists_after_init_failure() {
+    // Documents the accepted tradeoff: the builder calls `add_private_key`
+    // BEFORE running store initializers, so an init failure leaves the
+    // generated key in the user's key store. `UserKeyManager` does not
+    // expose a removal API, and the same leak exists for the pre-existing
+    // `add_private_key` + `create_database` flow. If this changes
+    // (rollback or deferred key generation), this assert must flip.
+    let (instance, username) = setup_instance_with_user("alice", None).await;
+    let mut user = login_user(&instance, &username, None).await;
+
+    let initial_keys = user.list_keys().expect("list_keys").len();
+
+    let result = user
+        .new_database()
+        .name("leaky")
+        .key_label("leaked-key")
+        .initialize_store::<DocStore, _, _>("config", |_s| async move {
+            Err(std::io::Error::other("init failed").into())
+        })
+        .build()
+        .await;
+    assert!(result.is_err());
+
+    let after_keys = user.list_keys().expect("list_keys").len();
+    assert_eq!(
+        after_keys,
+        initial_keys + 1,
+        "auto-generated key persists when builder.build fails"
+    );
+}
+
+#[tokio::test]
+async fn test_builder_writes_tracked_database_row() {
+    let (instance, username) = setup_instance_with_user("alice", None).await;
+    let mut user = login_user(&instance, &username, None).await;
+
+    let initial_count = user.databases().await.expect("databases").len();
+
+    let (db, _) = user
+        .new_database()
+        .name("tracked-db")
+        .empty_doc("config")
+        .build()
+        .await
+        .unwrap();
+
+    let after = user.databases().await.expect("databases");
+    assert_eq!(after.len(), initial_count + 1);
+    assert!(
+        after
+            .iter()
+            .any(|tracked| tracked.database_id == *db.root_id())
+    );
+}
+
+// ===== PasswordStore via the builder =====
+//
+// `PasswordStore<S>` overrides `Store::register` to mark itself as
+// Uninitialized (empty config in `_index`). The builder path calls
+// `S::open` → `register` for new subtrees, so the builder should produce a
+// PasswordStore in the Uninitialized state. These tests confirm that path
+// works end-to-end: register through the builder, initialize encryption in
+// a follow-up transaction, write encrypted data, and verify decryption on
+// reopen.
+
+#[tokio::test]
+async fn test_builder_registers_password_store_uninitialized() {
+    // Registering `PasswordStore<DocStore>` via the builder lands the store
+    // in the Uninitialized state — its `_index` config is empty until a
+    // caller invokes `initialize(password, ...)` to set up encryption.
+    let (instance, username) = setup_instance_with_user("alice", None).await;
+    let mut user = login_user(&instance, &username, None).await;
+
+    let (db, _) = user
+        .new_database()
+        .name("with-password-store")
+        .initialize_store::<PasswordStore<DocStore>, _, _>("secrets", |_| async move {
+            // No-op: registration only. Encryption initialization happens
+            // in a follow-up transaction with the password.
+            Ok(())
+        })
+        .build()
+        .await
+        .expect("builder.build with PasswordStore registration failed");
+
+    // The genesis entry should carry the `secrets` subtree alongside the
+    // standard system subtrees.
+    let genesis = db.get_entry(db.root_id()).await.unwrap();
+    let subtrees = genesis.subtrees();
+    assert!(subtrees.iter().any(|s| s == "secrets"));
+    assert!(subtrees.iter().any(|s| s == "_index"));
+}
+
+#[tokio::test]
+async fn test_builder_password_store_initialize_and_roundtrip() {
+    // End-to-end: builder registers the store, a follow-up transaction
+    // initializes encryption and writes a value, a third transaction
+    // reopens with the password and reads the plaintext back. This proves
+    // the builder's registration is wire-compatible with PasswordStore's
+    // post-genesis initialization flow.
+    let (instance, username) = setup_instance_with_user("alice", None).await;
+    let mut user = login_user(&instance, &username, None).await;
+
+    let (db, _) = user
+        .new_database()
+        .name("password-roundtrip")
+        .initialize_store::<PasswordStore<DocStore>, _, _>("secrets", |_| async move { Ok(()) })
+        .build()
+        .await
+        .unwrap();
+
+    // Initialize encryption + write a value. Uses the standard PasswordStore
+    // post-genesis flow.
+    {
+        let txn = db.new_transaction().await.unwrap();
+        let mut encrypted = txn
+            .get_store::<PasswordStore<DocStore>>("secrets")
+            .await
+            .unwrap();
+        encrypted.initialize("hunter2", Doc::new()).await.unwrap();
+        let inner = encrypted.inner().await.unwrap();
+        inner.set("api_key", "s3cr3t").await.unwrap();
+        txn.commit().await.unwrap();
+    }
+
+    // Reopen, unlock, read.
+    {
+        let txn = db.new_transaction().await.unwrap();
+        let mut encrypted = txn
+            .get_store::<PasswordStore<DocStore>>("secrets")
+            .await
+            .unwrap();
+        encrypted.open("hunter2").unwrap();
+        let inner = encrypted.inner().await.unwrap();
+        let value = inner.get("api_key").await.unwrap();
+        assert_eq!(value.as_text(), Some("s3cr3t"));
+    }
+}
+
+#[tokio::test]
+async fn test_builder_password_store_wrong_password_rejected() {
+    // After builder registration + encryption initialization, opening with
+    // the wrong password must fail. This locks in the security contract:
+    // the builder path doesn't accidentally bypass the password check.
+    let (instance, username) = setup_instance_with_user("alice", None).await;
+    let mut user = login_user(&instance, &username, None).await;
+
+    let (db, _) = user
+        .new_database()
+        .name("password-wrong")
+        .initialize_store::<PasswordStore<DocStore>, _, _>("secrets", |_| async move { Ok(()) })
+        .build()
+        .await
+        .unwrap();
+
+    {
+        let txn = db.new_transaction().await.unwrap();
+        let mut encrypted = txn
+            .get_store::<PasswordStore<DocStore>>("secrets")
+            .await
+            .unwrap();
+        encrypted
+            .initialize("correct-password", Doc::new())
+            .await
+            .unwrap();
+        txn.commit().await.unwrap();
+    }
+
+    let txn = db.new_transaction().await.unwrap();
+    let mut encrypted = txn
+        .get_store::<PasswordStore<DocStore>>("secrets")
+        .await
+        .unwrap();
+    let result = encrypted.open("wrong-password");
+    assert!(result.is_err(), "wrong password must be rejected");
+}

--- a/crates/lib/tests/it/user/database_operations_tests.rs
+++ b/crates/lib/tests/it/user/database_operations_tests.rs
@@ -268,7 +268,7 @@ async fn test_database_supports_stores() {
 #[tokio::test]
 async fn test_multiple_users_create_databases() {
     let (instance, _) =
-        setup_instance_with_users(&[("alice", None), ("bob", None), ("charlie", None)]).await;
+        setup_local_instance_with_users(&[("alice", None), ("bob", None), ("charlie", None)]).await;
 
     // Each user creates a database
     let mut alice = login_user(&instance, "alice", None).await;

--- a/crates/lib/tests/it/user/helpers.rs
+++ b/crates/lib/tests/it/user/helpers.rs
@@ -37,13 +37,30 @@ pub async fn setup_instance() -> Instance {
 ///
 /// Returns (Instance, username) for easy access.
 ///
-/// Uses an always-local instance: the failing test patterns that go on
-/// to log in multiple sessions for the same user against this instance
-/// (e.g. multi-device key management) rely on each session seeing keys
-/// that other sessions added, which works naturally with a process-local
-/// instance. See [`setup_two_passwordless_users`] for the
-/// one-identity-per-connection rationale.
+/// Honors `TEST_BACKEND=service`: in service mode this returns a connected
+/// remote Instance, so callers exercise the wire path. Single-session use
+/// only — tests that log in multiple sessions on the same Instance (multi-
+/// device key visibility, sequential-login lifecycle) must use
+/// [`setup_local_instance_with_user`] instead, since the wire connection
+/// model is one-identity-per-connection and a second `login_user` would
+/// clobber the first session's `session_pubkey`.
 pub async fn setup_instance_with_user(
+    username: &str,
+    password: Option<&str>,
+) -> (Instance, String) {
+    let instance = crate::helpers::test_instance().await;
+    admin_create_user(&instance, username, password).await;
+    (instance, username.to_string())
+}
+
+/// Always-local variant of [`setup_instance_with_user`] for tests that log
+/// in multiple sessions on the same Instance — multi-device key visibility,
+/// sequential-login lifecycle, logout/relogin, etc. Bypasses
+/// `TEST_BACKEND=service` because the wire model is one-identity-per-
+/// connection (a second `login_user` against a connected Instance would
+/// clobber the first session's `session_pubkey`). Single-session tests
+/// should prefer [`setup_instance_with_user`] for wire coverage.
+pub async fn setup_local_instance_with_user(
     username: &str,
     password: Option<&str>,
 ) -> (Instance, String) {
@@ -56,12 +73,30 @@ pub async fn setup_instance_with_user(
 ///
 /// Returns (Instance, Vec<username>).
 ///
-/// Uses an always-local instance: tests that build a list of users with
-/// this helper invariably go on to log in as several of them against the
-/// same `Instance`, and the wire model can hold only one session per
-/// connection. See [`setup_two_passwordless_users`] for the same
-/// reasoning.
+/// Honors `TEST_BACKEND=service`. Same single-session constraint as
+/// [`setup_instance_with_user`]: only the first `login_user` call against
+/// the returned Instance is wire-safe. Tests that log in as more than one
+/// user (or the same user repeatedly) must use
+/// [`setup_local_instance_with_users`].
 pub async fn setup_instance_with_users(
+    user_configs: &[(&str, Option<&str>)],
+) -> (Instance, Vec<String>) {
+    let instance = crate::helpers::test_instance().await;
+    let mut usernames = Vec::new();
+
+    for (username, password) in user_configs {
+        admin_create_user(&instance, username, *password).await;
+        usernames.push(username.to_string());
+    }
+
+    (instance, usernames)
+}
+
+/// Always-local variant of [`setup_instance_with_users`] for tests that
+/// log in as more than one of the created users (or the same user
+/// multiple times) on the shared Instance. See
+/// [`setup_local_instance_with_user`] for the wire-model rationale.
+pub async fn setup_local_instance_with_users(
     user_configs: &[(&str, Option<&str>)],
 ) -> (Instance, Vec<String>) {
     let instance = crate::helpers::test_local_instance().await;

--- a/crates/lib/tests/it/user/integration_tests.rs
+++ b/crates/lib/tests/it/user/integration_tests.rs
@@ -21,7 +21,7 @@ use eidetica::{
 
 #[tokio::test]
 async fn test_independent_users_coexist() {
-    let (instance, _) = setup_instance_with_users(&[
+    let (instance, _) = setup_local_instance_with_users(&[
         ("alice", None),
         ("bob", Some("bob_pass")),
         ("charlie", None),
@@ -96,7 +96,7 @@ async fn test_independent_users_coexist() {
 
 #[tokio::test]
 async fn test_multi_device_key_management_and_database_access() {
-    let (instance, username) = setup_instance_with_user("alice", None).await;
+    let (instance, username) = setup_local_instance_with_user("alice", None).await;
 
     // Session 1: Desktop - Create user's first database with default key
     let mut user1 = instance
@@ -181,7 +181,7 @@ async fn test_multi_device_key_management_and_database_access() {
 #[tokio::test]
 async fn test_team_scenario_multiple_users_own_databases() {
     let (instance, _) =
-        setup_instance_with_users(&[("alice", None), ("bob", None), ("charlie", None)]).await;
+        setup_local_instance_with_users(&[("alice", None), ("bob", None), ("charlie", None)]).await;
 
     // Each team member creates their own project database
     let mut alice = instance
@@ -267,7 +267,8 @@ async fn test_collaborative_database_with_global_permissions() {
     // Setup two users on the same instance
     let alice_name = "alice";
     let bob_name = "bob";
-    let (instance, _) = setup_instance_with_users(&[(alice_name, None), (bob_name, None)]).await;
+    let (instance, _) =
+        setup_local_instance_with_users(&[(alice_name, None), (bob_name, None)]).await;
 
     // Alice logs in and creates a database with global Write(10) permission
     let mut alice = login_user(&instance, alice_name, None).await;

--- a/crates/lib/tests/it/user/mod.rs
+++ b/crates/lib/tests/it/user/mod.rs
@@ -1,5 +1,6 @@
 //! User module integration tests
 
+mod builder_tests;
 mod database_operations_tests;
 mod database_tracking_tests;
 mod helpers;

--- a/crates/lib/tests/it/user/multi_user_tests.rs
+++ b/crates/lib/tests/it/user/multi_user_tests.rs
@@ -14,7 +14,7 @@ use super::helpers::*;
 #[tokio::test]
 async fn test_many_users_create_databases() {
     let user_count = 5;
-    let (instance, _) = setup_instance_with_users(&[
+    let (instance, _) = setup_local_instance_with_users(&[
         ("user1", None),
         ("user2", None),
         ("user3", None),
@@ -113,7 +113,7 @@ async fn test_database_created_by_one_user() {
 
 #[tokio::test]
 async fn test_multiple_simultaneous_logins() {
-    let (instance, _) = setup_instance_with_users(&[("alice", None), ("bob", None)]).await;
+    let (instance, _) = setup_local_instance_with_users(&[("alice", None), ("bob", None)]).await;
 
     // Simulate simultaneous logins
     let alice1 = login_user(&instance, "alice", None).await;

--- a/crates/lib/tests/it/user/security_tests.rs
+++ b/crates/lib/tests/it/user/security_tests.rs
@@ -36,7 +36,7 @@ async fn test_empty_password_different_from_no_password() {
 async fn test_case_sensitive_passwords() {
     let username = "bob";
     let password = "MyPassword";
-    let (instance, _) = setup_instance_with_user(username, Some(password)).await;
+    let (instance, _) = setup_local_instance_with_user(username, Some(password)).await;
 
     // Wrong case should fail
     let result = instance.login_user(username, Some("mypassword")).await;
@@ -78,7 +78,7 @@ async fn test_long_password() {
 #[tokio::test]
 async fn test_key_ids_are_unique_per_user() {
     let (instance, _) =
-        setup_instance_with_users(&[("alice", None), ("bob", None), ("charlie", None)]).await;
+        setup_local_instance_with_users(&[("alice", None), ("bob", None), ("charlie", None)]).await;
 
     let alice = login_user(&instance, "alice", None).await;
     let bob = login_user(&instance, "bob", None).await;
@@ -222,7 +222,7 @@ async fn test_database_access_requires_key() {
 
 #[tokio::test]
 async fn test_multiple_sessions_see_persisted_changes() {
-    let (instance, username) = setup_instance_with_user("alice", None).await;
+    let (instance, username) = setup_local_instance_with_user("alice", None).await;
 
     // Session 1: Add a key
     let mut user1 = login_user(&instance, &username, None).await;

--- a/crates/lib/tests/it/user/user_lifecycle_tests.rs
+++ b/crates/lib/tests/it/user/user_lifecycle_tests.rs
@@ -54,7 +54,7 @@ async fn test_create_multiple_users_same_instance() {
         ("diana", Some("another_password")),
     ];
 
-    let (instance, usernames) = setup_instance_with_users(user_configs).await;
+    let (instance, usernames) = setup_local_instance_with_users(user_configs).await;
 
     assert_eq!(usernames.len(), 4, "Should have created 4 users");
 
@@ -165,7 +165,7 @@ async fn test_login_nonexistent_user() {
 #[tokio::test]
 async fn test_multiple_sequential_logins_same_user() {
     let username = "frank";
-    let (instance, _) = setup_instance_with_user(username, None).await;
+    let (instance, _) = setup_local_instance_with_user(username, None).await;
 
     // Login multiple times sequentially
     let _user1 = login_user(&instance, username, None).await;
@@ -180,7 +180,7 @@ async fn test_multiple_sequential_logins_same_user() {
 #[tokio::test]
 async fn test_logout_clears_session() {
     let username = "grace";
-    let (instance, _) = setup_instance_with_user(username, None).await;
+    let (instance, _) = setup_local_instance_with_user(username, None).await;
 
     let user = login_user(&instance, username, None).await;
 
@@ -195,7 +195,7 @@ async fn test_logout_clears_session() {
 async fn test_logout_and_relogin() {
     let username = "henry";
     let password = "password123";
-    let (instance, _) = setup_instance_with_user(username, Some(password)).await;
+    let (instance, _) = setup_local_instance_with_user(username, Some(password)).await;
 
     // First session
     let user1 = login_user(&instance, username, Some(password)).await;
@@ -212,7 +212,7 @@ async fn test_logout_and_relogin() {
 #[tokio::test]
 async fn test_logout_multiple_sessions() {
     let username = "iris";
-    let (instance, _) = setup_instance_with_user(username, None).await;
+    let (instance, _) = setup_local_instance_with_user(username, None).await;
 
     // Create multiple sessions and logout each one
     let user1 = login_user(&instance, username, None).await;


### PR DESCRIPTION
Replaces the 6-step setup-then-initialize dance (generate key -> build settings -> `create_database` -> open txn -> register stores -> write seed data) with a chainable builder that folds everything into one signed genesis entry.

```rust
use eidetica::store::DocStoreInit;

let (db, key) = user.new_database()
    .name("agent:demo")
    .key_label("agent:demo")
    .empty_doc("config")
    .initialize_doc("meta", meta)
    .initialize_store::<Table<Memory>, _, _>("memory", |t| async move {
        t.insert(&seed).await
    })
    .build()
    .await?;
```