### PR TITLE
ci: collapse into shared nix derivations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,15 +18,23 @@ jobs:
       - name: Setup Nix
         uses: ./.github/actions/setup-nix
 
+      # On PRs: build the checks only — fast feedback, integration is push-only.
       - name: Checks
+        if: github.event_name == 'pull_request'
         run: |
           nix-fast-build --skip-cached --no-nom --no-link
 
-      - name: Integration tests
-        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+      # On push/dispatch: build checks + integration in ONE nix-fast-build
+      # invocation. nix-fast-build only takes a single target, so we point it at
+      # the `.#legacyPackages.x86_64-linux.ci` aggregate (checks + integration).
+      # A single dependency graph shares testCheckArtifacts (built once) and lets
+      # the integration VM's serial boot/run overlap the check compiles, instead
+      # of the two running back-to-back as separate steps.
+      - name: Checks + integration
+        if: github.event_name != 'pull_request'
         run: |
           nix-fast-build --skip-cached --no-nom --no-link \
-            -f '.#legacyPackages.x86_64-linux.integration.default'
+            -f '.#legacyPackages.x86_64-linux.ci'
 
   ci-arm:
     name: CI (aarch64-linux)

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -7,13 +7,9 @@ on:
 
 jobs:
   sanitize:
-    name: Sanitize (${{ matrix.sanitizer }})
+    name: Sanitize
     runs-on: ubicloud-standard-4
     if: github.repository_owner == 'arcuru'
-    strategy:
-      matrix:
-        sanitizer: [asan, lsan]
-      fail-fast: false
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -21,7 +17,9 @@ jobs:
       - name: Setup Nix
         uses: ./.github/actions/setup-nix
 
-      - name: Run ${{ matrix.sanitizer }}
+      # asan + lsan in one target (.#…sanitize.default), one dependency graph
+      # sharing the nightly toolchain and sanitizer-instrumented deps.
+      - name: Run sanitizers
         run: |
           nix-fast-build --skip-cached --no-nom --no-link \
-            -f '.#legacyPackages.x86_64-linux.sanitize.${{ matrix.sanitizer }}'
+            -f '.#legacyPackages.x86_64-linux.sanitize.default'

--- a/flake.nix
+++ b/flake.nix
@@ -216,6 +216,21 @@
               default = mkAll "eval" nixTests.eval;
               all = mkAll "eval" nixTests.eval;
             };
+
+          # Combined push-CI target: the full check set (including the
+          # module-injected treefmt check, via config.checks) plus integration
+          # tests, as a single attrset. nix-fast-build only accepts one target,
+          # so this lets the push pipeline build checks and integration in one
+          # invocation — one dependency graph that shares testCheckArtifacts and
+          # overlaps the integration VM's serial boot/run with the check
+          # compiles instead of running them back-to-back. Integration is
+          # Linux-only (gated on stdenv.isLinux); on other systems this is just
+          # the checks. Not used by `nix flake check`, which builds `checks`.
+          ci =
+            config.checks
+            // lib.optionalAttrs pkgs.stdenv.isLinux {
+              integration = mkAll "integration" nixTests.integration;
+            };
         };
 
         # Standard packages output for `nix build` (bare) and `nix build .#eidetica-bin`


### PR DESCRIPTION
Merges a few of the separate CI steps into running on fewer nix derivations. This allows for better parallelism in the builds, hopefully getting a bit better CI utilization.