### PR TITLE
feat: use "Snapshot" in place of the internal "Tips"

### DIFF
--- a/crates/bin/src/commands/db.rs
+++ b/crates/bin/src/commands/db.rs
@@ -47,7 +47,7 @@ pub async fn list(
 
             let mut rows = Vec::with_capacity(user_roots.len());
             for root in &user_roots {
-                let tips = instance.backend().get_tips(root).await?;
+                let tips = instance.backend().snapshot(root).await?;
                 rows.push(vec![root.to_string(), tips.len().to_string()]);
             }
             print_table(&["ROOT ID", "TIPS"], &rows);
@@ -55,7 +55,7 @@ pub async fn list(
         OutputFormat::Json => {
             let mut entries = Vec::with_capacity(user_roots.len());
             for root in &user_roots {
-                let tips = instance.backend().get_tips(root).await?;
+                let tips = instance.backend().snapshot(root).await?;
                 entries.push(serde_json::json!({
                     "id": root.to_string(),
                     "tips": tips.len(),

--- a/crates/lib/benches/backend_benchmarks.rs
+++ b/crates/lib/benches/backend_benchmarks.rs
@@ -2,7 +2,8 @@ mod helpers;
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use eidetica::{
-    Database, backend::BackendImpl, backend::database::InMemory, entry::ID, store::DocStore,
+    Database, Snapshot, backend::BackendImpl, backend::database::InMemory, entry::ID,
+    store::DocStore,
 };
 use std::hint::black_box;
 
@@ -43,7 +44,7 @@ async fn create_diamond_pattern(tree: &Database) -> (Vec<ID>, ID) {
 
     // Create B and C from A
     let txn_b = tree
-        .new_transaction_with_tips(std::slice::from_ref(&entry_a))
+        .new_transaction_at(&Snapshot::from(std::slice::from_ref(&entry_a)))
         .await
         .expect("Failed to create txn");
     let kv_b = txn_b
@@ -56,7 +57,7 @@ async fn create_diamond_pattern(tree: &Database) -> (Vec<ID>, ID) {
     let entry_b = txn_b.commit().await.expect("Failed to commit");
 
     let txn_c = tree
-        .new_transaction_with_tips(std::slice::from_ref(&entry_a))
+        .new_transaction_at(&Snapshot::from(std::slice::from_ref(&entry_a)))
         .await
         .expect("Failed to create txn");
     let kv_c = txn_c
@@ -101,7 +102,7 @@ async fn create_branching_tree(
 
         for entry_idx in 0..entries_per_branch {
             let txn = tree
-                .new_transaction_with_tips([current_tip])
+                .new_transaction_at(&Snapshot::from([current_tip]))
                 .await
                 .expect("Failed to create txn");
             let kv = txn
@@ -161,7 +162,7 @@ async fn create_large_tree(tree: &Database, num_entries: usize, structure: &str)
 
             for i in 0..num_entries {
                 let txn = tree
-                    .new_transaction_with_tips(std::slice::from_ref(&root_entry))
+                    .new_transaction_at(&Snapshot::from(std::slice::from_ref(&root_entry)))
                     .await
                     .expect("Failed to create txn");
                 let kv = txn
@@ -318,11 +319,11 @@ pub fn bench_tips_finding(c: &mut Criterion) {
                                 .expect("Failed to get backend")
                                 .local_engine()
                                 .expect("bench requires a local backend");
-                            let tips = backend
-                                .get_tips(tree.root_id())
+                            let snapshot = backend
+                                .snapshot(tree.root_id())
                                 .await
                                 .expect("Failed to get tips");
-                            black_box(tips);
+                            black_box(snapshot);
                         });
                     },
                 );
@@ -408,7 +409,7 @@ pub fn bench_crdt_merge_operations(c: &mut Criterion) {
                     |(_instance, tree, tip_entry)| {
                         rt.block_on(async {
                             let txn = tree
-                                .new_transaction_with_tips([tip_entry])
+                                .new_transaction_at(&Snapshot::from([tip_entry]))
                                 .await
                                 .expect("Failed to create txn");
                             let kv = txn

--- a/crates/lib/src/auth/validation/delegation.rs
+++ b/crates/lib/src/auth/validation/delegation.rs
@@ -77,7 +77,7 @@ impl DelegationResolver {
             })?;
 
             // Validate tips
-            let current_tips = current_backend.get_tips(&root_id).await.map_err(|e| {
+            let current_snapshot = current_backend.snapshot(&root_id).await.map_err(|e| {
                 AuthError::InvalidAuthConfiguration {
                     reason: format!(
                         "Failed to get current tips for delegated tree '{root_id}': {e}"
@@ -86,7 +86,7 @@ impl DelegationResolver {
             })?;
 
             let tips_valid = self
-                .validate_tip_ancestry(&step.tips, &current_tips, &current_backend)
+                .validate_tip_ancestry(&step.tips, current_snapshot.tips(), &current_backend)
                 .await?;
             if !tips_valid {
                 return Err(AuthError::InvalidDelegationTips {

--- a/crates/lib/src/auth/validation/tests.rs
+++ b/crates/lib/src/auth/validation/tests.rs
@@ -357,7 +357,7 @@ async fn test_complete_delegation_workflow() {
     txn.commit().await.unwrap();
 
     // Get the actual tips from the delegated tree
-    let delegated_tips = delegated_tree.get_tips().await.unwrap();
+    let delegated_tips = delegated_tree.snapshot().await.unwrap().into_tips();
 
     // Create the main tree — signing key bootstrapped as Admin(0)
     let main_tree = Database::create(
@@ -545,7 +545,7 @@ async fn test_nested_delegation_with_permission_clamping() {
         .unwrap();
     txn.commit().await.unwrap();
 
-    let user_tips = user_tree.get_tips().await.unwrap();
+    let user_tips = user_tree.snapshot().await.unwrap().into_tips();
 
     // 2. Create intermediate delegated tree that delegates to user tree
     let intermediate_tree = Database::create(
@@ -574,7 +574,7 @@ async fn test_nested_delegation_with_permission_clamping() {
         .unwrap();
     txn.commit().await.unwrap();
 
-    let intermediate_tips = intermediate_tree.get_tips().await.unwrap();
+    let intermediate_tips = intermediate_tree.snapshot().await.unwrap().into_tips();
 
     // 3. Create main tree that delegates to intermediate tree
     // Signing key stays at Admin(0) — matches original test intent.

--- a/crates/lib/src/backend/database/in_memory/mod.rs
+++ b/crates/lib/src/backend/database/in_memory/mod.rs
@@ -26,6 +26,7 @@ use crate::{
         errors::BackendError,
     },
     entry::{Entry, ID},
+    snapshot::Snapshot,
 };
 
 use cache::InMemoryCrdtCache;
@@ -285,42 +286,43 @@ impl BackendImpl for InMemory {
         Ok(ids)
     }
 
-    async fn get_tips(&self, tree: &ID) -> Result<Vec<ID>> {
+    async fn snapshot(&self, tree: &ID) -> Result<Snapshot> {
         // Fast path: check cache with read lock
         {
             let inner = self.inner.read().unwrap();
             if let Some(cache) = inner.tips.get(tree) {
-                return Ok(cache.tree_tips.iter().cloned().collect());
+                return Ok(Snapshot::new(cache.tree_tips.iter().cloned().collect()));
             }
         }
         // Slow path: compute and cache with write lock
         let mut inner = self.inner.write().unwrap();
-        traversal::get_tips(&mut inner, tree)
+        traversal::get_tips(&mut inner, tree).map(Snapshot::new)
     }
 
-    async fn get_store_tips(&self, tree: &ID, subtree: &str) -> Result<Vec<ID>> {
+    async fn store_snapshot(&self, tree: &ID, subtree: &str) -> Result<Snapshot> {
         // Fast path: check cache with read lock
         {
             let inner = self.inner.read().unwrap();
             if let Some(cache) = inner.tips.get(tree)
                 && let Some(subtree_tips) = cache.subtree_tips.get(subtree)
             {
-                return Ok(subtree_tips.iter().cloned().collect());
+                return Ok(Snapshot::new(subtree_tips.iter().cloned().collect()));
             }
         }
         // Slow path: compute and cache with write lock
         let mut inner = self.inner.write().unwrap();
-        traversal::get_store_tips(&mut inner, tree, subtree)
+        traversal::get_store_tips(&mut inner, tree, subtree).map(Snapshot::new)
     }
 
-    async fn get_store_tips_up_to_entries(
+    async fn store_snapshot_at(
         &self,
         tree: &ID,
         subtree: &str,
-        main_entries: &[ID],
-    ) -> Result<Vec<ID>> {
+        main_snapshot: &Snapshot,
+    ) -> Result<Snapshot> {
         let mut inner = self.inner.write().unwrap();
-        traversal::get_store_tips_up_to_entries(&mut inner, tree, subtree, main_entries)
+        traversal::get_store_tips_up_to_entries(&mut inner, tree, subtree, main_snapshot.tips())
+            .map(Snapshot::new)
     }
 
     /// Retrieves the IDs of all top-level root entries stored in the database.
@@ -377,14 +379,9 @@ impl BackendImpl for InMemory {
         storage::get_tree_from_tips(&inner, tree, tips)
     }
 
-    async fn get_store_from_tips(
-        &self,
-        tree: &ID,
-        subtree: &str,
-        tips: &[ID],
-    ) -> Result<Vec<Entry>> {
+    async fn store_at(&self, tree: &ID, subtree: &str, snapshot: &Snapshot) -> Result<Vec<Entry>> {
         let inner = self.inner.read().unwrap();
-        storage::get_store_from_tips(&inner, tree, subtree, tips)
+        storage::get_store_from_tips(&inner, tree, subtree, snapshot.tips())
     }
 
     async fn get_instance_metadata(&self) -> Result<Option<InstanceMetadata>> {

--- a/crates/lib/src/backend/database/sql/mod.rs
+++ b/crates/lib/src/backend/database/sql/mod.rs
@@ -42,6 +42,7 @@ use crate::backend::{
     BackendImpl, CacheScope, InstanceMetadata, InstanceSecrets, VerificationStatus,
 };
 use crate::entry::{Entry, ID};
+use crate::snapshot::Snapshot;
 
 /// Extension trait for sqlx Result types to simplify error handling.
 ///
@@ -402,21 +403,25 @@ impl BackendImpl for SqlxBackend {
         storage::get_entries_by_verification_status(self, status).await
     }
 
-    async fn get_tips(&self, tree: &ID) -> Result<Vec<ID>> {
-        traversal::get_tips(self, tree).await
+    async fn snapshot(&self, tree: &ID) -> Result<Snapshot> {
+        traversal::get_tips(self, tree).await.map(Snapshot::new)
     }
 
-    async fn get_store_tips(&self, tree: &ID, store: &str) -> Result<Vec<ID>> {
-        traversal::get_store_tips(self, tree, store).await
+    async fn store_snapshot(&self, tree: &ID, store: &str) -> Result<Snapshot> {
+        traversal::get_store_tips(self, tree, store)
+            .await
+            .map(Snapshot::new)
     }
 
-    async fn get_store_tips_up_to_entries(
+    async fn store_snapshot_at(
         &self,
         tree: &ID,
         store: &str,
-        main_entries: &[ID],
-    ) -> Result<Vec<ID>> {
-        traversal::get_store_tips_up_to_entries(self, tree, store, main_entries).await
+        main_snapshot: &Snapshot,
+    ) -> Result<Snapshot> {
+        traversal::get_store_tips_up_to_entries(self, tree, store, main_snapshot.tips())
+            .await
+            .map(Snapshot::new)
     }
 
     async fn all_roots(&self) -> Result<Vec<ID>> {
@@ -452,8 +457,8 @@ impl BackendImpl for SqlxBackend {
         traversal::get_tree_from_tips(self, tree, tips).await
     }
 
-    async fn get_store_from_tips(&self, tree: &ID, store: &str, tips: &[ID]) -> Result<Vec<Entry>> {
-        traversal::get_store_from_tips(self, tree, store, tips).await
+    async fn store_at(&self, tree: &ID, store: &str, snapshot: &Snapshot) -> Result<Vec<Entry>> {
+        traversal::get_store_from_tips(self, tree, store, snapshot.tips()).await
     }
 
     async fn get_cached_crdt_state(

--- a/crates/lib/src/backend/mod.rs
+++ b/crates/lib/src/backend/mod.rs
@@ -17,6 +17,7 @@ use crate::{
     Result,
     auth::crypto::{PrivateKey, PublicKey},
     entry::{Entry, ID},
+    snapshot::Snapshot,
 };
 
 /// Trust/visibility scope for a cached CRDT state entry.
@@ -295,52 +296,43 @@ pub trait BackendImpl: Send + Sync + Any {
         status: VerificationStatus,
     ) -> Result<Vec<ID>>;
 
-    /// Retrieves the IDs of the tip entries for a given tree.
+    /// Returns the current [`Snapshot`] of `tree` — its sorted, deduplicated
+    /// set of DAG tips.
     ///
-    /// Tips are defined as the set of entries within the specified tree
-    /// that have no children *within that same tree*. An entry is considered
-    /// a child of another if it lists the other entry in its `parents` list.
+    /// Tips are entries within `tree` that have no children *within that same
+    /// tree*: an entry is a child of another iff it lists the other entry in
+    /// its `parents` list.
     ///
     /// # Arguments
-    /// * `tree` - The root ID of the tree for which to find tips.
-    ///
-    /// # Returns
-    /// A `Result` containing a vector of tip entry IDs or an error.
-    async fn get_tips(&self, tree: &ID) -> Result<Vec<ID>>;
+    /// * `tree` - The root ID of the tree to snapshot.
+    async fn snapshot(&self, tree: &ID) -> Result<Snapshot>;
 
-    /// Retrieves the IDs of the tip entries for a specific store within a given tree.
+    /// Returns the snapshot of a specific store within a given tree.
     ///
-    /// Store tips are defined as the set of entries within the specified store
-    /// that have no children *within that same store*. An entry is considered
-    /// a child of another within a store if it lists the other entry in its
-    /// `store_parents` list for that specific store name.
+    /// Store tips are entries within the store that have no children *within
+    /// that same store*. An entry is a child of another within a store if it
+    /// lists the other entry in its `store_parents` list for that store name.
     ///
     /// # Arguments
     /// * `tree` - The root ID of the parent tree.
     /// * `store` - The name of the store for which to find tips.
-    ///
-    /// # Returns
-    /// A `Result` containing a vector of tip entry IDs for the store or an error.
-    async fn get_store_tips(&self, tree: &ID, store: &str) -> Result<Vec<ID>>;
+    async fn store_snapshot(&self, tree: &ID, store: &str) -> Result<Snapshot>;
 
-    /// Gets the store tips that exist up to a specific set of main tree entries.
+    /// Returns the store snapshot as of a specific main-tree snapshot.
     ///
-    /// This method finds all store entries that are reachable from the specified
-    /// main tree entries, then filters to find which of those are tips within the store.
+    /// Finds all store entries reachable from the boundary's tips, then filters
+    /// to the ones that are tips within the store.
     ///
     /// # Arguments
     /// * `tree` - The root ID of the parent tree.
     /// * `store` - The name of the store for which to find tips.
-    /// * `main_entries` - The main tree entry IDs to use as the boundary.
-    ///
-    /// # Returns
-    /// A `Result` containing a vector of store tip entry IDs up to the main entries.
-    async fn get_store_tips_up_to_entries(
+    /// * `main_snapshot` - Snapshot of the parent tree defining the boundary.
+    async fn store_snapshot_at(
         &self,
         tree: &ID,
         store: &str,
-        main_entries: &[ID],
-    ) -> Result<Vec<ID>>;
+        main_snapshot: &Snapshot,
+    ) -> Result<Snapshot>;
 
     /// Retrieves the IDs of all top-level root entries stored in the backend.
     ///
@@ -448,20 +440,15 @@ pub trait BackendImpl: Send + Sync + Any {
     /// - `EntryNotInTree` if any tip belongs to a different tree
     async fn get_tree_from_tips(&self, tree: &ID, tips: &[ID]) -> Result<Vec<Entry>>;
 
-    /// Retrieves all entries belonging to a specific store within a tree up to the given tips, sorted topologically.
+    /// Retrieves all entries belonging to a specific store at the given snapshot, sorted topologically.
     ///
-    /// Similar to `get_subtree`, but only includes entries that are ancestors of the provided store tips.
-    /// This allows reading from a specific state of the store defined by those tips.
+    /// Returns entries that are ancestors of the provided store snapshot's tips.
     ///
     /// # Arguments
     /// * `tree` - The root ID of the parent tree.
     /// * `store` - The name of the store to retrieve.
-    /// * `tips` - The tip IDs defining the state to read from.
-    ///
-    /// # Returns
-    /// A `Result` containing a vector of `Entry` objects in the store up to the given tips,
-    /// sorted topologically, or an error.
-    async fn get_store_from_tips(&self, tree: &ID, store: &str, tips: &[ID]) -> Result<Vec<Entry>>;
+    /// * `snapshot` - The store snapshot defining the state to read from.
+    async fn store_at(&self, tree: &ID, store: &str, snapshot: &Snapshot) -> Result<Vec<Entry>>;
 
     // === CRDT State Cache Methods ===
     //

--- a/crates/lib/src/database/mod.rs
+++ b/crates/lib/src/database/mod.rs
@@ -15,7 +15,7 @@ use crate::instance::backend::RemoteBackend;
 #[cfg(all(unix, feature = "service"))]
 use crate::service::client::RemoteConnection;
 use crate::{
-    Error, Instance, Result, Transaction, WeakInstance,
+    Error, Instance, Result, Snapshot, Transaction, WeakInstance,
     auth::{
         crypto::{PrivateKey, PublicKey},
         errors::AuthError,
@@ -582,8 +582,8 @@ impl Database {
                 }
 
                 // Get current tips for the delegated tree
-                let tips = match instance.backend().get_tips(delegated_root_id).await {
-                    Ok(t) => t,
+                let tips = match instance.backend().snapshot(delegated_root_id).await {
+                    Ok(snap) => snap.into_tips(),
                     Err(_) => continue,
                 };
 
@@ -798,23 +798,23 @@ impl Database {
     /// # Returns
     /// A `Result<Transaction>` containing the new atomic transaction
     pub async fn new_transaction(&self) -> Result<Transaction> {
-        let tips = self.get_tips().await?;
-        self.new_transaction_with_tips(&tips).await
+        let snapshot = self.snapshot().await?;
+        self.new_transaction_at(&snapshot).await
     }
 
-    /// Create a new atomic transaction on this database with specific parent tips
+    /// Create a new atomic transaction on this database anchored at a specific snapshot.
     ///
-    /// This creates a new atomic transaction that will have the specified entries as parents
-    /// instead of using the current database tips. This allows creating complex DAG structures
+    /// The transaction's parents are taken from the provided snapshot's tips instead of
+    /// the database's current state. This allows creating complex DAG structures
     /// like diamond patterns for testing and advanced use cases.
     ///
     /// # Arguments
-    /// * `tips` - The specific parent tips to use for this transaction
+    /// * `snapshot` - The snapshot to anchor the transaction at
     ///
     /// # Returns
     /// A `Result<Transaction>` containing the new atomic transaction
-    pub async fn new_transaction_with_tips(&self, tips: impl AsRef<[ID]>) -> Result<Transaction> {
-        let mut txn = Transaction::new_with_tips(self, tips.as_ref()).await?;
+    pub async fn new_transaction_at(&self, snapshot: &Snapshot) -> Result<Transaction> {
+        let mut txn = Transaction::new_at(self, snapshot).await?;
 
         // Set provided signing key from DatabaseKey
         if let Some(key) = &self.key {
@@ -852,11 +852,12 @@ impl Database {
             allow_unverified: matches!(scope, ReadScope::AllowUnverified),
             ..self.clone()
         };
-        let main_tips = db_for_tips.get_tips().await?;
+        let main_snapshot = db_for_tips.snapshot().await?;
+        let main_tips = main_snapshot.tips();
 
         // -- main parents: (tip, height) ------------------------------
         let mut main_parents = Vec::with_capacity(main_tips.len());
-        for tip in &main_tips {
+        for tip in main_tips {
             let entry = self.ops().get(tip).await?;
             main_parents.push((tip.clone(), entry.height()));
         }
@@ -864,12 +865,12 @@ impl Database {
         // -- per-store subtree parents: (tip, subtree_height) ---------
         let mut subtree_parents = std::collections::BTreeMap::new();
         for store in stores {
-            let child_tips = self
+            let child_snap = self
                 .ops()
-                .get_store_tips_up_to_entries(self.root_id(), store, &main_tips)
+                .store_snapshot_at(self.root_id(), store, &main_snapshot)
                 .await?;
-            let mut pairs = Vec::with_capacity(child_tips.len());
-            for tip in &child_tips {
+            let mut pairs = Vec::with_capacity(child_snap.len());
+            for tip in child_snap.tips() {
                 let entry = self.ops().get(tip).await?;
                 let height = entry.subtree_height(store).unwrap_or(0);
                 pairs.push((tip.clone(), height));
@@ -880,11 +881,12 @@ impl Database {
         // -- settings tips (pinned in entry metadata) -----------------
         let settings_tips = self
             .ops()
-            .get_store_tips_up_to_entries(self.root_id(), SETTINGS, &main_tips)
-            .await?;
+            .store_snapshot_at(self.root_id(), SETTINGS, &main_snapshot)
+            .await?
+            .into_tips();
 
         // -- merged _settings state as serde_json::Value --------------
-        let txn = Transaction::new_with_tips(self, &main_tips).await?;
+        let txn = Transaction::new_at(self, &main_snapshot).await?;
         let settings_doc: Doc = txn.get_full_state(SETTINGS).await?;
         let settings_value = serde_json::to_value(&settings_doc)?;
 
@@ -941,9 +943,8 @@ impl Database {
         tips: &[ID],
         _scope: crate::service::protocol::ReadScope,
     ) -> Result<Vec<Entry>> {
-        self.ops()
-            .get_store_from_tips(self.root_id(), store, tips)
-            .await
+        let snapshot = Snapshot::from(tips.to_vec());
+        self.ops().store_at(self.root_id(), store, &snapshot).await
     }
 
     /// Execute a closure within a transaction and commit the result.
@@ -1057,15 +1058,15 @@ impl Database {
     /// raw tips unchanged (the server owns verification).
     ///
     /// # Returns
-    /// A `Result` containing a vector of `ID`s for the tip entries or an error.
-    pub async fn get_tips(&self) -> Result<Vec<ID>> {
+    /// A `Result` containing the [`Snapshot`] of tip entries or an error.
+    pub async fn snapshot(&self) -> Result<Snapshot> {
         let instance = self.instance()?;
 
-        // On a remote instance the server owns verification: `get_verified_tips`
+        // On a remote instance the server owns verification: `snapshot`
         // already returns the server-side Verified frontier (or empty for a
         // not-yet-propagated tree, e.g. `Database::create`'s bootstrap
         // placeholder root — `EntryNotFound` is mapped to empty to match
-        // `Backend::get_tips`'s contract). Return it directly: the local
+        // `Backend::snapshot`'s contract). Return it directly: the local
         // verification machinery below (status probe, auto-verify,
         // `verified_frontier`) is local-only and would fail on a remote
         // backend anyway (e.g. `verified_frontier`'s `backend.get_tree(...)`).
@@ -1082,16 +1083,16 @@ impl Database {
         // backend, keeping the session-identity semantics for that path.
         #[cfg(all(unix, feature = "service"))]
         if instance.remote_connection().is_some() {
-            return match self.ops().get_tips(&self.root).await {
-                Ok(tips) => Ok(tips),
-                Err(e) if e.is_not_found() => Ok(Vec::new()),
+            return match self.ops().snapshot(&self.root).await {
+                Ok(snap) => Ok(snap),
+                Err(e) if e.is_not_found() => Ok(Snapshot::EMPTY),
                 Err(e) => Err(e),
             };
         }
 
         // Local path: verification-status probing needs the concrete engine.
         let backend = instance.require_local_engine()?;
-        let tips = self.ops().get_tips(&self.root).await?;
+        let tips = self.ops().snapshot(&self.root).await?.into_tips();
 
         // Verification status ops are local-only. On a remote backend the
         // server owns verification (and stores everything Unverified until
@@ -1099,7 +1100,7 @@ impl Database {
         if let Some(first) = tips.first()
             && backend.get_verification_status(first).await.is_err()
         {
-            return Ok(tips);
+            return Ok(Snapshot::new(tips));
         }
 
         // Access-time opportunistic verification: if any tip is still
@@ -1122,11 +1123,11 @@ impl Database {
                 }
             }
             if any_unverified {
-                // Boxed: this call closes a get_tips → verify →
-                // validate_entry → delegation → get_settings → get_tips
+                // Boxed: this call closes a snapshot → verify →
+                // validate_entry → delegation → get_settings → snapshot
                 // async cycle; the box gives it a finite future size.
                 let _ = Box::pin(self.verify()).await;
-                self.ops().get_tips(&self.root).await?
+                self.ops().snapshot(&self.root).await?.into_tips()
             } else {
                 tips
             }
@@ -1137,7 +1138,7 @@ impl Database {
         // reconstruct pinned `_settings` (the frontier filter itself depends
         // on verification status, which is exactly what verify is computing).
         if !self.allow_unverified && !auto_verify_suppressed() {
-            return self.verified_frontier().await;
+            return self.verified_frontier().await.map(Snapshot::new);
         }
 
         // `allow_unverified` view: keep Unverified tips, drop only Failed.
@@ -1147,7 +1148,7 @@ impl Database {
                 visible.push(t);
             }
         }
-        Ok(visible)
+        Ok(Snapshot::new(visible))
     }
 
     /// Compute the tips of the maximal all-`Verified` prefix of the DAG.
@@ -1200,9 +1201,9 @@ impl Database {
     /// A `Result` containing a vector of the tip `Entry` objects or an error.
     pub async fn get_tip_entries(&self) -> Result<Vec<Entry>> {
         let instance = self.instance()?;
-        let tips = self.get_tips().await?;
+        let snapshot = self.snapshot().await?;
         let mut entries = Vec::new();
-        for id in &tips {
+        for id in snapshot.tips() {
             entries.push(instance.get(id).await?);
         }
         Ok(entries)
@@ -1416,7 +1417,7 @@ impl Database {
     }
 
     /// Reconstruct the `_settings` auth config an entry's signature is pinned
-    /// to, from the `settings_tips` recorded in its signed metadata.
+    /// to, from the `settings_snapshot` recorded in its signed metadata.
     ///
     /// Validation must run against the settings the entry pinned — not the
     /// current settings — so granting authority later cannot retroactively
@@ -1430,10 +1431,10 @@ impl Database {
         let instance = self.instance()?;
         let backend = instance.backend();
 
-        // The pin: `_settings` tips recorded in the entry's signed metadata.
+        // The pin: `_settings` snapshot recorded in the entry's signed metadata.
         let settings_tips: Vec<ID> = match entry.metadata() {
             Some(raw) => match serde_json::from_slice::<crate::transaction::EntryMetadata>(raw) {
-                Ok(md) => md.settings_tips,
+                Ok(md) => md.settings_snapshot.into_tips(),
                 // Unparsable metadata ⇒ we cannot establish the pin.
                 Err(_) => return Ok(PinnedSettings::Incomplete),
             },
@@ -1485,8 +1486,9 @@ impl Database {
         // Reconstruct the merged `_settings` Doc as of the pinned tips.
         // Entries come back root-first; `_settings` is a system subtree and
         // is never encrypted, so deserialize directly.
+        let effective_snapshot = Snapshot::from(effective_tips.clone());
         let entries = backend
-            .get_store_from_tips(self.root_id(), SETTINGS, &effective_tips)
+            .store_at(self.root_id(), SETTINGS, &effective_snapshot)
             .await?;
         let mut settings_doc = Doc::default();
         for e in &entries {

--- a/crates/lib/src/instance/backend/local.rs
+++ b/crates/lib/src/instance/backend/local.rs
@@ -10,6 +10,7 @@ use crate::{
     backend::{BackendImpl, CacheScope, InstanceMetadata, VerificationStatus},
     entry::{Entry, ID},
     instance::WriteSource,
+    snapshot::Snapshot,
 };
 
 /// A [`Backend`] backed by a local [`BackendImpl`] (e.g. `InMemory`, SQLx).
@@ -39,27 +40,25 @@ impl Backend for LocalBackend {
         self.0.get(id).await
     }
 
-    async fn get_tips(&self, tree: &ID) -> Result<Vec<ID>> {
-        self.0.get_tips(tree).await
+    async fn snapshot(&self, tree: &ID) -> Result<Snapshot> {
+        self.0.snapshot(tree).await
     }
 
-    async fn get_store_tips(&self, tree: &ID, store: &str) -> Result<Vec<ID>> {
-        self.0.get_store_tips(tree, store).await
+    async fn store_snapshot(&self, tree: &ID, store: &str) -> Result<Snapshot> {
+        self.0.store_snapshot(tree, store).await
     }
 
-    async fn get_store_tips_up_to_entries(
+    async fn store_snapshot_at(
         &self,
         tree: &ID,
         store: &str,
-        up_to: &[ID],
-    ) -> Result<Vec<ID>> {
-        self.0
-            .get_store_tips_up_to_entries(tree, store, up_to)
-            .await
+        main_snapshot: &Snapshot,
+    ) -> Result<Snapshot> {
+        self.0.store_snapshot_at(tree, store, main_snapshot).await
     }
 
-    async fn get_store_from_tips(&self, tree: &ID, store: &str, tips: &[ID]) -> Result<Vec<Entry>> {
-        self.0.get_store_from_tips(tree, store, tips).await
+    async fn store_at(&self, tree: &ID, store: &str, snapshot: &Snapshot) -> Result<Vec<Entry>> {
+        self.0.store_at(tree, store, snapshot).await
     }
 
     async fn find_merge_base(&self, tree: &ID, store: &str, entry_ids: &[ID]) -> Result<ID> {

--- a/crates/lib/src/instance/backend/mod.rs
+++ b/crates/lib/src/instance/backend/mod.rs
@@ -31,6 +31,7 @@ use crate::{
     backend::{BackendImpl, InstanceMetadata, VerificationStatus},
     entry::{Entry, ID},
     instance::WriteSource,
+    snapshot::Snapshot,
 };
 
 /// The storage operations `Transaction`/`Store`/`Database`/`Instance` perform,
@@ -45,23 +46,23 @@ pub trait Backend: Send + Sync + std::fmt::Debug {
     /// Retrieve an entry by ID.
     async fn get(&self, id: &ID) -> Result<Entry>;
 
-    /// Raw tips of `tree` (no Verified-frontier filtering — that stays in
-    /// `Database`).
-    async fn get_tips(&self, tree: &ID) -> Result<Vec<ID>>;
+    /// Raw [`Snapshot`] of `tree` (no Verified-frontier filtering — that stays
+    /// in `Database`).
+    async fn snapshot(&self, tree: &ID) -> Result<Snapshot>;
 
-    /// Raw tips of `store` within `tree`.
-    async fn get_store_tips(&self, tree: &ID, store: &str) -> Result<Vec<ID>>;
+    /// Raw [`Snapshot`] of `store` within `tree`.
+    async fn store_snapshot(&self, tree: &ID, store: &str) -> Result<Snapshot>;
 
-    /// Store tips reachable up to the given main-tree entries.
-    async fn get_store_tips_up_to_entries(
+    /// Store snapshot reachable as of a specific main-tree snapshot.
+    async fn store_snapshot_at(
         &self,
         tree: &ID,
         store: &str,
-        up_to: &[ID],
-    ) -> Result<Vec<ID>>;
+        main_snapshot: &Snapshot,
+    ) -> Result<Snapshot>;
 
-    /// Every entry of `store` reachable from `tips`.
-    async fn get_store_from_tips(&self, tree: &ID, store: &str, tips: &[ID]) -> Result<Vec<Entry>>;
+    /// Every entry of `store` reachable from `snapshot`.
+    async fn store_at(&self, tree: &ID, store: &str, snapshot: &Snapshot) -> Result<Vec<Entry>>;
 
     /// Lowest common ancestor of `entry_ids` within `store`.
     async fn find_merge_base(&self, tree: &ID, store: &str, entry_ids: &[ID]) -> Result<ID>;

--- a/crates/lib/src/instance/backend/remote.rs
+++ b/crates/lib/src/instance/backend/remote.rs
@@ -10,6 +10,7 @@ use crate::{
     entry::{Entry, ID},
     instance::WriteSource,
     service::{client::RemoteConnection, protocol::ReadScope},
+    snapshot::Snapshot,
 };
 
 /// A [`Backend`] that translates every storage operation to a wire RPC over a
@@ -62,30 +63,30 @@ impl Backend for RemoteBackend {
             .await
     }
 
-    async fn get_tips(&self, tree: &ID) -> Result<Vec<ID>> {
+    async fn snapshot(&self, tree: &ID) -> Result<Snapshot> {
         match self
             .conn
             .get_verified_tips(tree.clone(), self.identity())
             .await
         {
-            Ok(tips) => Ok(tips),
-            Err(e) if e.is_not_found() => Ok(Vec::new()),
+            Ok(tips) => Ok(Snapshot::new(tips)),
+            Err(e) if e.is_not_found() => Ok(Snapshot::EMPTY),
             Err(e) => Err(e),
         }
     }
 
-    async fn get_store_tips(&self, tree: &ID, store: &str) -> Result<Vec<ID>> {
+    async fn store_snapshot(&self, tree: &ID, store: &str) -> Result<Snapshot> {
         let tree_tips = match self
             .conn
             .get_verified_tips(tree.clone(), self.identity())
             .await
         {
             Ok(tips) => tips,
-            Err(e) if e.is_not_found() => return Ok(Vec::new()),
+            Err(e) if e.is_not_found() => return Ok(Snapshot::EMPTY),
             Err(e) => return Err(e),
         };
         if tree_tips.is_empty() {
-            return Ok(Vec::new());
+            return Ok(Snapshot::EMPTY);
         }
         match self
             .conn
@@ -97,41 +98,41 @@ impl Backend for RemoteBackend {
             )
             .await
         {
-            Ok(tips) => Ok(tips),
-            Err(e) if e.is_not_found() => Ok(Vec::new()),
+            Ok(tips) => Ok(Snapshot::new(tips)),
+            Err(e) if e.is_not_found() => Ok(Snapshot::EMPTY),
             Err(e) => Err(e),
         }
     }
 
-    async fn get_store_tips_up_to_entries(
+    async fn store_snapshot_at(
         &self,
         tree: &ID,
         store: &str,
-        up_to: &[ID],
-    ) -> Result<Vec<ID>> {
+        main_snapshot: &Snapshot,
+    ) -> Result<Snapshot> {
         match self
             .conn
             .get_store_tips_up_to_entries(
                 tree.clone(),
                 self.identity(),
                 store.to_string(),
-                up_to.to_vec(),
+                main_snapshot.tips().to_vec(),
             )
             .await
         {
-            Ok(tips) => Ok(tips),
-            Err(e) if e.is_not_found() => Ok(Vec::new()),
+            Ok(tips) => Ok(Snapshot::new(tips)),
+            Err(e) if e.is_not_found() => Ok(Snapshot::EMPTY),
             Err(e) => Err(e),
         }
     }
 
-    async fn get_store_from_tips(&self, tree: &ID, store: &str, tips: &[ID]) -> Result<Vec<Entry>> {
+    async fn store_at(&self, tree: &ID, store: &str, snapshot: &Snapshot) -> Result<Vec<Entry>> {
         self.conn
             .get_store_entries(
                 tree.clone(),
                 self.identity(),
                 store.to_string(),
-                tips.to_vec(),
+                snapshot.tips().to_vec(),
                 ReadScope::Verified,
             )
             .await

--- a/crates/lib/src/instance/mod.rs
+++ b/crates/lib/src/instance/mod.rs
@@ -1091,8 +1091,8 @@ impl Instance {
     /// of the database by the Instance. This method checks if we're tracking
     /// the database's tip state.
     pub async fn has_database(&self, root_id: &ID) -> bool {
-        match self.inner.backend.get_tips(root_id).await {
-            Ok(tips) => !tips.is_empty(),
+        match self.inner.backend.snapshot(root_id).await {
+            Ok(snap) => !snap.is_empty(),
             Err(_) => false,
         }
     }
@@ -1124,9 +1124,13 @@ impl Instance {
         self.inner.backend.put(entry).await
     }
 
-    /// Get tips for a tree
-    pub(crate) async fn get_tips(&self, tree: &crate::entry::ID) -> Result<Vec<crate::entry::ID>> {
-        self.inner.backend.get_tips(tree).await
+    /// Returns the current [`crate::Snapshot`] of `tree` — its DAG tips. See
+    /// [`Database::snapshot`] for the public entry point.
+    pub(crate) async fn snapshot(
+        &self,
+        tree: &crate::entry::ID,
+    ) -> Result<crate::snapshot::Snapshot> {
+        self.inner.backend.snapshot(tree).await
     }
 
     // === System database accessors ===
@@ -1563,10 +1567,10 @@ impl Instance {
         let previous_tips = if self.remote_connection().is_some() {
             Vec::new()
         } else {
-            self.get_tips(tree_id).await?
+            self.snapshot(tree_id).await?.into_tips()
         };
         #[cfg(not(all(unix, feature = "service")))]
-        let previous_tips = self.get_tips(tree_id).await?;
+        let previous_tips = self.snapshot(tree_id).await?.into_tips();
 
         // 2. Persist to backend storage (and notify server for remote backends)
         self.backend()
@@ -1623,7 +1627,7 @@ impl Instance {
         let _guard = lock.lock().await;
 
         // 1. Capture tips before any writes
-        let previous_tips = self.get_tips(tree_id).await?;
+        let previous_tips = self.snapshot(tree_id).await?.into_tips();
 
         // 2. Store all entries
         let mut stored_entries = Vec::with_capacity(entries.len());

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -28,6 +28,7 @@ pub mod height;
 pub mod instance;
 #[cfg(all(unix, feature = "service"))]
 pub mod service;
+pub mod snapshot;
 pub mod store;
 pub mod sync;
 pub mod transaction;
@@ -41,6 +42,7 @@ pub use database::{Database, DatabaseKey};
 pub use entry::{Entry, ID};
 pub use height::HeightStrategy;
 pub use instance::{Instance, NewUser, WeakInstance, WriteCallback, WriteEvent, WriteSource};
+pub use snapshot::Snapshot;
 pub use store::{Registered, Store};
 /// Re-export fundamental types for easier access.
 pub use transaction::Transaction;

--- a/crates/lib/src/service/server.rs
+++ b/crates/lib/src/service/server.rs
@@ -443,12 +443,12 @@ async fn dispatch_database_op(
         }
 
         DatabaseOp::GetVerifiedTips => {
-            // The server runs the Database layer, so `get_tips()` returns the
+            // The server runs the Database layer, so `snapshot()` returns the
             // Verified frontier by construction — no client-side verify, no
             // remote-detection heuristic.
             let db = Database::open(instance, &root_id).await?;
-            let tips = db.get_tips().await?;
-            Ok(ServiceResponse::Ids(tips))
+            let snapshot = db.snapshot().await?;
+            Ok(ServiceResponse::Ids(snapshot.into_tips()))
         }
 
         DatabaseOp::SubmitSignedEntry { entry } => {
@@ -500,11 +500,12 @@ async fn dispatch_database_op(
 
         DatabaseOp::GetStoreTipsUpToEntries { store, up_to } => {
             let db = Database::open(instance, &root_id).await?;
-            let ids = db
+            let boundary = crate::Snapshot::from(up_to);
+            let snapshot = db
                 .ops()
-                .get_store_tips_up_to_entries(&root_id, &store, &up_to)
+                .store_snapshot_at(&root_id, &store, &boundary)
                 .await?;
-            Ok(ServiceResponse::Ids(ids))
+            Ok(ServiceResponse::Ids(snapshot.into_tips()))
         }
 
         DatabaseOp::ComputeMergeState { store, entry_ids } => {

--- a/crates/lib/src/snapshot.rs
+++ b/crates/lib/src/snapshot.rs
@@ -1,0 +1,294 @@
+//! Snapshot — an immutable identifier of a database state at a point in time.
+//!
+//! A `Snapshot` is the canonical (sorted, deduplicated) set of DAG tip IDs
+//! that fully identifies the state of a `Database` or a `Store` within one.
+//! Content-addressing makes the mapping bijective: given a snapshot and the
+//! database root it belongs to, the entries (and therefore all reachable
+//! content) are uniquely determined.
+//!
+//! Use a `Snapshot` to pin a read view, anchor a transaction, or describe
+//! a state transition (e.g. `WriteEvent { from, to }`).
+//!
+//! `Snapshot` is intentionally scope-free: it carries *only* a set of tips.
+//! The scope — a database root, or a `(database root, store name)` pair — is
+//! contextual and supplied alongside the snapshot at API boundaries. A
+//! snapshot can therefore describe either a database state or a store state;
+//! the distinction lives in the API method consuming it, not on the snapshot
+//! itself. Keeping `Snapshot` as just a canonical tip-set means no optional
+//! fields, no runtime "is the root set?" checks, and a wire format identical
+//! to `Vec<ID>`.
+
+use serde::{Deserialize, Serialize, Serializer};
+
+use crate::entry::ID;
+
+/// Identifier for a database state — a sorted, deduplicated set of DAG tips.
+///
+/// Equality and hashing are set-equality on the tips. Serialization is
+/// transparent: the wire form is a bare array of IDs, identical to a
+/// `Vec<ID>`. Deserialization normalizes (sort + dedup), so unsorted or
+/// duplicated wire input is canonicalized on read.
+#[derive(Debug, Clone, Default)]
+pub struct Snapshot {
+    /// Sorted, deduplicated set of tip IDs.
+    tips: Vec<ID>,
+}
+
+impl Serialize for Snapshot {
+    fn serialize<S: Serializer>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error> {
+        self.tips.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for Snapshot {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let tips = Vec::<ID>::deserialize(deserializer)?;
+        Ok(Self::new(tips))
+    }
+}
+
+impl Snapshot {
+    /// A snapshot containing no tips — the state of a database with no entries.
+    pub const EMPTY: Snapshot = Snapshot { tips: Vec::new() };
+
+    /// Construct a snapshot from a vector of tips.
+    ///
+    /// Tips are sorted and deduplicated.
+    pub fn new(mut tips: Vec<ID>) -> Self {
+        tips.sort();
+        tips.dedup();
+        Self { tips }
+    }
+
+    /// Borrow the tips as a sorted, deduplicated slice.
+    pub fn tips(&self) -> &[ID] {
+        &self.tips
+    }
+
+    /// Consume the snapshot and return the underlying tips.
+    pub fn into_tips(self) -> Vec<ID> {
+        self.tips
+    }
+
+    /// Returns true if this snapshot contains no tips.
+    pub fn is_empty(&self) -> bool {
+        self.tips.is_empty()
+    }
+
+    /// Number of tips in this snapshot.
+    pub fn len(&self) -> usize {
+        self.tips.len()
+    }
+}
+
+/// Equality is set-equality on tips.
+impl PartialEq for Snapshot {
+    fn eq(&self, other: &Self) -> bool {
+        // Set-equality holds because `tips` is canonical (sorted + deduped on construction).
+        self.tips == other.tips
+    }
+}
+
+impl Eq for Snapshot {}
+
+impl std::hash::Hash for Snapshot {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.tips.hash(state);
+    }
+}
+
+impl From<Vec<ID>> for Snapshot {
+    fn from(tips: Vec<ID>) -> Self {
+        Self::new(tips)
+    }
+}
+
+impl From<&[ID]> for Snapshot {
+    fn from(tips: &[ID]) -> Self {
+        Self::new(tips.to_vec())
+    }
+}
+
+impl<const N: usize> From<[ID; N]> for Snapshot {
+    fn from(tips: [ID; N]) -> Self {
+        Self::new(tips.to_vec())
+    }
+}
+
+impl AsRef<[ID]> for Snapshot {
+    fn as_ref(&self) -> &[ID] {
+        &self.tips
+    }
+}
+
+impl<'a> IntoIterator for &'a Snapshot {
+    type Item = &'a ID;
+    type IntoIter = std::slice::Iter<'a, ID>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.tips.iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn id(byte: u8) -> ID {
+        ID::from_bytes([byte])
+    }
+
+    #[test]
+    fn empty_const_is_empty() {
+        assert!(Snapshot::EMPTY.is_empty());
+        assert_eq!(Snapshot::EMPTY.len(), 0);
+        assert_eq!(Snapshot::EMPTY.tips(), &[] as &[ID]);
+    }
+
+    #[test]
+    fn default_equals_empty() {
+        assert_eq!(Snapshot::default(), Snapshot::EMPTY);
+    }
+
+    #[test]
+    fn new_sorts_input() {
+        let a = id(1);
+        let b = id(2);
+        let c = id(3);
+        let unsorted = Snapshot::new(vec![c.clone(), a.clone(), b.clone()]);
+        let sorted = Snapshot::new(vec![a, b, c]);
+        assert_eq!(unsorted.tips(), sorted.tips());
+    }
+
+    #[test]
+    fn new_dedups_input() {
+        let a = id(1);
+        let b = id(2);
+        let with_dupes = Snapshot::new(vec![a.clone(), b.clone(), a.clone(), b.clone(), a.clone()]);
+        let mut expected = vec![a, b];
+        expected.sort();
+        assert_eq!(with_dupes.len(), 2);
+        assert_eq!(with_dupes.tips(), expected.as_slice());
+    }
+
+    #[test]
+    fn set_equality_holds_via_canonical_form() {
+        let a = id(1);
+        let b = id(2);
+        let s1: Snapshot = vec![a.clone(), b.clone()].into();
+        let s2: Snapshot = vec![b, a].into();
+        assert_eq!(s1, s2);
+    }
+
+    #[test]
+    fn hash_matches_for_set_equal_snapshots() {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+        let a = id(1);
+        let b = id(2);
+        let s1: Snapshot = vec![a.clone(), b.clone()].into();
+        let s2: Snapshot = vec![b, a].into();
+        let mut h1 = DefaultHasher::new();
+        s1.hash(&mut h1);
+        let mut h2 = DefaultHasher::new();
+        s2.hash(&mut h2);
+        assert_eq!(h1.finish(), h2.finish());
+    }
+
+    #[test]
+    fn from_slice_sorts_and_dedups() {
+        let a = id(1);
+        let b = id(2);
+        let snap = Snapshot::from(&[b.clone(), a.clone(), a.clone()][..]);
+        let mut expected = vec![a, b];
+        expected.sort();
+        assert_eq!(snap.tips(), expected.as_slice());
+    }
+
+    #[test]
+    fn from_array_sorts_and_dedups() {
+        let a = id(1);
+        let b = id(2);
+        let snap = Snapshot::from([b.clone(), a.clone(), a.clone()]);
+        let mut expected = vec![a, b];
+        expected.sort();
+        assert_eq!(snap.tips(), expected.as_slice());
+    }
+
+    #[test]
+    fn into_tips_returns_sorted_vec() {
+        let mut expected = vec![id(1), id(2), id(3)];
+        expected.sort();
+        let snap = Snapshot::new(vec![id(3), id(1), id(2)]);
+        assert_eq!(snap.into_tips(), expected);
+    }
+
+    #[test]
+    fn iter_yields_sorted_tips() {
+        let mut expected = [id(1), id(2), id(3)];
+        expected.sort();
+        let snap = Snapshot::new(vec![id(3), id(1), id(2)]);
+        let collected: Vec<&ID> = (&snap).into_iter().collect();
+        let expected_refs: Vec<&ID> = expected.iter().collect();
+        assert_eq!(collected, expected_refs);
+    }
+
+    #[test]
+    fn as_ref_exposes_sorted_slice() {
+        let a = id(1);
+        let b = id(2);
+        let snap = Snapshot::new(vec![b.clone(), a.clone()]);
+        let slice: &[ID] = snap.as_ref();
+        let mut expected = vec![a, b];
+        expected.sort();
+        assert_eq!(slice, expected.as_slice());
+    }
+
+    #[test]
+    fn serde_roundtrip_preserves_invariant() {
+        let a = id(1);
+        let b = id(2);
+        let snap = Snapshot::new(vec![b, a]);
+        let json = serde_json::to_string(&snap).unwrap();
+        let parsed: Snapshot = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, snap);
+    }
+
+    #[test]
+    fn deserialize_normalizes_unsorted_wire_data() {
+        // Simulate wire data written without the sorted invariant
+        // (e.g. by an older client). The Snapshot deserializer must canonicalize.
+        let a = id(1);
+        let b = id(2);
+        let canonical = Snapshot::new(vec![a.clone(), b.clone()]);
+        let unsorted_json = serde_json::to_string(&vec![b, a]).unwrap();
+        let parsed: Snapshot = serde_json::from_str(&unsorted_json).unwrap();
+        assert_eq!(parsed, canonical);
+    }
+
+    #[test]
+    fn deserialize_dedups_wire_data() {
+        let a = id(1);
+        let b = id(2);
+        let canonical = Snapshot::new(vec![a.clone(), b.clone()]);
+        let duped_json = serde_json::to_string(&vec![a.clone(), b, a]).unwrap();
+        let parsed: Snapshot = serde_json::from_str(&duped_json).unwrap();
+        assert_eq!(parsed, canonical);
+    }
+
+    #[test]
+    fn serializes_as_bare_id_array() {
+        // Snapshot must be wire-compatible with Vec<ID> — same JSON shape.
+        // This matters for in-place migration of fields that were previously
+        // typed `Vec<ID>` (e.g. EntryMetadata.settings_tips).
+        let a = id(1);
+        let b = id(2);
+        let snap = Snapshot::new(vec![a.clone(), b.clone()]);
+        let snap_json = serde_json::to_string(&snap).unwrap();
+        let vec_json = serde_json::to_string(snap.tips()).unwrap();
+        assert_eq!(snap_json, vec_json);
+    }
+}

--- a/crates/lib/src/snapshot.rs
+++ b/crates/lib/src/snapshot.rs
@@ -118,8 +118,27 @@ impl<const N: usize> From<[ID; N]> for Snapshot {
     }
 }
 
+impl<const N: usize> From<&[ID; N]> for Snapshot {
+    fn from(tips: &[ID; N]) -> Self {
+        Self::new(tips.to_vec())
+    }
+}
+
+impl From<&Vec<ID>> for Snapshot {
+    fn from(tips: &Vec<ID>) -> Self {
+        Self::new(tips.clone())
+    }
+}
+
 impl AsRef<[ID]> for Snapshot {
     fn as_ref(&self) -> &[ID] {
+        &self.tips
+    }
+}
+
+impl std::ops::Deref for Snapshot {
+    type Target = [ID];
+    fn deref(&self) -> &[ID] {
         &self.tips
     }
 }

--- a/crates/lib/src/sync/background/mod.rs
+++ b/crates/lib/src/sync/background/mod.rs
@@ -738,11 +738,12 @@ impl BackgroundSync {
 
             // Get our tips for this tree (empty if tree doesn't exist)
             let instance = self.instance()?;
-            let our_tips = instance
+            let our_tips: Vec<ID> = instance
                 .backend()
-                .get_tips(tree_id)
+                .snapshot(tree_id)
                 .await
-                .map_err(|e| SyncError::BackendError(format!("Failed to get local tips: {e}")))?;
+                .map_err(|e| SyncError::BackendError(format!("Failed to get local tips: {e}")))?
+                .into_tips();
 
             // Get our device public key for automatic peer tracking
             let our_device_pubkey = Some(instance.id());

--- a/crates/lib/src/sync/handler.rs
+++ b/crates/lib/src/sync/handler.rs
@@ -911,8 +911,8 @@ impl SyncHandlerImpl {
             Ok(i) => i,
             Err(e) => return SyncResponse::Error(format!("Instance dropped: {e}")),
         };
-        let our_tips = match instance.backend().get_tips(tree_id).await {
-            Ok(tips) => tips,
+        let our_tips: Vec<ID> = match instance.backend().snapshot(tree_id).await {
+            Ok(snap) => snap.into_tips(),
             Err(e) => {
                 error!(tree_id = %tree_id, error = %e, "Failed to get our tips");
                 return SyncResponse::Error(format!("Failed to get tips: {e}"));

--- a/crates/lib/src/sync/handler_tree_ops.rs
+++ b/crates/lib/src/sync/handler_tree_ops.rs
@@ -59,8 +59,8 @@ impl SyncHandlerImpl {
         let mut to_visit = std::collections::VecDeque::new();
 
         // Get tips to start traversal
-        let tips = self.instance()?.backend().get_tips(tree_id).await?;
-        to_visit.extend(tips);
+        let snapshot = self.instance()?.backend().snapshot(tree_id).await?;
+        to_visit.extend(snapshot.into_tips());
 
         // Traverse the DAG depth-first
         while let Some(entry_id) = to_visit.pop_front() {
@@ -104,8 +104,8 @@ impl SyncHandlerImpl {
         let mut to_visit = std::collections::VecDeque::new();
 
         // Get tips to start traversal
-        let tips = self.instance()?.backend().get_tips(tree_id).await?;
-        to_visit.extend(tips);
+        let snapshot = self.instance()?.backend().snapshot(tree_id).await?;
+        to_visit.extend(snapshot.into_tips());
 
         // Traverse the DAG depth-first, INCLUDING the root
         while let Some(entry_id) = to_visit.pop_front() {
@@ -177,8 +177,8 @@ impl SyncHandlerImpl {
         let mut to_visit = std::collections::VecDeque::new();
 
         // Get tips to start traversal
-        let tips = self.instance()?.backend().get_tips(tree_id).await?;
-        to_visit.extend(tips);
+        let snapshot = self.instance()?.backend().snapshot(tree_id).await?;
+        to_visit.extend(snapshot.into_tips());
 
         // Count all entries
         while let Some(entry_id) = to_visit.pop_front() {

--- a/crates/lib/src/sync/ops.rs
+++ b/crates/lib/src/sync/ops.rs
@@ -49,10 +49,11 @@ impl Sync {
 
         // Get our current tips for this tree (empty if tree doesn't exist)
         let backend = self.backend()?;
-        let our_tips = backend
-            .get_tips(tree_id)
+        let our_tips: Vec<ID> = backend
+            .snapshot(tree_id)
             .await
-            .map_err(|e| SyncError::BackendError(format!("Failed to get local tips: {e}")))?;
+            .map_err(|e| SyncError::BackendError(format!("Failed to get local tips: {e}")))?
+            .into_tips();
 
         // Get our device public key for automatic peer tracking
         let our_device_pubkey = self.get_device_pubkey().ok();
@@ -161,11 +162,12 @@ impl Sync {
 
         // Step 2: Check if server is missing entries from us
         let backend = self.backend()?;
-        let our_tips = backend.get_tips(&response.tree_id).await?;
+        let our_snapshot = backend.snapshot(&response.tree_id).await?;
         let their_tips = &response.their_tips;
 
         // Find tips they don't have
-        let missing_tip_ids: Vec<_> = our_tips
+        let missing_tip_ids: Vec<_> = our_snapshot
+            .tips()
             .iter()
             .filter(|tip_id| !their_tips.contains(tip_id))
             .cloned()
@@ -650,10 +652,11 @@ impl Sync {
 
         // Get our current tips for this tree (empty if tree doesn't exist)
         let backend = self.backend()?;
-        let our_tips = backend
-            .get_tips(tree_id)
+        let our_tips: Vec<ID> = backend
+            .snapshot(tree_id)
             .await
-            .map_err(|e| SyncError::BackendError(format!("Failed to get local tips: {e}")))?;
+            .map_err(|e| SyncError::BackendError(format!("Failed to get local tips: {e}")))?
+            .into_tips();
 
         // Get our device public key for automatic peer tracking
         let our_device_pubkey = self.get_device_pubkey().ok();

--- a/crates/lib/src/sync/peer.rs
+++ b/crates/lib/src/sync/peer.rs
@@ -190,12 +190,12 @@ impl Sync {
     ) -> Result<SyncStatus> {
         // Check if we have local data for this tree
         let backend = self.backend()?;
-        let our_tips = backend.get_tips(tree_id).await.unwrap_or_default();
+        let our_snapshot = backend.snapshot(tree_id).await.unwrap_or_default();
 
         // TODO: Track last_sync time and last_error in sync tree
         // For now, just report if we have data
         Ok(SyncStatus {
-            has_local_data: !our_tips.is_empty(),
+            has_local_data: !our_snapshot.is_empty(),
             last_sync: None,
             last_error: None,
         })

--- a/crates/lib/src/sync/user.rs
+++ b/crates/lib/src/sync/user.rs
@@ -4,8 +4,8 @@ use tracing::{debug, info};
 
 use super::{Sync, SyncError, user_sync_manager::UserSyncManager};
 use crate::{
-    Database, Result, entry::ID, instance::settings_merge::merge_sync_settings, store::Table,
-    user::types::TrackedDatabase,
+    Database, Result, Snapshot, entry::ID, instance::settings_merge::merge_sync_settings,
+    store::Table, user::types::TrackedDatabase,
 };
 
 impl Sync {
@@ -68,10 +68,10 @@ impl Sync {
         let prefs_db = Database::open(&instance, preferences_db_id)
             .await?
             .with_key(device_key.clone());
-        let current_tips = prefs_db.get_tips().await?;
+        let current_snapshot = prefs_db.snapshot().await?;
 
-        // Check if preferences have changed via tip comparison
-        if current_tips == old_tips {
+        // Check if preferences have changed via snapshot comparison (set-equal).
+        if current_snapshot == Snapshot::from(old_tips.clone()) {
             debug!(user_uuid = %user_uuid_str, "No changes to user preferences, skipping update");
             return Ok(());
         }
@@ -163,7 +163,7 @@ impl Sync {
 
         // Update stored tips to reflect processed state
         user_mgr
-            .update_tracked_tips(user_uuid_str, &current_tips)
+            .update_tracked_tips(user_uuid_str, current_snapshot.tips())
             .await?;
 
         // Commit all changes atomically

--- a/crates/lib/src/transaction/mod.rs
+++ b/crates/lib/src/transaction/mod.rs
@@ -29,7 +29,7 @@ pub use errors::TransactionError;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    Database, Result, Store,
+    Database, Result, Snapshot, Store,
     auth::{
         AuthSettings,
         crypto::{PrivateKey, sign_entry},
@@ -126,11 +126,15 @@ pub(crate) trait Encryptor: Send + Sync {
 /// Metadata structure for entries
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct EntryMetadata {
-    /// Tips of the _settings subtree at the time this entry was created.
+    /// Snapshot of the `_settings` subtree at the time this entry was created.
     /// This is the entry's **pin**: the exact `_settings` state its
     /// signature must be validated against. Used for sync performance,
     /// sparse-checkout validation, and deferred re-verification.
-    pub(crate) settings_tips: Vec<ID>,
+    ///
+    /// Wire name remains `settings_tips` for on-disk stability — `Snapshot`
+    /// serializes as a bare ID array, identical to the legacy `Vec<ID>` shape.
+    #[serde(rename = "settings_tips")]
+    pub(crate) settings_snapshot: Snapshot,
     /// Random entropy for ensuring unique IDs for root entries
     pub(crate) entropy: Option<u64>,
 }
@@ -167,22 +171,19 @@ pub struct Transaction {
 }
 
 impl Transaction {
-    /// Creates a new atomic transaction for a specific `Database` with custom parent tips.
+    /// Creates a new atomic transaction for a specific `Database` anchored at a snapshot.
     ///
     /// Initializes an internal `EntryBuilder` with its main parent pointers set to the
-    /// specified tips instead of the current database tips. This allows creating
-    /// transactions that branch from specific points in the database history.
-    ///
-    /// This enables creating diamond patterns and other complex DAG structures
-    /// for testing and advanced use cases.
+    /// snapshot's tips instead of the database's current state. This allows creating
+    /// transactions that branch from specific points in the database history (e.g.
+    /// diamond patterns).
     ///
     /// # Arguments
     /// * `database` - The `Database` this transaction will modify.
-    /// * `tips` - The specific parent tips to use for this transaction. Must contain at least one tip.
-    ///
-    /// # Returns
-    /// A `Result<Self>` containing the new transaction or an error if tips are empty or invalid.
-    pub(crate) async fn new_with_tips(database: &Database, tips: &[ID]) -> Result<Self> {
+    /// * `snapshot` - The snapshot to anchor the transaction at. Must contain at least one tip,
+    ///   unless this transaction is creating the database's root entry.
+    pub(crate) async fn new_at(database: &Database, snapshot: &Snapshot) -> Result<Self> {
+        let tips = snapshot.tips();
         // Validate that tips are not empty, unless we're creating the root entry
         if tips.is_empty() {
             // Check if this is a root entry creation by seeing if the database root exists in backend
@@ -410,8 +411,8 @@ impl Transaction {
         let mut metadata = builder
             .metadata()
             .and_then(|m| serde_json::from_slice::<EntryMetadata>(m).ok())
-            .unwrap_or_else(|| EntryMetadata {
-                settings_tips: Vec::new(),
+            .unwrap_or(EntryMetadata {
+                settings_snapshot: Snapshot::EMPTY,
                 entropy: None,
             });
 
@@ -461,8 +462,13 @@ impl Transaction {
         // Fetch tips if needed (no borrow held across this await)
         let tips = if needs_tips {
             let backend = self.db.ops();
-            // FIXME: we should get the subtree tips while still using the parent pointers
-            Some(backend.get_store_tips(self.db.root_id(), subtree).await?)
+            // FIXME: we should get the subtree snapshot while still using the parent pointers
+            Some(
+                backend
+                    .store_snapshot(self.db.root_id(), subtree)
+                    .await?
+                    .into_tips(),
+            )
         } else {
             None
         };
@@ -542,10 +548,12 @@ impl Transaction {
 
     /// Get the subtree tips reachable from the given main tree entries.
     async fn get_subtree_tips(&self, subtree_name: &str, main_parents: &[ID]) -> Result<Vec<ID>> {
+        let boundary = Snapshot::from(main_parents.to_vec());
         self.db
             .ops()
-            .get_store_tips_up_to_entries(self.db.root_id(), subtree_name, main_parents)
+            .store_snapshot_at(self.db.root_id(), subtree_name, &boundary)
             .await
+            .map(Snapshot::into_tips)
     }
 
     /// Initialize subtree parents if this is the first time accessing this subtree
@@ -671,19 +679,23 @@ impl Transaction {
 
         // Initialize subtree tips if needed (async operations)
         if needs_init {
-            let current_database_tips = self.db.ops().get_tips(self.db.root_id()).await?;
+            let current_database_snapshot = self.db.ops().snapshot(self.db.root_id()).await?;
 
-            let tips = if main_parents == current_database_tips {
+            // Set-equal comparison via Snapshot canonical form.
+            let parents_snapshot = Snapshot::from(main_parents.clone());
+            let tips = if parents_snapshot == current_database_snapshot {
                 let backend = self.db.ops();
                 backend
-                    .get_store_tips(self.db.root_id(), subtree_name)
+                    .store_snapshot(self.db.root_id(), subtree_name)
                     .await?
+                    .into_tips()
             } else {
                 // This transaction uses custom tips - use special handler
                 self.db
                     .ops()
-                    .get_store_tips_up_to_entries(self.db.root_id(), subtree_name, &main_parents)
+                    .store_snapshot_at(self.db.root_id(), subtree_name, &parents_snapshot)
                     .await?
+                    .into_tips()
             };
 
             // Update RefCell after async operations
@@ -845,14 +857,11 @@ impl Transaction {
 
             // Step 2: Batch fetch all ancestors sorted by height (root first)
             // This single query replaces N recursive queries
+            let boundary = Snapshot::from([entry_id.clone()]);
             let entries = self
                 .db
                 .ops()
-                .get_store_from_tips(
-                    self.db.root_id(),
-                    subtree_name,
-                    std::slice::from_ref(entry_id),
-                )
+                .store_at(self.db.root_id(), subtree_name, &boundary)
                 .await?;
 
             // Step 3: Merge all entries in order (already sorted by height, root first)
@@ -1038,13 +1047,13 @@ impl Transaction {
             builder.remove_empty_subtrees_mut()?;
         }
 
-        // Add metadata with settings tips for all entries
-        // Get the backend to access settings tips (do async ops before RefCell borrow)
-        let db_tips = self.db.get_tips().await?;
-        let settings_tips = self
+        // Add metadata with settings snapshot for all entries
+        // Get the backend to access the settings snapshot (do async ops before RefCell borrow)
+        let db_snapshot = self.db.snapshot().await?;
+        let settings_snapshot = self
             .db
             .ops()
-            .get_store_tips_up_to_entries(self.db.root_id(), SETTINGS, &db_tips)
+            .store_snapshot_at(self.db.root_id(), SETTINGS, &db_snapshot)
             .await?;
 
         // Clone the builder from RefCell (limit borrow scope to avoid holding across await)
@@ -1060,13 +1069,13 @@ impl Transaction {
         let mut metadata = builder
             .metadata()
             .and_then(|m| serde_json::from_slice::<EntryMetadata>(m).ok())
-            .unwrap_or_else(|| EntryMetadata {
-                settings_tips: Vec::new(),
+            .unwrap_or(EntryMetadata {
+                settings_snapshot: Snapshot::EMPTY,
                 entropy: None,
             });
 
-        // Update settings tips
-        metadata.settings_tips = settings_tips;
+        // Update settings snapshot
+        metadata.settings_snapshot = settings_snapshot;
 
         // Serialize the metadata
         let metadata_json = serde_json::to_vec(&metadata)?;

--- a/crates/lib/tests/it/auth/delegated_trees.rs
+++ b/crates/lib/tests/it/auth/delegated_trees.rs
@@ -73,7 +73,7 @@ async fn test_delegated_tree_basic_validation() -> Result<()> {
     // Test delegated tree validation
     let mut validator = AuthValidator::new();
     let main_auth_settings = main_tree.get_settings().await?.auth_snapshot().await?;
-    let delegated_tips = delegated_tree.get_tips().await?;
+    let delegated_tips = delegated_tree.snapshot().await?.into_tips();
 
     // Create delegation path - DelegationStep uses root tree ID and tips
     let delegated_auth_id = SigKey::Delegation {
@@ -127,7 +127,7 @@ async fn test_delegated_tree_permission_clamping() -> Result<()> {
     // Test permission clamping
     let mut validator = AuthValidator::new();
     let main_auth_settings = main_tree.get_settings().await?.auth_snapshot().await?;
-    let delegated_tips = delegated_tree.get_tips().await?;
+    let delegated_tips = delegated_tree.snapshot().await?.into_tips();
 
     let delegated_auth_id = SigKey::Delegation {
         path: vec![DelegationStep {
@@ -182,7 +182,7 @@ async fn test_nested_delegation() -> Result<()> {
     .await?;
 
     // Add delegation to user tree
-    let user_tips = user_tree.get_tips().await?;
+    let user_tips = user_tree.snapshot().await?.into_tips();
     let user_tree_root = user_tree.root_id().clone();
     let txn = org_tree.new_transaction().await?;
     {
@@ -206,7 +206,7 @@ async fn test_nested_delegation() -> Result<()> {
     .await?;
 
     // Add delegation to org tree
-    let org_tips = org_tree.get_tips().await?;
+    let org_tips = org_tree.snapshot().await?.into_tips();
     let org_tree_root = org_tree.root_id().clone();
     let txn = main_tree.new_transaction().await?;
     {
@@ -288,7 +288,7 @@ async fn test_delegated_tree_with_revoked_keys() -> Result<()> {
     .await?;
 
     // Add delegation to delegated tree
-    let delegated_tips = delegated_tree.get_tips().await?;
+    let delegated_tips = delegated_tree.snapshot().await?.into_tips();
     let delegated_tree_root = delegated_tree.root_id().clone();
     let txn = main_tree.new_transaction().await?;
     {
@@ -377,7 +377,7 @@ async fn test_delegation_depth_limits() -> Result<()> {
     .await?;
 
     // Add delegation to delegated tree
-    let delegated_tips = delegated_tree.get_tips().await?;
+    let delegated_tips = delegated_tree.snapshot().await?.into_tips();
     let delegated_tree_root = delegated_tree.root_id().clone();
     let txn = main_tree.new_transaction().await?;
     {
@@ -451,7 +451,7 @@ async fn test_delegated_tree_min_bound_upgrade() -> Result<()> {
         ],
     )
     .await?;
-    let delegated_tips = delegated_tree.get_tips().await?;
+    let delegated_tips = delegated_tree.snapshot().await?.into_tips();
 
     // ---------------- Main tree with delegation using SettingsStore API ----------------
     let main_tree = user.create_database(Doc::new(), &main_admin_key).await?;
@@ -537,7 +537,7 @@ async fn test_delegated_tree_priority_preservation() -> Result<()> {
         ],
     )
     .await?;
-    let delegated_tips = delegated_tree.get_tips().await?;
+    let delegated_tips = delegated_tree.snapshot().await?.into_tips();
 
     // Main tree delegates with max Write(8) (more privileged) and no min using SettingsStore API
     let main_tree = user.create_database(Doc::new(), &main_admin_key).await?;
@@ -599,7 +599,7 @@ async fn test_delegation_depth_limit_exact() -> Result<()> {
         &[("admin", &admin_key, Permission::Admin(0), KeyStatus::Active)],
     )
     .await?;
-    let tips = tree.get_tips().await?;
+    let tips = tree.snapshot().await?.into_tips();
 
     // Build a chain exactly 10 levels deep
     let mut delegation_steps = Vec::new();
@@ -823,7 +823,7 @@ async fn open_via_delegation(
     signing_key: PrivateKey,
     hint_key_id: &PublicKey,
 ) -> Result<Database> {
-    let identity_db_tips = pair.identity_db.get_tips().await?;
+    let identity_db_tips = pair.identity_db.snapshot().await?.into_tips();
     let delegation_sigkey = SigKey::Delegation {
         path: vec![DelegationStep {
             tree: pair.identity_db.root_id().clone(),
@@ -1006,7 +1006,7 @@ async fn test_delegated_entry_validation_across_instances() -> Result<()> {
     // Get tip entries from target_db on instance B and validate them
     let target_tips = instance_b
         .backend()
-        .get_tips(pair.target_db.root_id())
+        .snapshot(pair.target_db.root_id())
         .await?;
     assert!(
         !target_tips.is_empty(),
@@ -1082,7 +1082,11 @@ async fn test_delegated_entry_synced_unverified_then_verified() -> Result<()> {
     );
     // It is now visible in the default Verified-frontier view on B.
     assert!(
-        target_db_b.get_tips().await?.contains(&delegated_entry),
+        target_db_b
+            .snapshot()
+            .await?
+            .into_tips()
+            .contains(&delegated_entry),
         "verified delegated entry must be on the frontier"
     );
 
@@ -1125,7 +1129,7 @@ async fn test_delegated_write_secondary_identity_key() -> Result<()> {
     txn.commit().await?;
 
     // Open target_db using the secondary key via delegation
-    let identity_db_tips = identity_db.get_tips().await?;
+    let identity_db_tips = identity_db.snapshot().await?.into_tips();
     let delegation_sigkey = SigKey::Delegation {
         path: vec![DelegationStep {
             tree: identity_db.root_id().clone(),

--- a/crates/lib/tests/it/auth/error_handling_tests.rs
+++ b/crates/lib/tests/it/auth/error_handling_tests.rs
@@ -178,7 +178,7 @@ async fn test_privilege_escalation_through_delegation() -> Result<()> {
     let delegated_tree = user
         .create_database(delegated_settings, &admin_key_id)
         .await?;
-    let delegated_tips = delegated_tree.get_tips().await?;
+    let delegated_tips = delegated_tree.snapshot().await?.into_tips();
 
     // Create main tree (signing key becomes Admin(0))
     let main_settings = Doc::new();
@@ -256,7 +256,7 @@ async fn test_delegation_with_tampered_tips() -> Result<()> {
         .await?;
     txn.commit().await?;
 
-    let real_tips = delegated_tree.get_tips().await?;
+    let real_tips = delegated_tree.snapshot().await?.into_tips();
 
     // Create main tree (signing key becomes Admin(0))
     let main_settings = Doc::new();
@@ -340,7 +340,7 @@ async fn test_delegation_mixed_key_statuses() -> Result<()> {
         .await?;
     txn.commit().await?;
 
-    let delegated_tips = delegated_tree.get_tips().await?;
+    let delegated_tips = delegated_tree.snapshot().await?.into_tips();
 
     // Create main tree (signing key becomes Admin(0))
     let main_settings = Doc::new();

--- a/crates/lib/tests/it/auth/helpers.rs
+++ b/crates/lib/tests/it/auth/helpers.rs
@@ -258,7 +258,7 @@ pub async fn create_delegation_ref(
     max_permission: Permission,
     min_permission: Option<Permission>,
 ) -> Result<DelegatedTreeRef> {
-    let tips = tree.get_tips().await?;
+    let tips = tree.snapshot().await?.into_tips();
     Ok(DelegatedTreeRef {
         permission_bounds: PermissionBounds {
             max: max_permission,
@@ -341,7 +341,11 @@ impl DelegationChain {
         let mut steps = Vec::new();
 
         for tree in self.trees.iter() {
-            let tips = tree.get_tips().await.expect("Failed to get tips");
+            let tips = tree
+                .snapshot()
+                .await
+                .expect("Failed to get tips")
+                .into_tips();
             steps.push(DelegationStep {
                 tree: tree.root_id().clone(),
                 tips,

--- a/crates/lib/tests/it/auth/sig_key_edge_cases.rs
+++ b/crates/lib/tests/it/auth/sig_key_edge_cases.rs
@@ -267,7 +267,7 @@ async fn test_circular_delegation_simple() -> Result<()> {
 
     // Create a tree (signing key becomes Admin(0))
     let tree = user.create_database(Doc::new(), &key_id).await?;
-    let tree_tips = tree.get_tips().await?;
+    let tree_tips = tree.snapshot().await?.into_tips();
 
     // Create delegation path that references the same tree
     let circular_delegation = SigKey::Delegation {

--- a/crates/lib/tests/it/backend/basic_operations.rs
+++ b/crates/lib/tests/it/backend/basic_operations.rs
@@ -30,7 +30,7 @@ async fn test_backend_error_handling() {
     assert!(get_result.is_err());
 
     // get_tips for non-existent tree returns an empty vector
-    let tips_result = backend.get_tips(&non_existent_id).await;
+    let tips_result = backend.snapshot(&non_existent_id).await;
     assert!(
         tips_result.is_ok(),
         "get_tips should succeed for non-existent tree"
@@ -55,7 +55,7 @@ async fn test_backend_error_handling() {
 
     // get_store_tips for non-existent tree returns an empty vector
     let subtree_tips_result = backend
-        .get_store_tips(&non_existent_id, "non_existent_subtree")
+        .store_snapshot(&non_existent_id, "non_existent_subtree")
         .await;
     assert!(
         subtree_tips_result.is_ok(),

--- a/crates/lib/tests/it/backend/helpers.rs
+++ b/crates/lib/tests/it/backend/helpers.rs
@@ -87,7 +87,8 @@ pub struct DiamondStructure {
 
 /// Assert that a tree has a single tip with the specified ID
 pub async fn assert_single_tip(backend: &dyn BackendImpl, tree_id: &ID, expected_tip: &ID) {
-    let tips = backend.get_tips(tree_id).await.unwrap();
+    let snapshot = backend.snapshot(tree_id).await.unwrap();
+    let tips = snapshot.tips();
     assert_eq!(tips.len(), 1, "Expected exactly one tip");
     assert_eq!(tips[0], *expected_tip, "Tip ID doesn't match expected");
 }

--- a/crates/lib/tests/it/backend/out_of_order_tips.rs
+++ b/crates/lib/tests/it/backend/out_of_order_tips.rs
@@ -28,7 +28,7 @@ async fn test_tree_tips_out_of_order_arrival() {
     backend.put_verified(entry_a).await.unwrap();
 
     // Verify A is the only tip
-    let tips = backend.get_tips(&id_a).await.unwrap();
+    let tips = backend.snapshot(&id_a).await.unwrap().into_tips();
     assert_eq!(tips.len(), 1, "Initially A should be the only tip");
     assert_eq!(tips[0], id_a);
 
@@ -49,7 +49,7 @@ async fn test_tree_tips_out_of_order_arrival() {
 
     // At this point, C is stored but its parent B is not
     // C should be a tip
-    let tips = backend.get_tips(&id_a).await.unwrap();
+    let tips = backend.snapshot(&id_a).await.unwrap().into_tips();
     assert!(tips.contains(&id_c), "C should be a tip");
 
     // Now store B (the parent of C)
@@ -57,7 +57,7 @@ async fn test_tree_tips_out_of_order_arrival() {
 
     // After storing B, only C should be a tip
     // B should NOT be a tip because C already references it as a parent
-    let tips = backend.get_tips(&id_a).await.unwrap();
+    let tips = backend.snapshot(&id_a).await.unwrap().into_tips();
     assert_eq!(tips.len(), 1, "Only C should be a tip after storing B");
     assert_eq!(tips[0], id_c, "The single tip should be C, not B");
 }
@@ -79,7 +79,11 @@ async fn test_store_tips_out_of_order_arrival() {
     backend.put_verified(entry_a).await.unwrap();
 
     // Verify A is the only store tip
-    let tips = backend.get_store_tips(&id_a, store_name).await.unwrap();
+    let tips = backend
+        .store_snapshot(&id_a, store_name)
+        .await
+        .unwrap()
+        .into_tips();
     assert_eq!(tips.len(), 1, "Initially A should be the only store tip");
     assert_eq!(tips[0], id_a);
 
@@ -103,14 +107,22 @@ async fn test_store_tips_out_of_order_arrival() {
     backend.put_verified(entry_c).await.unwrap();
 
     // C should be a store tip
-    let tips = backend.get_store_tips(&id_a, store_name).await.unwrap();
+    let tips = backend
+        .store_snapshot(&id_a, store_name)
+        .await
+        .unwrap()
+        .into_tips();
     assert!(tips.contains(&id_c), "C should be a store tip");
 
     // Now store B
     backend.put_verified(entry_b).await.unwrap();
 
     // After storing B, only C should be a store tip
-    let tips = backend.get_store_tips(&id_a, store_name).await.unwrap();
+    let tips = backend
+        .store_snapshot(&id_a, store_name)
+        .await
+        .unwrap()
+        .into_tips();
     assert_eq!(
         tips.len(),
         1,
@@ -160,14 +172,14 @@ async fn test_diamond_tips_out_of_order_arrival() {
     backend.put_verified(entry_d).await.unwrap();
 
     // D should be a tip (its parents don't exist yet)
-    let tips = backend.get_tips(&id_a).await.unwrap();
+    let tips = backend.snapshot(&id_a).await.unwrap().into_tips();
     assert!(tips.contains(&id_d), "D should be a tip");
 
     // Store B
     backend.put_verified(entry_b).await.unwrap();
 
     // B should NOT be a tip (D references it)
-    let tips = backend.get_tips(&id_a).await.unwrap();
+    let tips = backend.snapshot(&id_a).await.unwrap().into_tips();
     assert!(
         !tips.contains(&id_b),
         "B should NOT be a tip (D is its child)"
@@ -179,7 +191,7 @@ async fn test_diamond_tips_out_of_order_arrival() {
 
     // C should NOT be a tip (D references it)
     // Only D should be a tip
-    let tips = backend.get_tips(&id_a).await.unwrap();
+    let tips = backend.snapshot(&id_a).await.unwrap().into_tips();
     assert_eq!(tips.len(), 1, "Only D should be a tip");
     assert_eq!(tips[0], id_d, "The single tip should be D");
 }
@@ -240,7 +252,7 @@ async fn test_partial_sync_with_gaps() {
     backend.put_verified(entry_b).await.unwrap();
 
     // After storing B: B is the only entry, so B is a tip
-    let tips = backend.get_tips(&id_a).await.unwrap();
+    let tips = backend.snapshot(&id_a).await.unwrap().into_tips();
     assert_eq!(tips.len(), 1, "After storing B: only B should be a tip");
     assert!(tips.contains(&id_b));
 
@@ -249,7 +261,7 @@ async fn test_partial_sync_with_gaps() {
     // After storing E: B and E are both tips
     // B has no children (C is not stored)
     // E has no children
-    let tips = backend.get_tips(&id_a).await.unwrap();
+    let tips = backend.snapshot(&id_a).await.unwrap().into_tips();
     assert_eq!(tips.len(), 2, "After storing E: B and E should be tips");
     assert!(tips.contains(&id_b), "B should be a tip (C is missing)");
     assert!(tips.contains(&id_e), "E should be a tip (no children)");
@@ -259,7 +271,7 @@ async fn test_partial_sync_with_gaps() {
     // After storing D: B and E are still the tips
     // D is NOT a tip because E references it as parent
     // B is still a tip because C is missing
-    let tips = backend.get_tips(&id_a).await.unwrap();
+    let tips = backend.snapshot(&id_a).await.unwrap().into_tips();
     assert_eq!(
         tips.len(),
         2,

--- a/crates/lib/tests/it/backend/save_load.rs
+++ b/crates/lib/tests/it/backend/save_load.rs
@@ -165,8 +165,8 @@ async fn test_save_load_with_various_entries() {
     );
 
     // Check tips match
-    let orig_tips = backend.get_tips(&root_id).await.unwrap();
-    let loaded_tips = loaded_backend.get_tips(&root_id).await.unwrap();
+    let orig_tips = backend.snapshot(&root_id).await.unwrap().into_tips();
+    let loaded_tips = loaded_backend.snapshot(&root_id).await.unwrap().into_tips();
     assert_eq!(orig_tips.len(), loaded_tips.len());
 
     // Should have 3 tips (grandchild, entry_with_subtree, and child2)

--- a/crates/lib/tests/it/backend/subtree_operations.rs
+++ b/crates/lib/tests/it/backend/subtree_operations.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 
+use eidetica::Snapshot;
 use eidetica::entry::{Entry, ID};
 
 use super::helpers::test_backend;
@@ -27,7 +28,7 @@ async fn test_backend_subtree_operations() {
     backend.put_verified(child_entry).await.unwrap();
 
     // Test get_store_tips
-    let subtree_tips_result = backend.get_store_tips(&root_id, "subtree1").await;
+    let subtree_tips_result = backend.store_snapshot(&root_id, "subtree1").await;
     assert!(subtree_tips_result.is_ok());
     let subtree_tips = subtree_tips_result.unwrap();
     assert_eq!(subtree_tips.len(), 1);
@@ -91,7 +92,11 @@ async fn test_backend_get_store_from_tips() {
 
     // --- Test with single tip e2a ---
     let subtree_e2a = backend
-        .get_store_from_tips(&root_entry_id, subtree_name, std::slice::from_ref(&e2a_id))
+        .store_at(
+            &root_entry_id,
+            subtree_name,
+            &Snapshot::from(std::slice::from_ref(&e2a_id).to_vec()),
+        )
         .await
         .expect("Failed to get subtree from tip e2a");
     // Should contain root and e2a (which have the subtree), but not e1 (no subtree) or e2b (not in history of tip e2a)
@@ -112,10 +117,10 @@ async fn test_backend_get_store_from_tips() {
 
     // --- Test with both tips e2a and e2b ---
     let subtree_both = backend
-        .get_store_from_tips(
+        .store_at(
             &root_entry_id,
             subtree_name,
-            &[e2a_id.clone(), e2b_id.clone()],
+            &Snapshot::from([e2a_id.clone(), e2b_id.clone()]),
         )
         .await
         .expect("Failed to get subtree from tips e2a, e2b");
@@ -141,7 +146,11 @@ async fn test_backend_get_store_from_tips() {
     // When given a tip that exists but doesn't have the specified store,
     // the result should be empty.
     let subtree_bad_name = backend
-        .get_store_from_tips(&root_entry_id, "bad_name", std::slice::from_ref(&e2a_id))
+        .store_at(
+            &root_entry_id,
+            "bad_name",
+            &Snapshot::from(std::slice::from_ref(&e2a_id).to_vec()),
+        )
         .await
         .expect("Getting subtree with bad name should succeed");
     assert!(
@@ -151,10 +160,10 @@ async fn test_backend_get_store_from_tips() {
 
     // --- Test with non-existent tip ---
     let subtree_bad_tip = backend
-        .get_store_from_tips(
+        .store_at(
             &root_entry_id,
             subtree_name,
-            &[ID::from_bytes("bad_tip_id")],
+            &Snapshot::from([ID::from_bytes("bad_tip_id")]),
         )
         .await
         .expect("Failed to get subtree with non-existent tip");
@@ -168,7 +177,11 @@ async fn test_backend_get_store_from_tips() {
     // the result should be empty because the tip doesn't belong to the specified tree.
     let bad_root_id_2: ID = ID::from_bytes("bad_root");
     let subtree_bad_root = backend
-        .get_store_from_tips(&bad_root_id_2, subtree_name, std::slice::from_ref(&e1_id))
+        .store_at(
+            &bad_root_id_2,
+            subtree_name,
+            &Snapshot::from(std::slice::from_ref(&e1_id).to_vec()),
+        )
         .await
         .expect("Failed to get subtree with non-existent root");
     assert!(
@@ -215,7 +228,11 @@ async fn test_get_store_tips() {
     backend.put_verified(entry_a).await.unwrap();
 
     // Initially, A is the only tip in subtree "sub1"
-    let sub1_tips = backend.get_store_tips(&root_id, "sub1").await.unwrap();
+    let sub1_tips = backend
+        .store_snapshot(&root_id, "sub1")
+        .await
+        .unwrap()
+        .into_tips();
     assert_eq!(sub1_tips.len(), 1);
     assert_eq!(sub1_tips[0], id_a);
 
@@ -230,7 +247,11 @@ async fn test_get_store_tips() {
     backend.put_verified(entry_b).await.unwrap();
 
     // Now B is the only tip in subtree "sub1"
-    let sub1_tips = backend.get_store_tips(&root_id, "sub1").await.unwrap();
+    let sub1_tips = backend
+        .store_snapshot(&root_id, "sub1")
+        .await
+        .unwrap()
+        .into_tips();
     assert_eq!(sub1_tips.len(), 1);
     assert_eq!(sub1_tips[0], id_b);
 
@@ -244,12 +265,20 @@ async fn test_get_store_tips() {
     backend.put_verified(entry_c).await.unwrap();
 
     // Check tips for subtree "sub1" (should still be just B)
-    let sub1_tips = backend.get_store_tips(&root_id, "sub1").await.unwrap();
+    let sub1_tips = backend
+        .store_snapshot(&root_id, "sub1")
+        .await
+        .unwrap()
+        .into_tips();
     assert_eq!(sub1_tips.len(), 1);
     assert_eq!(sub1_tips[0], id_b);
 
     // Check tips for subtree "sub2" (should be just C)
-    let sub2_tips = backend.get_store_tips(&root_id, "sub2").await.unwrap();
+    let sub2_tips = backend
+        .store_snapshot(&root_id, "sub2")
+        .await
+        .unwrap()
+        .into_tips();
     assert_eq!(sub2_tips.len(), 1);
     assert_eq!(sub2_tips[0], id_c);
 
@@ -267,11 +296,19 @@ async fn test_get_store_tips() {
     backend.put_verified(entry_d).await.unwrap();
 
     // Now D should be the tip for both subtrees
-    let sub1_tips = backend.get_store_tips(&root_id, "sub1").await.unwrap();
+    let sub1_tips = backend
+        .store_snapshot(&root_id, "sub1")
+        .await
+        .unwrap()
+        .into_tips();
     assert_eq!(sub1_tips.len(), 1);
     assert_eq!(sub1_tips[0], id_d);
 
-    let sub2_tips = backend.get_store_tips(&root_id, "sub2").await.unwrap();
+    let sub2_tips = backend
+        .store_snapshot(&root_id, "sub2")
+        .await
+        .unwrap()
+        .into_tips();
     assert_eq!(sub2_tips.len(), 1);
     assert_eq!(sub2_tips[0], id_d);
 }
@@ -342,7 +379,11 @@ async fn test_get_store_tips_up_to_entries_linear_chain() {
     backend.put_verified(entry_d).await.unwrap();
 
     // Verify current tips (fast path) - should be D
-    let current_tips = backend.get_store_tips(&root_id, subtree).await.unwrap();
+    let current_tips = backend
+        .store_snapshot(&root_id, subtree)
+        .await
+        .unwrap()
+        .into_tips();
     assert_eq!(current_tips.len(), 1);
     assert_eq!(current_tips[0], id_d);
 
@@ -350,7 +391,11 @@ async fn test_get_store_tips_up_to_entries_linear_chain() {
 
     // Query tips up to {A} - should return A as the tip
     let tips_at_a = backend
-        .get_store_tips_up_to_entries(&root_id, subtree, std::slice::from_ref(&id_a))
+        .store_snapshot_at(
+            &root_id,
+            subtree,
+            &Snapshot::from(std::slice::from_ref(&id_a).to_vec()),
+        )
         .await
         .unwrap();
     assert_eq!(tips_at_a.len(), 1, "Tips at A should have 1 entry");
@@ -358,7 +403,11 @@ async fn test_get_store_tips_up_to_entries_linear_chain() {
 
     // Query tips up to {B} - should return B as the tip
     let tips_at_b = backend
-        .get_store_tips_up_to_entries(&root_id, subtree, std::slice::from_ref(&id_b))
+        .store_snapshot_at(
+            &root_id,
+            subtree,
+            &Snapshot::from(std::slice::from_ref(&id_b).to_vec()),
+        )
         .await
         .unwrap();
     assert_eq!(tips_at_b.len(), 1, "Tips at B should have 1 entry");
@@ -366,7 +415,11 @@ async fn test_get_store_tips_up_to_entries_linear_chain() {
 
     // Query tips up to {C} - should return C as the tip
     let tips_at_c = backend
-        .get_store_tips_up_to_entries(&root_id, subtree, std::slice::from_ref(&id_c))
+        .store_snapshot_at(
+            &root_id,
+            subtree,
+            &Snapshot::from(std::slice::from_ref(&id_c).to_vec()),
+        )
         .await
         .unwrap();
     assert_eq!(tips_at_c.len(), 1, "Tips at C should have 1 entry");
@@ -374,7 +427,11 @@ async fn test_get_store_tips_up_to_entries_linear_chain() {
 
     // Query tips up to {root} - should return root as the tip
     let tips_at_root = backend
-        .get_store_tips_up_to_entries(&root_id, subtree, std::slice::from_ref(&root_id))
+        .store_snapshot_at(
+            &root_id,
+            subtree,
+            &Snapshot::from(std::slice::from_ref(&root_id).to_vec()),
+        )
         .await
         .unwrap();
     assert_eq!(tips_at_root.len(), 1, "Tips at root should have 1 entry");
@@ -382,7 +439,11 @@ async fn test_get_store_tips_up_to_entries_linear_chain() {
 
     // Query tips up to {A, B} - should return B (A is ancestor of B)
     let tips_at_ab = backend
-        .get_store_tips_up_to_entries(&root_id, subtree, &[id_a.clone(), id_b.clone()])
+        .store_snapshot_at(
+            &root_id,
+            subtree,
+            &Snapshot::from(&[id_a.clone(), id_b.clone()].to_vec()),
+        )
         .await
         .unwrap();
     assert_eq!(tips_at_ab.len(), 1, "Tips at {{A, B}} should have 1 entry");
@@ -444,7 +505,11 @@ async fn test_get_store_tips_up_to_entries_diamond_pattern() {
     backend.put_verified(entry_c).await.unwrap();
 
     // Verify current tips (fast path) - should be C
-    let current_tips = backend.get_store_tips(&root_id, subtree).await.unwrap();
+    let current_tips = backend
+        .store_snapshot(&root_id, subtree)
+        .await
+        .unwrap()
+        .into_tips();
     assert_eq!(current_tips.len(), 1);
     assert_eq!(current_tips[0], id_c);
 
@@ -452,7 +517,11 @@ async fn test_get_store_tips_up_to_entries_diamond_pattern() {
 
     // Query tips up to {A} - should return A
     let tips_at_a = backend
-        .get_store_tips_up_to_entries(&root_id, subtree, std::slice::from_ref(&id_a))
+        .store_snapshot_at(
+            &root_id,
+            subtree,
+            &Snapshot::from(std::slice::from_ref(&id_a).to_vec()),
+        )
         .await
         .unwrap();
     assert_eq!(tips_at_a.len(), 1);
@@ -460,7 +529,11 @@ async fn test_get_store_tips_up_to_entries_diamond_pattern() {
 
     // Query tips up to {B} - should return B
     let tips_at_b = backend
-        .get_store_tips_up_to_entries(&root_id, subtree, std::slice::from_ref(&id_b))
+        .store_snapshot_at(
+            &root_id,
+            subtree,
+            &Snapshot::from(std::slice::from_ref(&id_b).to_vec()),
+        )
         .await
         .unwrap();
     assert_eq!(tips_at_b.len(), 1);
@@ -468,7 +541,11 @@ async fn test_get_store_tips_up_to_entries_diamond_pattern() {
 
     // Query tips up to {A, B} - should return BOTH A and B (neither is ancestor of the other)
     let tips_at_ab = backend
-        .get_store_tips_up_to_entries(&root_id, subtree, &[id_a.clone(), id_b.clone()])
+        .store_snapshot_at(
+            &root_id,
+            subtree,
+            &Snapshot::from(&[id_a.clone(), id_b.clone()].to_vec()),
+        )
         .await
         .unwrap();
     let tips_set: HashSet<_> = tips_at_ab.iter().collect();
@@ -488,7 +565,11 @@ async fn test_get_store_tips_up_to_entries_diamond_pattern() {
 
     // Query tips up to {root} - should return root
     let tips_at_root = backend
-        .get_store_tips_up_to_entries(&root_id, subtree, std::slice::from_ref(&root_id))
+        .store_snapshot_at(
+            &root_id,
+            subtree,
+            &Snapshot::from(std::slice::from_ref(&root_id).to_vec()),
+        )
         .await
         .unwrap();
     assert_eq!(tips_at_root.len(), 1);
@@ -563,7 +644,7 @@ async fn test_get_store_tips_up_to_entries_multiple_subtrees() {
     backend.put_verified(entry_d).await.unwrap();
 
     // Current tree tips are C and D (parallel branches)
-    let tree_tips = backend.get_tips(&root_id).await.unwrap();
+    let tree_tips = backend.snapshot(&root_id).await.unwrap().into_tips();
     let tree_tips_set: HashSet<_> = tree_tips.iter().collect();
     assert_eq!(tree_tips.len(), 2);
     assert!(tree_tips_set.contains(&id_c));
@@ -573,7 +654,11 @@ async fn test_get_store_tips_up_to_entries_multiple_subtrees() {
 
     // Query sub1 tips up to {A} - should return A
     let sub1_tips_at_a = backend
-        .get_store_tips_up_to_entries(&root_id, "sub1", std::slice::from_ref(&id_a))
+        .store_snapshot_at(
+            &root_id,
+            "sub1",
+            &Snapshot::from(std::slice::from_ref(&id_a).to_vec()),
+        )
         .await
         .unwrap();
     assert_eq!(sub1_tips_at_a.len(), 1);
@@ -581,7 +666,11 @@ async fn test_get_store_tips_up_to_entries_multiple_subtrees() {
 
     // Query sub1 tips up to {C} - should return C
     let sub1_tips_at_c = backend
-        .get_store_tips_up_to_entries(&root_id, "sub1", std::slice::from_ref(&id_c))
+        .store_snapshot_at(
+            &root_id,
+            "sub1",
+            &Snapshot::from(std::slice::from_ref(&id_c).to_vec()),
+        )
         .await
         .unwrap();
     assert_eq!(sub1_tips_at_c.len(), 1);
@@ -589,7 +678,11 @@ async fn test_get_store_tips_up_to_entries_multiple_subtrees() {
 
     // Query sub1 tips up to {B} - B is not in sub1, so only root is reachable
     let sub1_tips_at_b = backend
-        .get_store_tips_up_to_entries(&root_id, "sub1", std::slice::from_ref(&id_b))
+        .store_snapshot_at(
+            &root_id,
+            "sub1",
+            &Snapshot::from(std::slice::from_ref(&id_b).to_vec()),
+        )
         .await
         .unwrap();
     assert_eq!(
@@ -603,7 +696,11 @@ async fn test_get_store_tips_up_to_entries_multiple_subtrees() {
 
     // Query sub2 tips up to {B} - should return B
     let sub2_tips_at_b = backend
-        .get_store_tips_up_to_entries(&root_id, "sub2", std::slice::from_ref(&id_b))
+        .store_snapshot_at(
+            &root_id,
+            "sub2",
+            &Snapshot::from(std::slice::from_ref(&id_b).to_vec()),
+        )
         .await
         .unwrap();
     assert_eq!(sub2_tips_at_b.len(), 1);
@@ -611,7 +708,11 @@ async fn test_get_store_tips_up_to_entries_multiple_subtrees() {
 
     // Query sub2 tips up to {D} - should return D
     let sub2_tips_at_d = backend
-        .get_store_tips_up_to_entries(&root_id, "sub2", std::slice::from_ref(&id_d))
+        .store_snapshot_at(
+            &root_id,
+            "sub2",
+            &Snapshot::from(std::slice::from_ref(&id_d).to_vec()),
+        )
         .await
         .unwrap();
     assert_eq!(sub2_tips_at_d.len(), 1);
@@ -619,7 +720,11 @@ async fn test_get_store_tips_up_to_entries_multiple_subtrees() {
 
     // Query sub2 tips up to {A} - A is not in sub2, so only root is reachable
     let sub2_tips_at_a = backend
-        .get_store_tips_up_to_entries(&root_id, "sub2", std::slice::from_ref(&id_a))
+        .store_snapshot_at(
+            &root_id,
+            "sub2",
+            &Snapshot::from(std::slice::from_ref(&id_a).to_vec()),
+        )
         .await
         .unwrap();
     assert_eq!(
@@ -632,7 +737,11 @@ async fn test_get_store_tips_up_to_entries_multiple_subtrees() {
     // Query sub1 tips up to {C, D} (both current tree tips)
     // Only C is in sub1, D is not, so tip should be C
     let sub1_tips_at_cd = backend
-        .get_store_tips_up_to_entries(&root_id, "sub1", &[id_c.clone(), id_d.clone()])
+        .store_snapshot_at(
+            &root_id,
+            "sub1",
+            &Snapshot::from(&[id_c.clone(), id_d.clone()].to_vec()),
+        )
         .await
         .unwrap();
     assert_eq!(sub1_tips_at_cd.len(), 1);
@@ -672,7 +781,7 @@ async fn test_get_store_tips_up_to_entries_edge_cases() {
 
     // --- Edge case: empty main_entries ---
     let tips_empty = backend
-        .get_store_tips_up_to_entries(&root_id, subtree, &[])
+        .store_snapshot_at(&root_id, subtree, &Snapshot::from(&[].to_vec()))
         .await
         .unwrap();
     assert!(
@@ -684,7 +793,7 @@ async fn test_get_store_tips_up_to_entries_edge_cases() {
     // Backends may either return an error or an empty result for non-existent entries
     let fake_id: ID = ID::from_bytes("nonexistent_entry_12345");
     let result = backend
-        .get_store_tips_up_to_entries(&root_id, subtree, &[fake_id])
+        .store_snapshot_at(&root_id, subtree, &Snapshot::from(&[fake_id].to_vec()))
         .await;
     match result {
         Err(_) => {} // InMemory backend returns error
@@ -696,7 +805,11 @@ async fn test_get_store_tips_up_to_entries_edge_cases() {
 
     // --- Edge case: non-existent subtree name returns empty ---
     let tips_bad_subtree = backend
-        .get_store_tips_up_to_entries(&root_id, "nonexistent_subtree", std::slice::from_ref(&id_a))
+        .store_snapshot_at(
+            &root_id,
+            "nonexistent_subtree",
+            &Snapshot::from(std::slice::from_ref(&id_a).to_vec()),
+        )
         .await
         .unwrap();
     assert!(
@@ -826,7 +939,11 @@ async fn test_get_store_tips_up_to_entries_complex_dag() {
     backend.put_verified(entry_i).await.unwrap();
 
     // Current tips should be H and I
-    let current_tips = backend.get_store_tips(&root_id, subtree).await.unwrap();
+    let current_tips = backend
+        .store_snapshot(&root_id, subtree)
+        .await
+        .unwrap()
+        .into_tips();
     let current_tips_set: HashSet<_> = current_tips.iter().collect();
     assert_eq!(current_tips.len(), 2);
     assert!(current_tips_set.contains(&id_h));
@@ -836,10 +953,10 @@ async fn test_get_store_tips_up_to_entries_complex_dag() {
 
     // Query tips up to {A, B, C} - should return A, B, C
     let tips_abc = backend
-        .get_store_tips_up_to_entries(
+        .store_snapshot_at(
             &root_id,
             subtree,
-            &[id_a.clone(), id_b.clone(), id_c.clone()],
+            &Snapshot::from([id_a.clone(), id_b.clone(), id_c.clone()]),
         )
         .await
         .unwrap();
@@ -855,10 +972,10 @@ async fn test_get_store_tips_up_to_entries_complex_dag() {
 
     // Query tips up to {D, E, F, G} - all four should be tips
     let tips_defg = backend
-        .get_store_tips_up_to_entries(
+        .store_snapshot_at(
             &root_id,
             subtree,
-            &[id_d.clone(), id_e.clone(), id_f.clone(), id_g.clone()],
+            &Snapshot::from([id_d.clone(), id_e.clone(), id_f.clone(), id_g.clone()]),
         )
         .await
         .unwrap();
@@ -875,7 +992,11 @@ async fn test_get_store_tips_up_to_entries_complex_dag() {
 
     // Query tips up to {A, D} - A is ancestor of D, so only D is tip
     let tips_ad = backend
-        .get_store_tips_up_to_entries(&root_id, subtree, &[id_a.clone(), id_d.clone()])
+        .store_snapshot_at(
+            &root_id,
+            subtree,
+            &Snapshot::from(&[id_a.clone(), id_d.clone()].to_vec()),
+        )
         .await
         .unwrap();
     assert_eq!(tips_ad.len(), 1, "Tips at {{A, D}} should have 1 entry");
@@ -883,7 +1004,11 @@ async fn test_get_store_tips_up_to_entries_complex_dag() {
 
     // Query tips up to {E} - should return E only
     let tips_e = backend
-        .get_store_tips_up_to_entries(&root_id, subtree, std::slice::from_ref(&id_e))
+        .store_snapshot_at(
+            &root_id,
+            subtree,
+            &Snapshot::from(std::slice::from_ref(&id_e).to_vec()),
+        )
         .await
         .unwrap();
     assert_eq!(tips_e.len(), 1);
@@ -891,7 +1016,11 @@ async fn test_get_store_tips_up_to_entries_complex_dag() {
 
     // Query tips up to {D, E} - both D and E are tips (neither is ancestor of the other)
     let tips_de = backend
-        .get_store_tips_up_to_entries(&root_id, subtree, &[id_d.clone(), id_e.clone()])
+        .store_snapshot_at(
+            &root_id,
+            subtree,
+            &Snapshot::from(&[id_d.clone(), id_e.clone()].to_vec()),
+        )
         .await
         .unwrap();
     let tips_de_set: HashSet<_> = tips_de.iter().collect();
@@ -901,7 +1030,11 @@ async fn test_get_store_tips_up_to_entries_complex_dag() {
 
     // Query tips up to {H} - should return H only
     let tips_h = backend
-        .get_store_tips_up_to_entries(&root_id, subtree, std::slice::from_ref(&id_h))
+        .store_snapshot_at(
+            &root_id,
+            subtree,
+            &Snapshot::from(std::slice::from_ref(&id_h).to_vec()),
+        )
         .await
         .unwrap();
     assert_eq!(tips_h.len(), 1);
@@ -909,10 +1042,10 @@ async fn test_get_store_tips_up_to_entries_complex_dag() {
 
     // Query tips up to {D, E, H} - D and E are ancestors of H, so only H is tip
     let tips_deh = backend
-        .get_store_tips_up_to_entries(
+        .store_snapshot_at(
             &root_id,
             subtree,
-            &[id_d.clone(), id_e.clone(), id_h.clone()],
+            &Snapshot::from([id_d.clone(), id_e.clone(), id_h.clone()]),
         )
         .await
         .unwrap();
@@ -921,7 +1054,11 @@ async fn test_get_store_tips_up_to_entries_complex_dag() {
 
     // Query tips up to {H, I} (current tips)
     let tips_hi = backend
-        .get_store_tips_up_to_entries(&root_id, subtree, &[id_h.clone(), id_i.clone()])
+        .store_snapshot_at(
+            &root_id,
+            subtree,
+            &Snapshot::from(&[id_h.clone(), id_i.clone()].to_vec()),
+        )
         .await
         .unwrap();
     let tips_hi_set: HashSet<_> = tips_hi.iter().collect();

--- a/crates/lib/tests/it/backend/tree_operations.rs
+++ b/crates/lib/tests/it/backend/tree_operations.rs
@@ -214,7 +214,7 @@ async fn test_get_tips() {
     backend.put_verified(root.clone()).await.unwrap();
 
     // Initially, root is the only tip
-    let tips = backend.get_tips(&root_id).await.unwrap();
+    let tips = backend.snapshot(&root_id).await.unwrap().into_tips();
     assert_eq!(tips.len(), 1);
     assert_eq!(tips[0], root_id);
 
@@ -228,7 +228,7 @@ async fn test_get_tips() {
     backend.put_verified(entry_a.clone()).await.unwrap();
 
     // Now A should be the only tip
-    let tips = backend.get_tips(&root_id).await.unwrap();
+    let tips = backend.snapshot(&root_id).await.unwrap().into_tips();
     assert_eq!(tips.len(), 1);
     assert_eq!(tips[0], id_a);
 
@@ -242,7 +242,7 @@ async fn test_get_tips() {
     backend.put_verified(entry_b.clone()).await.unwrap();
 
     // Now B should be the only tip from that branch
-    let tips = backend.get_tips(&root_id).await.unwrap();
+    let tips = backend.snapshot(&root_id).await.unwrap().into_tips();
     assert_eq!(tips.len(), 1);
     assert_eq!(tips[0], id_b);
 
@@ -256,7 +256,7 @@ async fn test_get_tips() {
     backend.put_verified(entry_c.clone()).await.unwrap();
 
     // Now should have 2 tips: B and C
-    let tips = backend.get_tips(&root_id).await.unwrap();
+    let tips = backend.snapshot(&root_id).await.unwrap().into_tips();
     assert_eq!(tips.len(), 2);
     assert!(tips.contains(&id_b));
     assert!(tips.contains(&id_c));

--- a/crates/lib/tests/it/database/api_methods.rs
+++ b/crates/lib/tests/it/database/api_methods.rs
@@ -4,7 +4,7 @@
 //! authentication, validation, and error handling.
 
 use eidetica::{
-    Database, Instance,
+    Database, Instance, Snapshot,
     auth::{
         crypto::generate_keypair,
         types::{AuthKey, KeyStatus, Permission, SigKey},
@@ -520,7 +520,7 @@ async fn test_database_verify_promotes_unverified_and_access_hook() {
         .update_verification_status(&id, VerificationStatus::Unverified)
         .await
         .unwrap();
-    let tips = tree.get_tips().await.unwrap();
+    let tips = tree.snapshot().await.unwrap().into_tips();
     assert!(!tips.is_empty(), "the verified tip must remain visible");
     assert_eq!(
         backend.get_verification_status(&id).await.unwrap(),
@@ -559,18 +559,24 @@ async fn test_verified_frontier_prefix_cut_and_allow_unverified() {
 
     // Default view: `b` is not in the Verified prefix, so neither is its
     // descendant `c` (ancestor-closed). The frontier falls back to `a`.
-    let tips = tree.get_tips().await.unwrap();
+    let tips = tree.snapshot().await.unwrap().into_tips();
     assert_eq!(tips, vec![a.clone()], "frontier must cut back to `a`");
     assert!(!tips.contains(&b) && !tips.contains(&c));
 
     // allow_unverified view: raw tip `c` is visible (only `Failed` `b` is
     // dropped from the set; `c` itself is still a Verified tip).
-    let loose_tips = tree.clone().allow_unverified().get_tips().await.unwrap();
+    let loose_tips = tree
+        .clone()
+        .allow_unverified()
+        .snapshot()
+        .await
+        .unwrap()
+        .into_tips();
     assert_eq!(loose_tips, vec![c.clone()], "loose view keeps raw tip `c`");
 
     // The setting is per-handle and composes with the original handle being
     // unchanged.
-    assert_eq!(tree.get_tips().await.unwrap(), vec![a]);
+    assert_eq!(tree.snapshot().await.unwrap().into_tips(), vec![a]);
 }
 
 /// Verification is prefix-closed: it must be impossible for an entry to be
@@ -680,7 +686,7 @@ async fn test_cross_instance_sync_then_verify_cascade() {
         );
     }
     // The tip is now visible in the default (Verified-frontier) view on B.
-    assert_eq!(db_b.get_tips().await.unwrap(), vec![c]);
+    assert_eq!(db_b.snapshot().await.unwrap().into_tips(), vec![c]);
 }
 
 /// An entry whose pinned `_settings` ancestor set is not fully held locally
@@ -701,7 +707,7 @@ async fn test_incomplete_pinned_settings_stays_unverified_then_recovers() {
         AuthKey::active(Some("k2"), Permission::Write(10)),
     )
     .await;
-    let s = tree_a.get_tips().await.unwrap()[0].clone();
+    let s = tree_a.snapshot().await.unwrap().into_tips()[0].clone();
     let d = add_data_to_subtree(&tree_a, "data", &[("k", "v")]).await;
 
     // Sync everything to B *except* the settings entry `s`. `get_tree` is a
@@ -755,7 +761,7 @@ async fn test_diamond_dag_taint_propagation() {
     // Merge a and b into c.
     let c = {
         let txn = tree
-            .new_transaction_with_tips(&[a.clone(), b.clone()])
+            .new_transaction_at(&Snapshot::from(&[a.clone(), b.clone()]))
             .await
             .unwrap();
         txn.get_store::<DocStore>("data")
@@ -797,11 +803,11 @@ async fn test_diamond_dag_taint_propagation() {
 
     // Frontier cuts to the surviving verified branch `b`; the loose view
     // still drops Failed `c`, leaving nothing (c is the only raw tip).
-    assert_eq!(tree.get_tips().await.unwrap(), vec![b]);
+    assert_eq!(tree.snapshot().await.unwrap().into_tips(), vec![b]);
     assert!(
         tree.clone()
             .allow_unverified()
-            .get_tips()
+            .snapshot()
             .await
             .unwrap()
             .is_empty(),
@@ -827,7 +833,7 @@ async fn test_allow_unverified_composes_with_key_for_writes() {
         .update_verification_status(&a, VerificationStatus::Failed)
         .await
         .unwrap();
-    let default_tips = tree.get_tips().await.unwrap();
+    let default_tips = tree.snapshot().await.unwrap().into_tips();
     assert!(
         !default_tips.contains(&b),
         "default view must not expose state behind a Failed ancestor"
@@ -836,7 +842,7 @@ async fn test_allow_unverified_composes_with_key_for_writes() {
     // The loose handle keeps the signing key (set via `..self`) and sees the
     // raw tip `b`, so it can commit on top of it.
     let loose = tree.clone().allow_unverified();
-    assert_eq!(loose.get_tips().await.unwrap(), vec![b.clone()]);
+    assert_eq!(loose.snapshot().await.unwrap().into_tips(), vec![b.clone()]);
     let e = add_data_to_subtree(&loose, "data", &[("s", "e")]).await;
 
     // The new entry was locally validated → Verified, and built on `b`.
@@ -850,8 +856,8 @@ async fn test_allow_unverified_composes_with_key_for_writes() {
     );
     // Loose view advances to `e`; the default frontier is still cut (the new
     // entry sits behind the Failed `a`, so it remains hidden by default).
-    assert_eq!(loose.get_tips().await.unwrap(), vec![e.clone()]);
-    assert!(!tree.get_tips().await.unwrap().contains(&e));
+    assert_eq!(loose.snapshot().await.unwrap().into_tips(), vec![e.clone()]);
+    assert!(!tree.snapshot().await.unwrap().into_tips().contains(&e));
 }
 
 /// The access-time auto-verify hook in `get_tips` must handle *multiple*
@@ -878,7 +884,7 @@ async fn test_access_hook_promotes_multiple_unverified_tips() {
 
     // A plain default read: the hook fires because tips are Unverified and
     // must promote *both* diverged tips.
-    let tips = tree.get_tips().await.unwrap();
+    let tips = tree.snapshot().await.unwrap().into_tips();
     assert_eq!(
         tips.len(),
         2,
@@ -1098,7 +1104,7 @@ async fn test_deep_chain_frontier_cut() {
         .await
         .unwrap();
 
-    let tips = tree.get_tips().await.unwrap();
+    let tips = tree.snapshot().await.unwrap().into_tips();
     assert_eq!(
         tips,
         vec![chain[failed_idx - 1].clone()],
@@ -1107,7 +1113,12 @@ async fn test_deep_chain_frontier_cut() {
     // The loose view keeps the raw tip (#29) — only Failed is dropped, and
     // #29 itself is Verified.
     assert_eq!(
-        tree.clone().allow_unverified().get_tips().await.unwrap(),
+        tree.clone()
+            .allow_unverified()
+            .snapshot()
+            .await
+            .unwrap()
+            .into_tips(),
         vec![chain[29].clone()]
     );
 }

--- a/crates/lib/tests/it/database/core_operations.rs
+++ b/crates/lib/tests/it/database/core_operations.rs
@@ -3,7 +3,7 @@
 //! This module contains tests for fundamental Tree operations including
 //! entry creation, subtree operations, atomic operations, and tip management.
 
-use eidetica::{constants::SETTINGS, store::DocStore, store::Table};
+use eidetica::{Snapshot, constants::SETTINGS, store::DocStore, store::Table};
 use serde::{Deserialize, Serialize};
 
 use super::helpers::*;
@@ -33,7 +33,11 @@ async fn test_insert_into_tree() {
     let id2 = txn2.commit().await.expect("Failed to commit transaction");
 
     // Verify tips include id2
-    let tips = tree.get_tips().await.expect("Failed to get tips");
+    let tips = tree
+        .snapshot()
+        .await
+        .expect("Failed to get tips")
+        .into_tips();
     assert!(tips.contains(&id2));
     assert!(!tips.contains(&id1)); // id1 should no longer be a tip
 
@@ -216,7 +220,7 @@ async fn test_txn_scenarios() {
 
     // --- 1. Modify multiple subtrees in one transaction and read staged data ---
     let txn1 = tree.new_transaction().await.expect("Txn1: Failed to start");
-    let initial_tip = tree.get_tips().await.unwrap()[0].clone();
+    let initial_tip = tree.snapshot().await.unwrap().into_tips()[0].clone();
     {
         let store_a = txn1
             .get_store::<DocStore>("sub_a")
@@ -289,7 +293,7 @@ async fn test_txn_scenarios() {
     // If it's not an error, check the tip is still changed to the empty commit
     assert!(commit_empty_result.is_ok());
     assert_eq!(
-        tree.get_tips().await.unwrap()[0],
+        tree.snapshot().await.unwrap().into_tips()[0],
         commit_empty_result.unwrap(),
         "Empty commit should still be a tip"
     );
@@ -418,7 +422,11 @@ async fn test_get_tips() {
     let (_instance, tree) = setup_tree().await;
 
     // Initially, the tree should have one tip (the root entry)
-    let initial_tips = tree.get_tips().await.expect("Failed to get initial tips");
+    let initial_tips = tree
+        .snapshot()
+        .await
+        .expect("Failed to get initial tips")
+        .into_tips();
     assert_eq!(
         initial_tips.len(),
         1,
@@ -429,7 +437,11 @@ async fn test_get_tips() {
     let entry1_id = add_data_to_subtree(&tree, "data", &[("key1", "value1")]).await;
 
     // Tips should now include entry1_id
-    let tips_after_op1 = tree.get_tips().await.expect("Failed to get tips after op1");
+    let tips_after_op1 = tree
+        .snapshot()
+        .await
+        .expect("Failed to get tips after op1")
+        .into_tips();
     assert_eq!(
         tips_after_op1.len(),
         1,
@@ -448,7 +460,11 @@ async fn test_get_tips() {
     let entry2_id = add_data_to_subtree(&tree, "data", &[("key2", "value2")]).await;
 
     // Tips should now include entry2_id
-    let tips_after_op2 = tree.get_tips().await.expect("Failed to get tips after op2");
+    let tips_after_op2 = tree
+        .snapshot()
+        .await
+        .expect("Failed to get tips after op2")
+        .into_tips();
     assert_eq!(
         tips_after_op2.len(),
         1,
@@ -498,7 +514,7 @@ async fn test_new_transaction_with_tips() {
 
     // Create operation with custom tips (using entry1 instead of current tip)
     let custom_op = tree
-        .new_transaction_with_tips([entry1_id.clone()])
+        .new_transaction_at(&Snapshot::from([entry1_id.clone()]))
         .await
         .expect("Failed to create custom operation");
     let custom_store = custom_op
@@ -525,7 +541,7 @@ async fn test_new_transaction_with_tips() {
 
     // Now we should have two tips: entry2_id and custom_entry_id
     let tips_after_branch = tree
-        .get_tips()
+        .snapshot()
         .await
         .expect("Failed to get tips after branch");
     assert_eq!(
@@ -576,7 +592,7 @@ async fn test_new_transaction_with_specific_tips() {
 
     // Create operation starting from entry A (should see only A)
     let op_from_a = tree
-        .new_transaction_with_tips(std::slice::from_ref(&entry_a_id))
+        .new_transaction_at(&Snapshot::from(std::slice::from_ref(&entry_a_id)))
         .await
         .expect("Failed to create op from A");
     let store_from_a = op_from_a
@@ -603,7 +619,7 @@ async fn test_new_transaction_with_specific_tips() {
 
     // Create operation starting from entry B (should see A and B but not C)
     let op_from_b = tree
-        .new_transaction_with_tips([entry_b_id])
+        .new_transaction_at(&Snapshot::from([entry_b_id]))
         .await
         .expect("Failed to create op from B");
     let store_from_b = op_from_b
@@ -630,7 +646,7 @@ async fn test_new_transaction_with_specific_tips() {
 
     // Create operation starting from entry C (should see all)
     let op_from_c = tree
-        .new_transaction_with_tips([entry_c_id])
+        .new_transaction_at(&Snapshot::from([entry_c_id]))
         .await
         .expect("Failed to create op from C");
     let store_from_c = op_from_c
@@ -666,7 +682,7 @@ async fn test_new_transaction_with_specific_tips() {
 
     // Verify the branch only sees data from A
     let op_verify_branch = tree
-        .new_transaction_with_tips([branch_id])
+        .new_transaction_at(&Snapshot::from([branch_id]))
         .await
         .expect("Failed to create verify op");
     let store_verify_branch = op_verify_branch
@@ -713,7 +729,7 @@ async fn test_new_transaction_with_multiple_tips() {
     // Create operation with multiple tips (merge operation)
     let merge_tips = vec![branch1_id.clone(), branch2_id.clone()];
     let op_merge = tree
-        .new_transaction_with_tips(&merge_tips)
+        .new_transaction_at(&Snapshot::from(&merge_tips))
         .await
         .expect("Failed to create merge operation");
     let store_merge = op_merge

--- a/crates/lib/tests/it/database/helpers.rs
+++ b/crates/lib/tests/it/database/helpers.rs
@@ -4,7 +4,7 @@
 //! core operations, API methods, merging algorithms, and settings management.
 
 use eidetica::{
-    Database, Instance,
+    Database, Instance, Snapshot,
     auth::crypto::PublicKey,
     crdt::{Doc, doc::Value},
     entry::ID,
@@ -63,7 +63,7 @@ pub async fn create_branch_from_entry(
     data: &[(&str, &str)],
 ) -> ID {
     let txn = tree
-        .new_transaction_with_tips(std::slice::from_ref(entry_id))
+        .new_transaction_at(&Snapshot::from(std::slice::from_ref(entry_id)))
         .await
         .expect("Failed to create branch operation");
     {
@@ -173,9 +173,9 @@ pub async fn create_diamond_pattern(
     .await;
 
     // Create merge entry (D) from both branches
-    let merge_tips = vec![branch_b_id.clone(), branch_c_id.clone()];
+    let merge_snapshot = Snapshot::from(vec![branch_b_id.clone(), branch_c_id.clone()]);
     let txn = tree
-        .new_transaction_with_tips(&merge_tips)
+        .new_transaction_at(&merge_snapshot)
         .await
         .expect("Failed to create merge operation");
     {

--- a/crates/lib/tests/it/database/merge_algorithms.rs
+++ b/crates/lib/tests/it/database/merge_algorithms.rs
@@ -3,7 +3,7 @@
 //! This module contains tests for complex merging scenarios including
 //! LCA computation, diamond patterns, and parent-aware state resolution.
 
-use eidetica::{crdt::doc::Value, store::DocStore};
+use eidetica::{Snapshot, crdt::doc::Value, store::DocStore};
 
 use super::helpers::*;
 use crate::helpers::*;
@@ -398,7 +398,7 @@ async fn test_true_diamond_pattern() {
     let entry_a_id = op_a.commit().await.unwrap();
 
     // Verify A is now the only tip
-    let tips_after_a = tree.get_tips().await.unwrap();
+    let tips_after_a = tree.snapshot().await.unwrap().into_tips();
     assert_eq!(tips_after_a.len(), 1, "Should have exactly 1 tip after A");
     assert_eq!(tips_after_a[0], entry_a_id, "A should be the only tip");
 
@@ -407,7 +407,7 @@ async fn test_true_diamond_pattern() {
 
     // Create operation B - starts from A
     let op_b = tree
-        .new_transaction_with_tips(std::slice::from_ref(&entry_a_id))
+        .new_transaction_at(&Snapshot::from(std::slice::from_ref(&entry_a_id)))
         .await
         .unwrap();
     let subtree_b = op_b.get_store::<DocStore>("data").await.unwrap();
@@ -417,7 +417,7 @@ async fn test_true_diamond_pattern() {
 
     // Create operation C - also starts from A (same parent!)
     let op_c = tree
-        .new_transaction_with_tips(std::slice::from_ref(&entry_a_id))
+        .new_transaction_at(&Snapshot::from(std::slice::from_ref(&entry_a_id)))
         .await
         .unwrap();
     let subtree_c = op_c.get_store::<DocStore>("data").await.unwrap();
@@ -430,7 +430,7 @@ async fn test_true_diamond_pattern() {
     let entry_c_id = op_c.commit().await.unwrap();
 
     // Verify we now have a true diamond: both B and C should be tips with A as parent
-    let tips_after_fork = tree.get_tips().await.unwrap();
+    let tips_after_fork = tree.snapshot().await.unwrap().into_tips();
     assert_eq!(
         tips_after_fork.len(),
         2,
@@ -699,7 +699,7 @@ async fn test_find_merge_base_shallow_divergence() {
     let mut chain_a_tip = base_id.clone();
     for i in 0..CHAIN_DEPTH {
         let txn = tree
-            .new_transaction_with_tips(std::slice::from_ref(&chain_a_tip))
+            .new_transaction_at(&Snapshot::from(std::slice::from_ref(&chain_a_tip)))
             .await
             .unwrap();
         let subtree = txn.get_store::<DocStore>("data").await.unwrap();
@@ -711,7 +711,7 @@ async fn test_find_merge_base_shallow_divergence() {
     let mut chain_b_tip = base_id.clone();
     for i in 0..CHAIN_DEPTH {
         let txn = tree
-            .new_transaction_with_tips(std::slice::from_ref(&chain_b_tip))
+            .new_transaction_at(&Snapshot::from(std::slice::from_ref(&chain_b_tip)))
             .await
             .unwrap();
         let subtree = txn.get_store::<DocStore>("data").await.unwrap();
@@ -721,7 +721,10 @@ async fn test_find_merge_base_shallow_divergence() {
 
     // Create merge operation from both tips
     let merge_tips = vec![chain_a_tip.clone(), chain_b_tip.clone()];
-    let op_merge = tree.new_transaction_with_tips(&merge_tips).await.unwrap();
+    let op_merge = tree
+        .new_transaction_at(&Snapshot::from(&merge_tips))
+        .await
+        .unwrap();
     let subtree_merge = op_merge.get_store::<DocStore>("data").await.unwrap();
     subtree_merge.set("merged", "true").await.unwrap();
     let _merge_id = op_merge.commit().await.unwrap();
@@ -778,7 +781,7 @@ async fn test_find_merge_base_deep_divergence() {
     let mut chain_a_tip = base_id.clone();
     for i in 0..CHAIN_DEPTH {
         let txn = tree
-            .new_transaction_with_tips(std::slice::from_ref(&chain_a_tip))
+            .new_transaction_at(&Snapshot::from(std::slice::from_ref(&chain_a_tip)))
             .await
             .unwrap();
         let subtree = txn.get_store::<DocStore>("data").await.unwrap();
@@ -790,7 +793,7 @@ async fn test_find_merge_base_deep_divergence() {
     let mut chain_b_tip = base_id.clone();
     for i in 0..CHAIN_DEPTH {
         let txn = tree
-            .new_transaction_with_tips(std::slice::from_ref(&chain_b_tip))
+            .new_transaction_at(&Snapshot::from(std::slice::from_ref(&chain_b_tip)))
             .await
             .unwrap();
         let subtree = txn.get_store::<DocStore>("data").await.unwrap();
@@ -800,7 +803,10 @@ async fn test_find_merge_base_deep_divergence() {
 
     // Create merge operation from both tips
     let merge_tips = vec![chain_a_tip.clone(), chain_b_tip.clone()];
-    let op_merge = tree.new_transaction_with_tips(&merge_tips).await.unwrap();
+    let op_merge = tree
+        .new_transaction_at(&Snapshot::from(&merge_tips))
+        .await
+        .unwrap();
     let subtree_merge = op_merge.get_store::<DocStore>("data").await.unwrap();
     subtree_merge.set("deep_merged", "true").await.unwrap();
     let _merge_id = op_merge.commit().await.unwrap();
@@ -857,7 +863,7 @@ async fn test_find_merge_base_very_deep_chains() {
     let mut chain_a_tip = base_id.clone();
     for i in 0..CHAIN_DEPTH {
         let txn = tree
-            .new_transaction_with_tips(std::slice::from_ref(&chain_a_tip))
+            .new_transaction_at(&Snapshot::from(std::slice::from_ref(&chain_a_tip)))
             .await
             .unwrap();
         let subtree = txn.get_store::<DocStore>("data").await.unwrap();
@@ -869,7 +875,7 @@ async fn test_find_merge_base_very_deep_chains() {
     let mut chain_b_tip = base_id.clone();
     for i in 0..CHAIN_DEPTH {
         let txn = tree
-            .new_transaction_with_tips(std::slice::from_ref(&chain_b_tip))
+            .new_transaction_at(&Snapshot::from(std::slice::from_ref(&chain_b_tip)))
             .await
             .unwrap();
         let subtree = txn.get_store::<DocStore>("data").await.unwrap();
@@ -879,7 +885,10 @@ async fn test_find_merge_base_very_deep_chains() {
 
     // Create merge operation from both tips
     let merge_tips = vec![chain_a_tip.clone(), chain_b_tip.clone()];
-    let op_merge = tree.new_transaction_with_tips(&merge_tips).await.unwrap();
+    let op_merge = tree
+        .new_transaction_at(&Snapshot::from(&merge_tips))
+        .await
+        .unwrap();
     let subtree_merge = op_merge.get_store::<DocStore>("data").await.unwrap();
     subtree_merge.set("very_deep_merged", "true").await.unwrap();
     let _merge_id = op_merge.commit().await.unwrap();
@@ -937,7 +946,7 @@ async fn test_find_merge_base_actually_called() {
     let mut chain_a_tip = base_id.clone();
     for i in 0..CHAIN_DEPTH {
         let txn = tree
-            .new_transaction_with_tips(std::slice::from_ref(&chain_a_tip))
+            .new_transaction_at(&Snapshot::from(std::slice::from_ref(&chain_a_tip)))
             .await
             .unwrap();
         let subtree = txn.get_store::<DocStore>("data").await.unwrap();
@@ -949,7 +958,7 @@ async fn test_find_merge_base_actually_called() {
     let mut chain_b_tip = base_id.clone();
     for i in 0..CHAIN_DEPTH {
         let txn = tree
-            .new_transaction_with_tips(std::slice::from_ref(&chain_b_tip))
+            .new_transaction_at(&Snapshot::from(std::slice::from_ref(&chain_b_tip)))
             .await
             .unwrap();
         let subtree = txn.get_store::<DocStore>("data").await.unwrap();
@@ -959,7 +968,10 @@ async fn test_find_merge_base_actually_called() {
 
     // Create merge transaction with BOTH tips
     let merge_tips = vec![chain_a_tip.clone(), chain_b_tip.clone()];
-    let op_merge = tree.new_transaction_with_tips(&merge_tips).await.unwrap();
+    let op_merge = tree
+        .new_transaction_at(&Snapshot::from(&merge_tips))
+        .await
+        .unwrap();
     let subtree_merge = op_merge.get_store::<DocStore>("data").await.unwrap();
 
     // THIS is the key: read state DURING the merge transaction

--- a/crates/lib/tests/it/database/settings_metadata.rs
+++ b/crates/lib/tests/it/database/settings_metadata.rs
@@ -4,7 +4,7 @@
 //! settings tips tracking, metadata propagation, and historical validation.
 
 use eidetica::{
-    Entry,
+    Entry, Snapshot,
     crdt::{Doc, doc::Value},
     store::DocStore,
 };
@@ -325,7 +325,7 @@ async fn test_settings_metadata_with_branching() {
 
     // Create two branches from base
     let branch1_op = tree
-        .new_transaction_with_tips(std::slice::from_ref(&base_id))
+        .new_transaction_at(&Snapshot::from(std::slice::from_ref(&base_id)))
         .await
         .unwrap();
     let branch1_store = branch1_op.get_store::<DocStore>("data").await.unwrap();
@@ -333,7 +333,7 @@ async fn test_settings_metadata_with_branching() {
     let branch1_id = branch1_op.commit().await.unwrap();
 
     let branch2_op = tree
-        .new_transaction_with_tips(std::slice::from_ref(&base_id))
+        .new_transaction_at(&Snapshot::from(std::slice::from_ref(&base_id)))
         .await
         .unwrap();
     let branch2_store = branch2_op.get_store::<DocStore>("data").await.unwrap();
@@ -342,7 +342,7 @@ async fn test_settings_metadata_with_branching() {
 
     // Update settings on one branch
     let settings_op = tree
-        .new_transaction_with_tips(std::slice::from_ref(&branch1_id))
+        .new_transaction_at(&Snapshot::from(std::slice::from_ref(&branch1_id)))
         .await
         .unwrap();
     let settings_store = settings_op
@@ -357,7 +357,10 @@ async fn test_settings_metadata_with_branching() {
 
     // Create merge operation
     let merge_tips = vec![settings_id.clone(), branch2_id.clone()];
-    let merge_op = tree.new_transaction_with_tips(&merge_tips).await.unwrap();
+    let merge_op = tree
+        .new_transaction_at(&Snapshot::from(&merge_tips))
+        .await
+        .unwrap();
     let merge_store = merge_op.get_store::<DocStore>("data").await.unwrap();
     merge_store.set("merged", "true").await.unwrap();
     let merge_id = merge_op.commit().await.unwrap();

--- a/crates/lib/tests/it/service.rs
+++ b/crates/lib/tests/it/service.rs
@@ -919,7 +919,7 @@ async fn test_submit_cross_session_signed_by_tree_admin_becomes_verified() {
         .await
         .unwrap();
     let bob_root = bob_db.root_id().clone();
-    let initial_tips = bob_db.get_tips().await.unwrap();
+    let initial_tips = bob_db.snapshot().await.unwrap().into_tips();
 
     // The bootstrap admin (NOT bob) connects over the wire. Admin holds
     // Admin on `_users`/`_databases` but is *not* a member of bob's tree.
@@ -994,7 +994,7 @@ async fn test_submit_cross_session_signed_by_tree_admin_becomes_verified() {
         );
 
     // The submitted entry is in bob's Verified frontier.
-    let tips_after = bob_db.get_tips().await.unwrap();
+    let tips_after = bob_db.snapshot().await.unwrap().into_tips();
     assert!(
         tips_after.contains(&entry_id),
         "submitted entry must be a Verified tip; tips={tips_after:?}, entry={entry_id}"
@@ -1024,7 +1024,7 @@ async fn test_submit_unauthorized_signer_stays_invisible_in_default_reads() {
         .await
         .unwrap();
     let bob_root = bob_db.root_id().clone();
-    let initial_tips = bob_db.get_tips().await.unwrap();
+    let initial_tips = bob_db.snapshot().await.unwrap().into_tips();
 
     // Admin connects and signs an entry with the *admin* key, which has no
     // auth on bob's tree.
@@ -1054,7 +1054,7 @@ async fn test_submit_unauthorized_signer_stays_invisible_in_default_reads() {
 
     // Bob's Verified frontier is unchanged: the unauthorized entry never
     // graduated past Unverified/Failed and is excluded from default reads.
-    let tips_after = bob_db.get_tips().await.unwrap();
+    let tips_after = bob_db.snapshot().await.unwrap().into_tips();
     assert!(
         !tips_after.contains(&entry_id),
         "unauthorized-signer entry must NOT appear in Verified frontier; tips={tips_after:?}"

--- a/crates/lib/tests/it/store/helpers.rs
+++ b/crates/lib/tests/it/store/helpers.rs
@@ -6,7 +6,7 @@
 #[cfg(feature = "y-crdt")]
 use eidetica::store::{YDoc, YrsBinary};
 use eidetica::{
-    Database, Registered, Transaction,
+    Database, Registered, Snapshot, Transaction,
     crdt::{
         Doc,
         doc::{List, Value},
@@ -536,7 +536,7 @@ pub async fn test_table_concurrent_modifications(
 
     // Branch A: Concurrent modification
     let op_branch_a = tree
-        .new_transaction_with_tips([base_entry_id.clone()])
+        .new_transaction_at(&Snapshot::from([base_entry_id.clone()]))
         .await
         .unwrap();
     {
@@ -555,7 +555,7 @@ pub async fn test_table_concurrent_modifications(
 
     // Branch B: Parallel modification
     let op_branch_b = tree
-        .new_transaction_with_tips([base_entry_id])
+        .new_transaction_at(&Snapshot::from([base_entry_id]))
         .await
         .unwrap();
     {

--- a/crates/lib/tests/it/store/integration.rs
+++ b/crates/lib/tests/it/store/integration.rs
@@ -3,6 +3,7 @@
 //! This module contains tests for complex integration scenarios including
 //! concurrent modifications, merging, authentication, and cross-subtree operations.
 
+use eidetica::Snapshot;
 use eidetica::store::{DocStore, Table};
 
 use super::helpers::*;
@@ -255,7 +256,7 @@ async fn test_subtree_concurrent_access_patterns() {
     // Branch A: Modify Table data
     let op_branch_a = ctx
         .database()
-        .new_transaction_with_tips([base_entry_id.clone()])
+        .new_transaction_at(&Snapshot::from([base_entry_id.clone()]))
         .await
         .expect("Branch A: Failed to start");
     {
@@ -282,7 +283,7 @@ async fn test_subtree_concurrent_access_patterns() {
     // Branch B: Modify Doc data (parallel to Branch A)
     let op_branch_b = ctx
         .database()
-        .new_transaction_with_tips([base_entry_id])
+        .new_transaction_at(&Snapshot::from([base_entry_id]))
         .await
         .expect("Branch B: Failed to start");
     {

--- a/crates/lib/tests/it/store/table_operations.rs
+++ b/crates/lib/tests/it/store/table_operations.rs
@@ -3,6 +3,7 @@
 //! This module contains tests for Table subtree functionality including
 //! CRUD operations, search functionality, UUID generation, and multiple operations.
 
+use eidetica::Snapshot;
 use eidetica::store::Table;
 
 use super::helpers::*;
@@ -666,7 +667,7 @@ async fn test_table_delete_concurrent_modifications() {
     // Branch A: Delete the record
     let op_branch_a = ctx
         .database()
-        .new_transaction_with_tips([base_entry_id.clone()])
+        .new_transaction_at(&Snapshot::from([base_entry_id.clone()]))
         .await
         .expect("Failed to start branch A");
     {
@@ -688,7 +689,7 @@ async fn test_table_delete_concurrent_modifications() {
     // Branch B: Update the same record
     let op_branch_b = ctx
         .database()
-        .new_transaction_with_tips([base_entry_id])
+        .new_transaction_at(&Snapshot::from([base_entry_id]))
         .await
         .expect("Failed to start branch B");
     {

--- a/crates/lib/tests/it/sync/auto_peer_registration_tests.rs
+++ b/crates/lib/tests/it/sync/auto_peer_registration_tests.rs
@@ -309,7 +309,12 @@ async fn test_incremental_sync_tracks_tree_peer_relationship() {
         .unwrap();
 
     // Get current tips for incremental sync
-    let tips = instance.backend().get_tips(&tree_id).await.unwrap();
+    let tips = instance
+        .backend()
+        .snapshot(&tree_id)
+        .await
+        .unwrap()
+        .into_tips();
 
     // Create incremental sync request (non-empty tips)
     let sync_request = SyncTreeRequest {

--- a/crates/lib/tests/it/sync/bidirectional_sync_test.rs
+++ b/crates/lib/tests/it/sync/bidirectional_sync_test.rs
@@ -281,14 +281,14 @@ async fn test_bidirectional_sync_no_common_ancestor_issue() -> Result<()> {
     let current_tips = device1_database
         .backend()
         .expect("Failed to get backend")
-        .get_tips(&room_id)
+        .snapshot(&room_id)
         .await
         .expect("Failed to get tips");
     println!("🔍 Device 1 current tree tips before adding C: {current_tips:?}");
     let current_subtree_tips = device1_database
         .backend()
         .expect("Failed to get backend")
-        .get_store_tips(&room_id, "messages")
+        .store_snapshot(&room_id, "messages")
         .await
         .expect("Failed to get store tips");
     println!("🔍 Device 1 current messages store tips before adding C: {current_subtree_tips:?}");

--- a/crates/lib/tests/it/sync/bootstrap_sync_tests.rs
+++ b/crates/lib/tests/it/sync/bootstrap_sync_tests.rs
@@ -37,7 +37,7 @@ async fn test_bootstrap_sync_from_zero_state() {
     // Debug server state
     let server_tips = server_instance
         .backend()
-        .get_tips(&test_tree_id)
+        .snapshot(&test_tree_id)
         .await
         .unwrap();
     println!("🧪 DEBUG: Server tips: {server_tips:?}");
@@ -86,7 +86,7 @@ async fn test_bootstrap_sync_from_zero_state() {
     );
 
     // Verify client has tips
-    let tips = client_instance.backend().get_tips(&test_tree_id).await;
+    let tips = client_instance.backend().snapshot(&test_tree_id).await;
     println!("🧪 DEBUG: Client tips result: {tips:?}");
     match tips {
         Ok(tip_vec) => {
@@ -181,7 +181,7 @@ async fn test_incremental_sync_after_bootstrap() {
     // Verify tips have been updated
     let tips = client_instance
         .backend()
-        .get_tips(&test_tree_id)
+        .snapshot(&test_tree_id)
         .await
         .unwrap();
     assert!(

--- a/crates/lib/tests/it/sync/chat_simulation_test.rs
+++ b/crates/lib/tests/it/sync/chat_simulation_test.rs
@@ -302,7 +302,12 @@ async fn test_global_key_bootstrap() {
     }
 
     // Verify entry uses global permission key (encoded as "*:ed25519:...")
-    let tips = client_instance.backend().get_tips(&tree_id).await.unwrap();
+    let tips = client_instance
+        .backend()
+        .snapshot(&tree_id)
+        .await
+        .unwrap()
+        .into_tips();
     let latest_entry = client_instance.backend().get(&tips[0]).await.unwrap();
     assert!(
         latest_entry.sig.key.is_global(),

--- a/crates/lib/tests/it/sync/sync_enabled_security_tests.rs
+++ b/crates/lib/tests/it/sync/sync_enabled_security_tests.rs
@@ -191,9 +191,10 @@ async fn test_incremental_sync_rejected_when_sync_disabled() {
         .with_key(DatabaseKey::global(reader_key));
     let client_tips = client_instance
         .backend()
-        .get_tips(client_db.root_id())
+        .snapshot(client_db.root_id())
         .await
-        .unwrap();
+        .unwrap()
+        .into_tips();
 
     // NOW disable sync on the server
     server_user

--- a/crates/lib/tests/it/sync/ticket_sync_tests.rs
+++ b/crates/lib/tests/it/sync/ticket_sync_tests.rs
@@ -145,7 +145,7 @@ async fn test_sync_with_ticket_happy_path() {
     // Verify tips are non-empty
     let tips = client_instance
         .backend()
-        .get_tips(&tree_id)
+        .snapshot(&tree_id)
         .await
         .expect("Client should have tips");
     assert!(
@@ -337,7 +337,7 @@ async fn test_bootstrap_with_ticket_authenticated() {
     // Verify tips exist
     let tips = client_instance
         .backend()
-        .get_tips(&tree_id)
+        .snapshot(&tree_id)
         .await
         .expect("Client should have tips");
     assert!(

--- a/crates/lib/tests/it/transaction/custom_tips.rs
+++ b/crates/lib/tests/it/transaction/custom_tips.rs
@@ -3,7 +3,7 @@
 //! This module contains tests for operations using custom tips including
 //! branching, parallel operations, and tip-based state management.
 
-use eidetica::{crdt::doc::Value, store::DocStore};
+use eidetica::{Snapshot, crdt::doc::Value, store::DocStore};
 
 use super::helpers::*;
 use crate::helpers::*;
@@ -34,7 +34,7 @@ async fn test_transaction_with_custom_tips() {
     // Create operation from entry A using new_transaction_with_tips
     let op_from_a = ctx
         .database()
-        .new_transaction_with_tips(std::slice::from_ref(&entry_a_id))
+        .new_transaction_at(&Snapshot::from(std::slice::from_ref(&entry_a_id)))
         .await
         .unwrap();
     let store_from_a = op_from_a.get_store::<DocStore>("data").await.unwrap();
@@ -78,7 +78,7 @@ async fn test_transaction_multiple_subtrees_with_custom_tips() {
     // Create branch that only modifies users
     let op_users = ctx
         .database()
-        .new_transaction_with_tips(std::slice::from_ref(&base_id))
+        .new_transaction_at(&Snapshot::from(std::slice::from_ref(&base_id)))
         .await
         .unwrap();
     let users_branch = op_users.get_store::<DocStore>("users").await.unwrap();
@@ -88,7 +88,7 @@ async fn test_transaction_multiple_subtrees_with_custom_tips() {
     // Create branch that only modifies posts
     let op_posts = ctx
         .database()
-        .new_transaction_with_tips([base_id])
+        .new_transaction_at(&Snapshot::from([base_id]))
         .await
         .unwrap();
     let posts_branch = op_posts.get_store::<DocStore>("posts").await.unwrap();
@@ -98,7 +98,7 @@ async fn test_transaction_multiple_subtrees_with_custom_tips() {
     // Create merge operation
     let op_merge = ctx
         .database()
-        .new_transaction_with_tips([users_id.clone(), posts_id.clone()])
+        .new_transaction_at(&Snapshot::from([users_id.clone(), posts_id.clone()]))
         .await
         .unwrap();
     let users_merge = op_merge.get_store::<DocStore>("users").await.unwrap();
@@ -119,7 +119,7 @@ async fn test_transaction_multiple_subtrees_with_custom_tips() {
     // Verify final state has all data
     let op_final = ctx
         .database()
-        .new_transaction_with_tips([merge_id])
+        .new_transaction_at(&Snapshot::from([merge_id]))
         .await
         .unwrap();
     let users_final = op_final.get_store::<DocStore>("users").await.unwrap();
@@ -149,7 +149,7 @@ async fn test_transaction_custom_tips_subtree_in_ancestors_not_tips() {
     // Create a parallel branch that also has subtree data
     let txn2 = ctx
         .database()
-        .new_transaction_with_tips(std::slice::from_ref(&entry1_id))
+        .new_transaction_at(&Snapshot::from(std::slice::from_ref(&entry1_id)))
         .await
         .unwrap();
     let store2 = txn2.get_store::<DocStore>("data").await.unwrap();
@@ -159,7 +159,7 @@ async fn test_transaction_custom_tips_subtree_in_ancestors_not_tips() {
     // Create another branch that does NOT touch the "data" subtree at all
     let txn3 = ctx
         .database()
-        .new_transaction_with_tips([entry1_id])
+        .new_transaction_at(&Snapshot::from([entry1_id]))
         .await
         .unwrap();
     // Only touch a different subtree
@@ -171,7 +171,7 @@ async fn test_transaction_custom_tips_subtree_in_ancestors_not_tips() {
     // entry2_id has subtree data, entry3_id does NOT have subtree data
     let txn4 = ctx
         .database()
-        .new_transaction_with_tips([entry2_id.clone(), entry3_id.clone()])
+        .new_transaction_at(&Snapshot::from([entry2_id.clone(), entry3_id.clone()]))
         .await
         .unwrap();
     let store4 = txn4.get_store::<DocStore>("data").await.unwrap();
@@ -224,7 +224,7 @@ async fn test_transaction_custom_tips_no_subtree_data_in_tips() {
     // The "data" subtree should still be accessible from their common ancestor (entry1)
     let txn4 = ctx
         .database()
-        .new_transaction_with_tips([entry2_id.clone(), entry3_id.clone()])
+        .new_transaction_at(&Snapshot::from([entry2_id.clone(), entry3_id.clone()]))
         .await
         .unwrap();
     let store4 = txn4.get_store::<DocStore>("data").await.unwrap();

--- a/crates/lib/tests/it/transaction/data_operations.rs
+++ b/crates/lib/tests/it/transaction/data_operations.rs
@@ -4,6 +4,7 @@
 //! deletes, nested values, and staging isolation.
 
 use eidetica::{
+    Snapshot,
     constants::SETTINGS,
     crdt::{Doc, doc::Value},
     store::DocStore,
@@ -107,7 +108,7 @@ async fn test_transaction_staged_data_isolation() {
     // Create operation from entry1
     let txn2 = ctx
         .database()
-        .new_transaction_with_tips(std::slice::from_ref(&entry1_id))
+        .new_transaction_at(&Snapshot::from(std::slice::from_ref(&entry1_id)))
         .await
         .unwrap();
     let store2 = txn2.get_store::<DocStore>("data").await.unwrap();
@@ -126,7 +127,7 @@ async fn test_transaction_staged_data_isolation() {
     // Create another operation from same tip - should not see staged data
     let txn3 = ctx
         .database()
-        .new_transaction_with_tips([entry1_id])
+        .new_transaction_at(&Snapshot::from([entry1_id]))
         .await
         .unwrap();
     let store3 = txn3.get_store::<DocStore>("data").await.unwrap();
@@ -141,7 +142,7 @@ async fn test_transaction_staged_data_isolation() {
     // Create operation from entry2 - should see committed staged data
     let txn4 = ctx
         .database()
-        .new_transaction_with_tips([entry2_id])
+        .new_transaction_at(&Snapshot::from([entry2_id]))
         .await
         .unwrap();
     let store4 = txn4.get_store::<DocStore>("data").await.unwrap();

--- a/crates/lib/tests/it/transaction/helpers.rs
+++ b/crates/lib/tests/it/transaction/helpers.rs
@@ -4,7 +4,7 @@
 //! operations, custom tips, diamond patterns, and data isolation scenarios.
 
 use eidetica::{
-    Database, Instance,
+    Database, Instance, Snapshot,
     crdt::{Doc, doc::Value},
     entry::ID,
     store::DocStore,
@@ -74,7 +74,7 @@ pub async fn create_diamond_pattern(tree: &Database) -> DiamondIds {
 
     // Create left branch
     let left_op = tree
-        .new_transaction_with_tips(std::slice::from_ref(&base_id))
+        .new_transaction_at(&Snapshot::from(std::slice::from_ref(&base_id)))
         .await
         .unwrap();
     let left_store = left_op.get_store::<DocStore>("data").await.unwrap();
@@ -84,7 +84,7 @@ pub async fn create_diamond_pattern(tree: &Database) -> DiamondIds {
 
     // Create right branch
     let right_op = tree
-        .new_transaction_with_tips([base_id.clone()])
+        .new_transaction_at(&Snapshot::from([base_id.clone()]))
         .await
         .unwrap();
     let right_store = right_op.get_store::<DocStore>("data").await.unwrap();
@@ -109,7 +109,10 @@ pub struct DiamondIds {
 /// Create a merge operation from diamond pattern
 pub async fn create_merge_from_diamond(tree: &Database, diamond: &DiamondIds) -> ID {
     let merge_op = tree
-        .new_transaction_with_tips([diamond.left.clone(), diamond.right.clone()])
+        .new_transaction_at(&Snapshot::from([
+            diamond.left.clone(),
+            diamond.right.clone(),
+        ]))
         .await
         .unwrap();
     let merge_store = merge_op.get_store::<DocStore>("data").await.unwrap();
@@ -240,7 +243,7 @@ pub async fn create_lca_test_scenario(tree: &Database) -> LcaTestIds {
 
     // Create branch A
     let a_op = tree
-        .new_transaction_with_tips(std::slice::from_ref(&lca_id))
+        .new_transaction_at(&Snapshot::from(std::slice::from_ref(&lca_id)))
         .await
         .unwrap();
     let a_store = a_op.get_store::<DocStore>("data").await.unwrap();
@@ -249,7 +252,7 @@ pub async fn create_lca_test_scenario(tree: &Database) -> LcaTestIds {
 
     // Create branch B (parallel to A)
     let b_op = tree
-        .new_transaction_with_tips(std::slice::from_ref(&lca_id))
+        .new_transaction_at(&Snapshot::from(std::slice::from_ref(&lca_id)))
         .await
         .unwrap();
     let b_store = b_op.get_store::<DocStore>("data").await.unwrap();
@@ -258,7 +261,7 @@ pub async fn create_lca_test_scenario(tree: &Database) -> LcaTestIds {
 
     // Create merge tip
     let merge_op = tree
-        .new_transaction_with_tips([a_id.clone(), b_id.clone()])
+        .new_transaction_at(&Snapshot::from([a_id.clone(), b_id.clone()]))
         .await
         .unwrap();
     let merge_store = merge_op.get_store::<DocStore>("data").await.unwrap();
@@ -267,7 +270,7 @@ pub async fn create_lca_test_scenario(tree: &Database) -> LcaTestIds {
 
     // Create independent tip
     let indep_op = tree
-        .new_transaction_with_tips([lca_id.clone()])
+        .new_transaction_at(&Snapshot::from([lca_id.clone()]))
         .await
         .unwrap();
     let indep_store = indep_op.get_store::<DocStore>("data").await.unwrap();
@@ -288,7 +291,10 @@ pub struct LcaTestIds {
 
 /// Verify that LCA path finding includes all expected data
 pub async fn assert_lca_path_completeness(tree: &Database, tips: &[ID], expected_keys: &[&str]) {
-    let txn = tree.new_transaction_with_tips(tips).await.unwrap();
+    let txn = tree
+        .new_transaction_at(&Snapshot::from(tips.to_vec()))
+        .await
+        .unwrap();
     let store = txn.get_store::<DocStore>("data").await.unwrap();
     let state = store.get_all().await.unwrap();
 
@@ -307,7 +313,10 @@ pub async fn test_deterministic_operations(tree: &Database, tips: &[ID], iterati
     let mut results = Vec::new();
 
     for _i in 0..iterations {
-        let txn = tree.new_transaction_with_tips(tips).await.unwrap();
+        let txn = tree
+            .new_transaction_at(&Snapshot::from(tips.to_vec()))
+            .await
+            .unwrap();
         let store = txn.get_store::<DocStore>("data").await.unwrap();
         let state = store.get_all().await.unwrap();
         results.push(state);

--- a/crates/lib/tests/it/transaction/path_finding.rs
+++ b/crates/lib/tests/it/transaction/path_finding.rs
@@ -3,7 +3,7 @@
 //! This module contains tests for complex scenarios involving LCA (Lowest Common Ancestor)
 //! computation, path finding, and deterministic ordering in diamond and merge patterns.
 
-use eidetica::{entry::ID, store::DocStore};
+use eidetica::{Snapshot, entry::ID, store::DocStore};
 
 use super::helpers::*;
 use crate::helpers::*;
@@ -21,7 +21,7 @@ async fn test_transaction_diamond_pattern() {
     // Create two branches from base
     let op_left = ctx
         .database()
-        .new_transaction_with_tips(std::slice::from_ref(&base_id))
+        .new_transaction_at(&Snapshot::from(std::slice::from_ref(&base_id)))
         .await
         .unwrap();
     let store_left = op_left.get_store::<DocStore>("data").await.unwrap();
@@ -31,7 +31,7 @@ async fn test_transaction_diamond_pattern() {
 
     let op_right = ctx
         .database()
-        .new_transaction_with_tips([base_id])
+        .new_transaction_at(&Snapshot::from([base_id]))
         .await
         .unwrap();
     let store_right = op_right.get_store::<DocStore>("data").await.unwrap();
@@ -42,7 +42,7 @@ async fn test_transaction_diamond_pattern() {
     // Create merge operation with both branches as tips
     let op_merge = ctx
         .database()
-        .new_transaction_with_tips([left_id.clone(), right_id.clone()])
+        .new_transaction_at(&Snapshot::from([left_id.clone(), right_id.clone()]))
         .await
         .unwrap();
     let store_merge = op_merge.get_store::<DocStore>("data").await.unwrap();
@@ -91,7 +91,7 @@ async fn test_get_path_from_to_diamond_pattern() {
     // B branches from A
     let op_b = ctx
         .database()
-        .new_transaction_with_tips(std::slice::from_ref(&entry_a_id))
+        .new_transaction_at(&Snapshot::from(std::slice::from_ref(&entry_a_id)))
         .await
         .unwrap();
     let store_b = op_b.get_store::<DocStore>("data").await.unwrap();
@@ -101,7 +101,7 @@ async fn test_get_path_from_to_diamond_pattern() {
     // C also branches from A (parallel to B)
     let op_c = ctx
         .database()
-        .new_transaction_with_tips([entry_a_id])
+        .new_transaction_at(&Snapshot::from([entry_a_id]))
         .await
         .unwrap();
     let store_c = op_c.get_store::<DocStore>("data").await.unwrap();
@@ -111,7 +111,7 @@ async fn test_get_path_from_to_diamond_pattern() {
     // D merges B and C
     let op_d = ctx
         .database()
-        .new_transaction_with_tips([entry_b_id.clone(), entry_c_id.clone()])
+        .new_transaction_at(&Snapshot::from([entry_b_id.clone(), entry_c_id.clone()]))
         .await
         .unwrap();
     let store_d = op_d.get_store::<DocStore>("data").await.unwrap();
@@ -126,7 +126,7 @@ async fn test_get_path_from_to_diamond_pattern() {
     // This will internally call get_path_from_to when computing merged state
     let op_final = ctx
         .database()
-        .new_transaction_with_tips([entry_d_id])
+        .new_transaction_at(&Snapshot::from([entry_d_id]))
         .await
         .unwrap();
     let store_final = op_final.get_store::<DocStore>("data").await.unwrap();
@@ -166,7 +166,7 @@ async fn test_get_path_from_to_diamond_between_lca_and_tip() {
     // Branch A
     let op_a = ctx
         .database()
-        .new_transaction_with_tips(std::slice::from_ref(&lca_id))
+        .new_transaction_at(&Snapshot::from(std::slice::from_ref(&lca_id)))
         .await
         .unwrap();
     let store_a = op_a.get_store::<DocStore>("data").await.unwrap();
@@ -176,7 +176,7 @@ async fn test_get_path_from_to_diamond_between_lca_and_tip() {
     // Branch B (parallel to A)
     let op_b = ctx
         .database()
-        .new_transaction_with_tips(std::slice::from_ref(&lca_id))
+        .new_transaction_at(&Snapshot::from(std::slice::from_ref(&lca_id)))
         .await
         .unwrap();
     let store_b = op_b.get_store::<DocStore>("data").await.unwrap();
@@ -186,7 +186,7 @@ async fn test_get_path_from_to_diamond_between_lca_and_tip() {
     // Step 3: Create tip C that merges both A and B
     let op_c = ctx
         .database()
-        .new_transaction_with_tips([a_id.clone(), b_id.clone()])
+        .new_transaction_at(&Snapshot::from([a_id.clone(), b_id.clone()]))
         .await
         .unwrap();
     let store_c = op_c.get_store::<DocStore>("data").await.unwrap();
@@ -196,7 +196,7 @@ async fn test_get_path_from_to_diamond_between_lca_and_tip() {
     // Step 4: Create another tip D independently
     let op_d = ctx
         .database()
-        .new_transaction_with_tips([lca_id])
+        .new_transaction_at(&Snapshot::from([lca_id]))
         .await
         .unwrap();
     let store_d = op_d.get_store::<DocStore>("data").await.unwrap();
@@ -210,7 +210,7 @@ async fn test_get_path_from_to_diamond_between_lca_and_tip() {
     // Or LCA -> B -> C (missing branch A modifications)
     let op_final = ctx
         .database()
-        .new_transaction_with_tips([c_id.clone(), d_id.clone()])
+        .new_transaction_at(&Snapshot::from([c_id.clone(), d_id.clone()]))
         .await
         .unwrap();
     let store_final = op_final.get_store::<DocStore>("data").await.unwrap();
@@ -261,7 +261,7 @@ async fn test_correct_lca_and_path_sorting() {
     // Branch A (height 1)
     let op_a = ctx
         .database()
-        .new_transaction_with_tips(std::slice::from_ref(&root_id))
+        .new_transaction_at(&Snapshot::from(std::slice::from_ref(&root_id)))
         .await
         .unwrap();
     let store_a = op_a.get_store::<DocStore>("data").await.unwrap();
@@ -272,7 +272,7 @@ async fn test_correct_lca_and_path_sorting() {
     // Branch B (height 1)
     let op_b = ctx
         .database()
-        .new_transaction_with_tips(std::slice::from_ref(&root_id))
+        .new_transaction_at(&Snapshot::from(std::slice::from_ref(&root_id)))
         .await
         .unwrap();
     let store_b = op_b.get_store::<DocStore>("data").await.unwrap();
@@ -283,7 +283,7 @@ async fn test_correct_lca_and_path_sorting() {
     // Branch C (height 1)
     let op_c = ctx
         .database()
-        .new_transaction_with_tips([root_id])
+        .new_transaction_at(&Snapshot::from([root_id]))
         .await
         .unwrap();
     let store_c = op_c.get_store::<DocStore>("data").await.unwrap();
@@ -294,7 +294,7 @@ async fn test_correct_lca_and_path_sorting() {
     // Step 3: Create merge tip from A and B (height 2)
     let op_merge = ctx
         .database()
-        .new_transaction_with_tips([a_id.clone(), b_id.clone()])
+        .new_transaction_at(&Snapshot::from([a_id.clone(), b_id.clone()]))
         .await
         .unwrap();
     let store_merge = op_merge.get_store::<DocStore>("data").await.unwrap();
@@ -305,7 +305,7 @@ async fn test_correct_lca_and_path_sorting() {
     // Step 4: Create another tip from C (height 2)
     let op_other = ctx
         .database()
-        .new_transaction_with_tips([c_id])
+        .new_transaction_at(&Snapshot::from([c_id]))
         .await
         .unwrap();
     let store_other = op_other.get_store::<DocStore>("data").await.unwrap();
@@ -319,7 +319,7 @@ async fn test_correct_lca_and_path_sorting() {
     // Sorting order is critical for deterministic CRDT merge
     let op_final = ctx
         .database()
-        .new_transaction_with_tips([merge_id.clone(), other_id.clone()])
+        .new_transaction_at(&Snapshot::from([merge_id.clone(), other_id.clone()]))
         .await
         .unwrap();
     let store_final = op_final.get_store::<DocStore>("data").await.unwrap();
@@ -343,7 +343,7 @@ async fn test_correct_lca_and_path_sorting() {
     for _i in 0..5 {
         let txn_test = ctx
             .database()
-            .new_transaction_with_tips([merge_id.clone(), other_id.clone()])
+            .new_transaction_at(&Snapshot::from([merge_id.clone(), other_id.clone()]))
             .await
             .unwrap();
         let store_test = txn_test.get_store::<DocStore>("data").await.unwrap();
@@ -382,7 +382,7 @@ async fn test_deterministic_operations_with_helper() {
     // Create independent branch
     let other_op = ctx
         .database()
-        .new_transaction_with_tips([diamond.base.clone()])
+        .new_transaction_at(&Snapshot::from([diamond.base.clone()]))
         .await
         .unwrap();
     let other_store = other_op.get_store::<DocStore>("data").await.unwrap();
@@ -419,7 +419,7 @@ async fn test_complex_path_finding_scenario() {
     for (step, data) in branches {
         let txn = ctx
             .database()
-            .new_transaction_with_tips([root_id.clone()])
+            .new_transaction_at(&Snapshot::from([root_id.clone()]))
             .await
             .unwrap();
         let store = txn.get_store::<DocStore>("data").await.unwrap();
@@ -433,7 +433,7 @@ async fn test_complex_path_finding_scenario() {
     for (i, branch_id) in branch_ids.iter().enumerate() {
         let txn = ctx
             .database()
-            .new_transaction_with_tips([branch_id.clone()])
+            .new_transaction_at(&Snapshot::from([branch_id.clone()]))
             .await
             .unwrap();
         let store = txn.get_store::<DocStore>("data").await.unwrap();
@@ -444,7 +444,10 @@ async fn test_complex_path_finding_scenario() {
     // Create two merges
     let merge1_op = ctx
         .database()
-        .new_transaction_with_tips([extended_ids[0].clone(), extended_ids[1].clone()])
+        .new_transaction_at(&Snapshot::from([
+            extended_ids[0].clone(),
+            extended_ids[1].clone(),
+        ]))
         .await
         .unwrap();
     let merge1_store = merge1_op.get_store::<DocStore>("data").await.unwrap();
@@ -453,7 +456,10 @@ async fn test_complex_path_finding_scenario() {
 
     let merge2_op = ctx
         .database()
-        .new_transaction_with_tips([extended_ids[2].clone(), extended_ids[3].clone()])
+        .new_transaction_at(&Snapshot::from([
+            extended_ids[2].clone(),
+            extended_ids[3].clone(),
+        ]))
         .await
         .unwrap();
     let merge2_store = merge2_op.get_store::<DocStore>("data").await.unwrap();
@@ -508,7 +514,7 @@ async fn test_find_merge_base_with_bypass_path() {
     // Step 2: Create A (branches from R)
     let op_a = ctx
         .database()
-        .new_transaction_with_tips(std::slice::from_ref(&r_id))
+        .new_transaction_at(&Snapshot::from(std::slice::from_ref(&r_id)))
         .await
         .unwrap();
     let store_a = op_a.get_store::<DocStore>("data").await.unwrap();
@@ -518,7 +524,7 @@ async fn test_find_merge_base_with_bypass_path() {
     // Step 3: Create X (also branches from R, parallel to A)
     let op_x = ctx
         .database()
-        .new_transaction_with_tips(std::slice::from_ref(&r_id))
+        .new_transaction_at(&Snapshot::from(std::slice::from_ref(&r_id)))
         .await
         .unwrap();
     let store_x = op_x.get_store::<DocStore>("data").await.unwrap();
@@ -528,7 +534,7 @@ async fn test_find_merge_base_with_bypass_path() {
     // Step 4: Create B (child of A only)
     let op_b = ctx
         .database()
-        .new_transaction_with_tips(std::slice::from_ref(&a_id))
+        .new_transaction_at(&Snapshot::from(std::slice::from_ref(&a_id)))
         .await
         .unwrap();
     let store_b = op_b.get_store::<DocStore>("data").await.unwrap();
@@ -538,7 +544,7 @@ async fn test_find_merge_base_with_bypass_path() {
     // Step 5: Create C (child of BOTH A and X - this creates the bypass!)
     let op_c = ctx
         .database()
-        .new_transaction_with_tips([a_id.clone(), x_id.clone()])
+        .new_transaction_at(&Snapshot::from([a_id.clone(), x_id.clone()]))
         .await
         .unwrap();
     let store_c = op_c.get_store::<DocStore>("data").await.unwrap();
@@ -548,7 +554,7 @@ async fn test_find_merge_base_with_bypass_path() {
     // Step 6: Create D (child of B only)
     let op_d = ctx
         .database()
-        .new_transaction_with_tips(std::slice::from_ref(&b_id))
+        .new_transaction_at(&Snapshot::from(std::slice::from_ref(&b_id)))
         .await
         .unwrap();
     let store_d = op_d.get_store::<DocStore>("data").await.unwrap();
@@ -558,7 +564,7 @@ async fn test_find_merge_base_with_bypass_path() {
     // Step 7: Create E (tip, child of D)
     let op_e = ctx
         .database()
-        .new_transaction_with_tips(std::slice::from_ref(&d_id))
+        .new_transaction_at(&Snapshot::from(std::slice::from_ref(&d_id)))
         .await
         .unwrap();
     let store_e = op_e.get_store::<DocStore>("data").await.unwrap();
@@ -568,7 +574,7 @@ async fn test_find_merge_base_with_bypass_path() {
     // Step 8: Create F (tip, child of C)
     let op_f = ctx
         .database()
-        .new_transaction_with_tips(std::slice::from_ref(&c_id))
+        .new_transaction_at(&Snapshot::from(std::slice::from_ref(&c_id)))
         .await
         .unwrap();
     let store_f = op_f.get_store::<DocStore>("data").await.unwrap();
@@ -580,7 +586,7 @@ async fn test_find_merge_base_with_bypass_path() {
     // With correct merge base: finds R, includes all data including X
     let op_final = ctx
         .database()
-        .new_transaction_with_tips([e_id.clone(), f_id.clone()])
+        .new_transaction_at(&Snapshot::from([e_id.clone(), f_id.clone()]))
         .await
         .unwrap();
     let store_final = op_final.get_store::<DocStore>("data").await.unwrap();
@@ -682,7 +688,10 @@ async fn test_multi_tip_merge_state_caching() {
     // Read state with multiple tips - this should populate the cache
     let tx = ctx
         .database()
-        .new_transaction_with_tips([diamond.left.clone(), diamond.right.clone()])
+        .new_transaction_at(&Snapshot::from([
+            diamond.left.clone(),
+            diamond.right.clone(),
+        ]))
         .await
         .unwrap();
     let store = tx.get_store::<DocStore>("data").await.unwrap();
@@ -712,7 +721,10 @@ async fn test_multi_tip_merge_state_caching() {
     // Read again - should hit cache and return same result
     let tx2 = ctx
         .database()
-        .new_transaction_with_tips([diamond.left.clone(), diamond.right.clone()])
+        .new_transaction_at(&Snapshot::from([
+            diamond.left.clone(),
+            diamond.right.clone(),
+        ]))
         .await
         .unwrap();
     let store2 = tx2.get_store::<DocStore>("data").await.unwrap();
@@ -750,7 +762,10 @@ async fn test_multi_tip_cache_key_is_order_independent() {
     // Read with tips in order [left, right]
     let tx1 = ctx
         .database()
-        .new_transaction_with_tips([diamond.left.clone(), diamond.right.clone()])
+        .new_transaction_at(&Snapshot::from([
+            diamond.left.clone(),
+            diamond.right.clone(),
+        ]))
         .await
         .unwrap();
     let store1 = tx1.get_store::<DocStore>("data").await.unwrap();
@@ -790,7 +805,10 @@ async fn test_multi_tip_cache_key_is_order_independent() {
     // Read with tips in REVERSE order [right, left]
     let tx2 = ctx
         .database()
-        .new_transaction_with_tips([diamond.right.clone(), diamond.left.clone()])
+        .new_transaction_at(&Snapshot::from([
+            diamond.right.clone(),
+            diamond.left.clone(),
+        ]))
         .await
         .unwrap();
     let store2 = tx2.get_store::<DocStore>("data").await.unwrap();

--- a/docs/src/user_guide/authentication_guide.md
+++ b/docs/src/user_guide/authentication_guide.md
@@ -344,7 +344,7 @@ When you delegate to another database:
 # let project_database = user.create_database(Doc::new(), &default_key).await?;
 // Get the user's database root and current tips
 let user_root = alice_database.root_id().clone();
-let user_tips = alice_database.get_tips().await?;
+let user_tips = alice_database.snapshot().await?.into_tips();
 
 // Add delegation reference to project database
 let transaction = project_database.new_transaction().await?;
@@ -395,7 +395,7 @@ Delegations are stored in the **delegating database's** auth settings by the del
 # let default_key = user.get_default_key()?;
 # let alice_db = user.create_database(Doc::new(), &default_key).await?;
 # let alice_root = alice_db.root_id().clone();
-# let alice_tips = alice_db.get_tips().await?;
+# let alice_tips = alice_db.snapshot().await?.into_tips();
 # let project_db = user.create_database(Doc::new(), &default_key).await?;
 # let transaction = project_db.new_transaction().await?;
 # let settings = transaction.get_settings()?;
@@ -482,7 +482,7 @@ A delegation path is a sequence of steps that traverses from the delegating data
 # let default_key = user.get_default_key()?;
 # let project_db = user.create_database(Doc::new(), &default_key).await?;
 # let user_db = user.create_database(Doc::new(), &default_key).await?;
-# let user_tips = user_db.get_tips().await?;
+# let user_tips = user_db.snapshot().await?.into_tips();
 // Create a delegation path:
 // - path: list of delegated trees to traverse (by root ID)
 // - hint: identifies the final signer in the last delegated tree


### PR DESCRIPTION
Introduces `Snapshot` as the canonical type for "a database state at a point in time", consisting of a sorted, deduplicated set of DAG tip IDs. Retypes every `Vec<ID>`/`&[ID]` tip parameter and return value across the library to use it.

Tip-sets are the universal currency of this codebase: backend snapshots, transaction anchors, delegation references, entry-metadata pins, sync cursors, write-callback `previous_tips`. They're currently `Vec<ID>` everywhere, which has three problems:

- **No type-level distinction** between "a set of tips identifying a state" and "an arbitrary list of entry IDs."
- **Positional `==` is the wrong semantics** — set-equal tip lists in different orders compare unequal, and `InMemory::get_tips` collects from a `HashSet` whose iteration order isn't stable, so the bug surfaces in practice (see the `sync/user.rs` behavior-change note below).
- **No invariant** that the tip set is canonical (sorted + deduplicated), so downstream code reimplements that wherever it matters.

A newtype fixes all three, and is a precursor several pieces of in-flight work that need a Snapshot primitive.
