### PR TITLE
fix(security): partial verification of delegated auth pins

### DIFF
--- a/crates/lib/src/auth/errors.rs
+++ b/crates/lib/src/auth/errors.rs
@@ -97,6 +97,34 @@ pub enum AuthError {
         tree_id: ID,
     },
 
+    /// Delegation path exceeds the maximum allowed number of steps.
+    ///
+    /// The delegation path is wire-supplied on the entry's signature key, and
+    /// each step drives backend work before the authorization gate decides.
+    /// Bounding the path length caps that amplification (a flat path of N steps
+    /// is the chain-depth analog of N levels of recursion).
+    #[error("Delegation path too long: {len} steps (max {max})")]
+    DelegationPathTooLong {
+        /// Number of steps supplied
+        len: usize,
+        /// Maximum allowed
+        max: usize,
+    },
+
+    /// A delegation step claims more tips than allowed.
+    ///
+    /// Claimed tips are wire-supplied and each drives DAG traversal; the per-step
+    /// count is bounded to cap that amplification.
+    #[error("Delegation step for tree {tree_id} claims too many tips: {len} (max {max})")]
+    DelegationTipsTooMany {
+        /// The delegated tree root ID
+        tree_id: ID,
+        /// Number of tips claimed
+        len: usize,
+        /// Maximum allowed
+        max: usize,
+    },
+
     /// Attempted to revoke an entry that is not a key.
     #[error("Cannot revoke non-key entry: {key_name}")]
     CannotRevokeNonKey {
@@ -245,6 +273,8 @@ impl AuthError {
                 | AuthError::DelegatedTreeLoadFailed { .. }
                 | AuthError::InvalidDelegationTips { .. }
                 | AuthError::DelegationNotFound { .. }
+                | AuthError::DelegationPathTooLong { .. }
+                | AuthError::DelegationTipsTooMany { .. }
         )
     }
 

--- a/crates/lib/src/auth/errors.rs
+++ b/crates/lib/src/auth/errors.rs
@@ -125,6 +125,26 @@ pub enum AuthError {
         max: usize,
     },
 
+    /// A delegated tree referenced by a delegation is not synced locally enough
+    /// to decide the monotonicity floor.
+    ///
+    /// This is a *transient* condition, not a validation failure: the entries in
+    /// `missing` have not arrived yet. The caller should keep the entry
+    /// unverified and re-check after syncing `missing` from the delegated tree's
+    /// peers, rather than rejecting it as a forgery. Deliberately excluded from
+    /// [`AuthError::is_delegation_error`] — it signals sync state, not a
+    /// delegation defect.
+    #[error(
+        "Delegated tree {tree_id} not synced enough to validate delegation: {} entry(ies) missing",
+        missing.len()
+    )]
+    DelegatedTreeUnsynced {
+        /// The delegated tree root ID
+        tree_id: ID,
+        /// Entries that must be synced before validation can proceed.
+        missing: Vec<ID>,
+    },
+
     /// Attempted to revoke an entry that is not a key.
     #[error("Cannot revoke non-key entry: {key_name}")]
     CannotRevokeNonKey {
@@ -276,6 +296,13 @@ impl AuthError {
                 | AuthError::DelegationPathTooLong { .. }
                 | AuthError::DelegationTipsTooMany { .. }
         )
+    }
+
+    /// Check if this error indicates a delegated tree is not yet synced enough
+    /// to validate — a transient, retriable condition, not a delegation defect
+    /// (see [`AuthError::DelegatedTreeUnsynced`]).
+    pub fn is_delegated_tree_unsynced(&self) -> bool {
+        matches!(self, AuthError::DelegatedTreeUnsynced { .. })
     }
 
     /// Get the key name if this error is about a missing key.

--- a/crates/lib/src/auth/validation/delegation.rs
+++ b/crates/lib/src/auth/validation/delegation.rs
@@ -11,6 +11,7 @@ use crate::{
         settings::AuthSettings,
         types::{DelegationStep, KeyHint, PermissionBounds, ResolvedAuth},
     },
+    backend::Reachability,
 };
 
 /// Maximum number of steps in a single delegation path.
@@ -114,12 +115,13 @@ impl DelegationResolver {
             // may not regress below the snapshot the parent committed for this
             // delegation (`delegated_tree_ref.tree.tips`, the "floor"): every floor
             // tip must be an ancestor-or-equal of the claimed tips.
-            // `targets_reachable_from` answers exactly that, and in doing so
+            // `check_targets_reachable_from` answers exactly that, and in doing so
             // validates that each claimed tip is a real entry of this delegated
-            // tree (rejecting foreign or fabricated tips). It is bounded — the cost
-            // tracks the floor distance, not the whole tree — which matters because
-            // this runs on every delegated-entry validation (and re-validation).
-            // Membership here is *presence in the tree*, not
+            // tree (rejecting foreign or fabricated tips). It is bounded by the
+            // target floor height, so the cost tracks the floor distance rather
+            // than the whole tree on both the reachable and unreachable paths —
+            // which matters because this runs on every delegated-entry validation
+            // (and re-validation). Membership here is *presence in the tree*, not
             // `VerificationStatus::Verified`: a delegation can legitimately resolve
             // against a delegated tree whose entries are still unverified locally
             // (e.g. just arrived over sync and not yet re-verified).
@@ -129,25 +131,42 @@ impl DelegationResolver {
             // since-revoked key). Advancing the floor is an admin-gated `_settings`
             // write on the parent tree.
             //
+            // A three-state verdict keeps a *proven* regression (Unreachable →
+            // reject) distinct from "the delegated tree hasn't synced far enough
+            // to decide" (Indeterminate → surface a retriable error so the entry
+            // stays unverified and is re-checked once `missing` arrives, instead
+            // of being rejected as a forgery).
+            //
             // FIXME(security): the floor is the only monotonicity guarantee today
             // and is a known partial fix. It enforces neither strict per-entry
             // non-regression (siblings above the floor may still differ) nor a
             // forward-only gate on the committed pointer itself. Both remain to be
             // done.
             let floor = &delegated_tree_ref.tree.tips;
-            let floor_satisfied = current_backend
-                .targets_reachable_from(&root_id, &step.tips, floor)
+            match current_backend
+                .check_targets_reachable_from(&root_id, &step.tips, floor)
                 .await
+                // A foreign (wrong-tree) claimed tip surfaces as a backend
+                // integrity error — treat it as an invalid delegation tip.
                 .map_err(|_| AuthError::InvalidDelegationTips {
                     tree_id: root_id.clone(),
                     claimed_tips: step.tips.clone(),
-                })?;
-            if !floor_satisfied {
-                return Err(AuthError::InvalidDelegationTips {
-                    tree_id: root_id.clone(),
-                    claimed_tips: step.tips.clone(),
+                })? {
+                Reachability::Reachable => {}
+                Reachability::Unreachable => {
+                    return Err(AuthError::InvalidDelegationTips {
+                        tree_id: root_id.clone(),
+                        claimed_tips: step.tips.clone(),
+                    }
+                    .into());
                 }
-                .into());
+                Reachability::Indeterminate { missing } => {
+                    return Err(AuthError::DelegatedTreeUnsynced {
+                        tree_id: root_id.clone(),
+                        missing,
+                    }
+                    .into());
+                }
             }
 
             // Resolve the delegated tree's auth settings AS OF the claimed tips,

--- a/crates/lib/src/auth/validation/delegation.rs
+++ b/crates/lib/src/auth/validation/delegation.rs
@@ -3,19 +3,29 @@
 //! This module handles the complex logic of resolving delegation paths,
 //! including multi-tree traversal and permission clamping.
 
-use std::sync::Arc;
-
 use crate::{
-    Database, Instance, Result,
+    Database, Instance, Result, Snapshot,
     auth::{
         errors::AuthError,
         permission::clamp_permission,
         settings::AuthSettings,
         types::{DelegationStep, KeyHint, PermissionBounds, ResolvedAuth},
     },
-    backend::BackendImpl,
-    entry::ID,
 };
+
+/// Maximum number of steps in a single delegation path.
+///
+/// The path is wire-supplied and processed as a flat list, so its length is the
+/// delegation-chain depth. Bounding it caps the backend work an unauthenticated
+/// signature key can force before the authorization gate decides (mirrors the
+/// `MAX_DELEGATION_DEPTH` recursion guard in the resolver).
+const MAX_DELEGATION_STEPS: usize = 10;
+
+/// Maximum number of claimed tips per delegation step.
+///
+/// Tips are wire-supplied and each drives DAG traversal; bound the per-step
+/// fan-out. A legitimate tree frontier is small (concurrent heads only).
+const MAX_DELEGATION_TIPS: usize = 64;
 
 /// Delegation resolver for handling complex delegation paths
 pub struct DelegationResolver;
@@ -47,6 +57,15 @@ impl DelegationResolver {
             return Err(AuthError::EmptyDelegationPath.into());
         }
 
+        // Bound the wire-supplied path length before doing any backend work.
+        if steps.len() > MAX_DELEGATION_STEPS {
+            return Err(AuthError::DelegationPathTooLong {
+                len: steps.len(),
+                max: MAX_DELEGATION_STEPS,
+            }
+            .into());
+        }
+
         // Validate no global hints in delegation (must resolve to concrete key)
         if final_hint.is_global() {
             return Err(AuthError::InvalidDelegationStep {
@@ -65,7 +84,22 @@ impl DelegationResolver {
 
         // Process all delegation steps (tree traversal)
         for step in steps {
-            // Load delegated tree (step.tree contains the root ID)
+            // Bound the wire-supplied claimed tips before any backend traversal.
+            if step.tips.len() > MAX_DELEGATION_TIPS {
+                return Err(AuthError::DelegationTipsTooMany {
+                    tree_id: step.tree.clone(),
+                    len: step.tips.len(),
+                    max: MAX_DELEGATION_TIPS,
+                }
+                .into());
+            }
+
+            // Look up the delegation declaration in the *parent's* settings. The
+            // declaration carries `tree.tips` — the snapshot the parent tree has
+            // committed for this delegation — which is the monotonicity floor
+            // enforced below. Because the parent's auth settings here are taken
+            // at the validating entry's own settings snapshot, the floor is the
+            // historically-correct one, not a global "now".
             let delegated_tree_ref = current_auth_settings.get_delegated_tree(&step.tree)?;
 
             let root_id = delegated_tree_ref.tree.root.clone();
@@ -76,19 +110,39 @@ impl DelegationResolver {
                 }
             })?;
 
-            // Validate tips
-            let current_snapshot = current_backend.snapshot(&root_id).await.map_err(|e| {
-                AuthError::InvalidAuthConfiguration {
-                    reason: format!(
-                        "Failed to get current tips for delegated tree '{root_id}': {e}"
-                    ),
-                }
-            })?;
-
-            let tips_valid = self
-                .validate_tip_ancestry(&step.tips, current_snapshot.tips(), &current_backend)
-                .await?;
-            if !tips_valid {
+            // Tree-scoped membership + monotonicity floor. The claimed snapshot
+            // may not regress below the snapshot the parent committed for this
+            // delegation (`delegated_tree_ref.tree.tips`, the "floor"): every floor
+            // tip must be an ancestor-or-equal of the claimed tips.
+            // `targets_reachable_from` answers exactly that, and in doing so
+            // validates that each claimed tip is a real entry of this delegated
+            // tree (rejecting foreign or fabricated tips). It is bounded — the cost
+            // tracks the floor distance, not the whole tree — which matters because
+            // this runs on every delegated-entry validation (and re-validation).
+            // Membership here is *presence in the tree*, not
+            // `VerificationStatus::Verified`: a delegation can legitimately resolve
+            // against a delegated tree whose entries are still unverified locally
+            // (e.g. just arrived over sync and not yet re-verified).
+            //
+            // The floor stops an entry time-travelling the delegated tree backwards
+            // to resurrect auth state the parent has already advanced past (e.g. a
+            // since-revoked key). Advancing the floor is an admin-gated `_settings`
+            // write on the parent tree.
+            //
+            // FIXME(security): the floor is the only monotonicity guarantee today
+            // and is a known partial fix. It enforces neither strict per-entry
+            // non-regression (siblings above the floor may still differ) nor a
+            // forward-only gate on the committed pointer itself. Both remain to be
+            // done.
+            let floor = &delegated_tree_ref.tree.tips;
+            let floor_satisfied = current_backend
+                .targets_reachable_from(&root_id, &step.tips, floor)
+                .await
+                .map_err(|_| AuthError::InvalidDelegationTips {
+                    tree_id: root_id.clone(),
+                    claimed_tips: step.tips.clone(),
+                })?;
+            if !floor_satisfied {
                 return Err(AuthError::InvalidDelegationTips {
                     tree_id: root_id.clone(),
                     claimed_tips: step.tips.clone(),
@@ -96,17 +150,29 @@ impl DelegationResolver {
                 .into());
             }
 
-            // Get delegated tree's auth settings
-            let delegated_settings = delegated_tree.get_settings().await.map_err(|e| {
-                AuthError::InvalidAuthConfiguration {
-                    reason: format!("Failed to get delegated tree settings: {e}"),
-                }
-            })?;
-            current_auth_settings = delegated_settings.auth_snapshot().await.map_err(|e| {
-                AuthError::InvalidAuthConfiguration {
-                    reason: format!("Failed to get delegated tree auth settings: {e}"),
-                }
-            })?;
+            // Resolve the delegated tree's auth settings AS OF the claimed tips,
+            // not its live head: permissions are evaluated at the state the signer
+            // actually observed. This is safe now that the snapshot cannot regress
+            // below the committed floor. `new_transaction_at` re-validates the tips
+            // are in-tree (defence in depth) and is never committed — it is used
+            // purely as a read anchor at the pinned snapshot.
+            let pinned_txn = delegated_tree
+                .new_transaction_at(&Snapshot::from(step.tips.clone()))
+                .await
+                .map_err(|_| AuthError::InvalidDelegationTips {
+                    tree_id: root_id.clone(),
+                    claimed_tips: step.tips.clone(),
+                })?;
+            current_auth_settings =
+                pinned_txn
+                    .get_settings()?
+                    .auth_snapshot()
+                    .await
+                    .map_err(|e| AuthError::InvalidAuthConfiguration {
+                        reason: format!(
+                            "Failed to read delegated tree auth settings at claimed tips: {e}"
+                        ),
+                    })?;
 
             // Accumulate permission bounds
             cumulative_bounds = Some(match cumulative_bounds {
@@ -154,70 +220,6 @@ impl DelegationResolver {
         }
 
         Ok(matches)
-    }
-
-    /// Validate tip ancestry using backend's DAG traversal
-    ///
-    /// This method checks if claimed tips are descendants of or equal to current tips
-    /// using the backend's DAG traversal capabilities.
-    ///
-    /// # Arguments
-    /// * `claimed_tips` - Tips claimed by the entry being validated
-    /// * `current_tips` - Current tips from the backend
-    /// * `backend` - Backend to use for DAG traversal
-    async fn validate_tip_ancestry(
-        &self,
-        claimed_tips: &[ID],
-        current_tips: &[ID],
-        backend: &Arc<dyn BackendImpl>,
-    ) -> Result<bool> {
-        // Fast path: If no current tips, accept any claimed tips (first entry in tree)
-        if current_tips.is_empty() {
-            return Ok(true);
-        }
-
-        // Fast path: If no claimed tips, that's invalid (should have at least some context)
-        if claimed_tips.is_empty() {
-            return Ok(false);
-        }
-
-        // Fast path: Check if all claimed tips are identical to current tips
-        if claimed_tips.len() == current_tips.len()
-            && claimed_tips.iter().all(|tip| current_tips.contains(tip))
-        {
-            return Ok(true);
-        }
-
-        // Check if each claimed tip is either:
-        // 1. Equal to a current tip, or
-        // 2. An ancestor of a current tip (meaning we're using older but valid state)
-        // 3. A descendant of a current tip (meaning we're ahead of current state)
-
-        // Validate each claimed tip
-        for claimed_tip in claimed_tips {
-            let mut is_valid = false;
-
-            // Fast path: Check if claimed tip equals any current tip
-            if current_tips.contains(claimed_tip) {
-                is_valid = true;
-            } else {
-                // TODO: For now, we'll use a simplified check and accept the claimed tips
-                // if they exist in the tree at all. A more sophisticated implementation
-                // would verify the actual ancestry relationships using the backend's
-                // DAG traversal methods.
-
-                // Try to get the entry to verify it exists in the tree
-                if backend.get(claimed_tip).await.is_ok() {
-                    is_valid = true;
-                }
-            }
-
-            if !is_valid {
-                return Ok(false);
-            }
-        }
-
-        Ok(true)
     }
 }
 

--- a/crates/lib/src/auth/validation/entry.rs
+++ b/crates/lib/src/auth/validation/entry.rs
@@ -100,13 +100,17 @@ impl AuthValidator {
             }
         };
 
-        // FIXME(security): The claimed tips in a delegation SigKey are mostly
-        // unused. DelegationResolver::validate_tip_ancestry only checks that
-        // claimed tips exist as entries in the backend (not even tree-scoped),
-        // and then the code loads the delegated tree's *current* auth settings
-        // regardless of what tips were claimed. The claimed tips should instead
-        // determine which auth settings snapshot is used for resolution, so that
-        // permissions are evaluated at the state the signer actually observed.
+        // The claimed tips in a delegation SigKey pin resolution: the delegated
+        // tree's auth settings are read as of those tips (not its live head), and
+        // the tips may not regress below the snapshot the parent tree committed
+        // for the delegation (see DelegationResolver::resolve_delegation_path_with_depth).
+        //
+        // FIXME(security): this is the settings-pointer floor only — still a known
+        // gap. Two hardening steps remain: (1) strict per-entry non-regression
+        // (sibling entries above the committed floor can still pick different
+        // snapshots), and (2) a monotonic gate on settings writes so the committed
+        // pointer itself cannot be moved backwards. Until both land, the floor
+        // bounds regression but does not fully pin the delegated-tree snapshot.
 
         // Determine operation type from entry content
         let operation = if entry.subtrees().contains(&SETTINGS.to_string()) {

--- a/crates/lib/src/auth/validation/tests.rs
+++ b/crates/lib/src/auth/validation/tests.rs
@@ -873,3 +873,407 @@ async fn test_global_permission_vs_specific_key() {
         result2.err()
     );
 }
+
+/// Build an instance with a delegated tree (carrying `delegated_pubkey` as
+/// Admin) and a main tree that declares the delegation pinned at `floor_tips`.
+/// Returns everything needed to drive `resolve_sig_key` against it.
+async fn setup_delegation_with_floor(
+    floor_at_first_snapshot: bool,
+) -> (
+    crate::Instance,
+    Database,
+    PublicKey,
+    Vec<ID>, // snapshot 1 tips (older)
+    Vec<ID>, // snapshot 2 tips (newer)
+    AuthSettings,
+) {
+    use crate::{
+        Instance,
+        auth::types::{DelegatedTreeRef, PermissionBounds, TreeReference},
+        backend::database::InMemory,
+    };
+
+    let backend = Box::new(InMemory::new());
+    let (instance, _admin) =
+        Instance::create_backend(backend, crate::NewUser::passwordless("admin"))
+            .await
+            .expect("Failed to create test instance");
+
+    let (_, delegated_pubkey) = generate_keypair();
+
+    let delegated_tree = Database::create(
+        &instance,
+        instance.signing_key().unwrap().clone(),
+        Doc::new(),
+    )
+    .await
+    .unwrap();
+
+    // Snapshot 1: delegated user added.
+    let txn = delegated_tree.new_transaction().await.unwrap();
+    txn.get_settings()
+        .unwrap()
+        .set_auth_key(
+            &delegated_pubkey,
+            AuthKey::active(Some("delegated_user"), Permission::Admin(5)),
+        )
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
+    let snap1 = delegated_tree.snapshot().await.unwrap().into_tips();
+
+    // Snapshot 2: an unrelated settings write advances the delegated tree.
+    let txn = delegated_tree.new_transaction().await.unwrap();
+    txn.get_settings()
+        .unwrap()
+        .set_name("delegated-renamed")
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
+    let snap2 = delegated_tree.snapshot().await.unwrap().into_tips();
+    assert_ne!(snap1, snap2, "second commit must advance the tips");
+
+    let floor = if floor_at_first_snapshot {
+        snap1.clone()
+    } else {
+        snap2.clone()
+    };
+
+    let main_tree = Database::create(
+        &instance,
+        instance.signing_key().unwrap().clone(),
+        Doc::new(),
+    )
+    .await
+    .unwrap();
+    let txn = main_tree.new_transaction().await.unwrap();
+    txn.get_settings()
+        .unwrap()
+        .add_delegated_tree(DelegatedTreeRef {
+            permission_bounds: PermissionBounds {
+                max: Permission::Write(10),
+                min: Some(Permission::Read),
+            },
+            tree: TreeReference {
+                root: delegated_tree.root_id().clone(),
+                tips: floor,
+            },
+        })
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
+
+    let main_auth = main_tree
+        .get_settings()
+        .await
+        .unwrap()
+        .auth_snapshot()
+        .await
+        .unwrap();
+
+    (
+        instance,
+        delegated_tree,
+        delegated_pubkey,
+        snap1,
+        snap2,
+        main_auth,
+    )
+}
+
+/// The claimed delegated-tree snapshot must not regress below the snapshot the
+/// parent tree committed (the settings-pointer floor). Pinning at the floor (or
+/// ahead of it) resolves; pinning behind it is rejected.
+///
+/// `should_panic` documents the pre-fix flaw: today the regressed snapshot is
+/// accepted, so the `expect_err` below panics. The fix commit removes this
+/// attribute and the assertion holds for real.
+#[tokio::test]
+#[should_panic(expected = "claiming a snapshot behind the committed floor must be rejected")]
+async fn test_delegation_floor_rejects_snapshot_regression() {
+    // Floor committed at snapshot 2 (the newer state).
+    let (instance, delegated_tree, delegated_pubkey, snap1, snap2, main_auth) =
+        setup_delegation_with_floor(false).await;
+
+    // Regression: claim snapshot 1, which is an ancestor of the committed floor.
+    let regress = SigKey::Delegation {
+        path: vec![DelegationStep {
+            tree: delegated_tree.root_id().clone(),
+            tips: snap1,
+        }],
+        hint: KeyHint::from_pubkey(&delegated_pubkey),
+    };
+    let err = AuthValidator::new()
+        .resolve_sig_key(&regress, &main_auth, Some(&instance))
+        .await
+        .expect_err("claiming a snapshot behind the committed floor must be rejected");
+    assert!(
+        err.to_string().contains("Invalid delegation tips"),
+        "expected InvalidDelegationTips, got: {err}"
+    );
+
+    // At the floor: claim snapshot 2 — accepted, and resolves the delegated key.
+    let ok = SigKey::Delegation {
+        path: vec![DelegationStep {
+            tree: delegated_tree.root_id().clone(),
+            tips: snap2,
+        }],
+        hint: KeyHint::from_pubkey(&delegated_pubkey),
+    };
+    let resolved = AuthValidator::new()
+        .resolve_sig_key(&ok, &main_auth, Some(&instance))
+        .await
+        .expect("claiming the committed snapshot must resolve");
+    assert_eq!(resolved.len(), 1);
+    // Admin(5) clamped to the delegation's Write(10) bound.
+    assert_eq!(resolved[0].effective_permission, Permission::Write(10));
+}
+
+/// Tips pin resolution to the observed snapshot: a key that exists only at the
+/// newer snapshot is invisible when the entry pins the older one (floor at S1).
+#[tokio::test]
+async fn test_delegation_resolves_settings_at_claimed_tips() {
+    let (instance, delegated_tree, delegated_pubkey, snap1, _snap2, main_auth) =
+        setup_delegation_with_floor(true).await;
+
+    // Pinning exactly at the floor (snap1) resolves the key present there.
+    let sig = SigKey::Delegation {
+        path: vec![DelegationStep {
+            tree: delegated_tree.root_id().clone(),
+            tips: snap1,
+        }],
+        hint: KeyHint::from_pubkey(&delegated_pubkey),
+    };
+    let resolved = AuthValidator::new()
+        .resolve_sig_key(&sig, &main_auth, Some(&instance))
+        .await
+        .expect("resolution at the pinned snapshot should succeed");
+    assert_eq!(resolved.len(), 1);
+    assert_eq!(resolved[0].key_status, KeyStatus::Active);
+}
+
+/// F5a: a delegation path longer than the cap is rejected before backend work.
+///
+/// `should_panic` documents the pre-fix behaviour: the over-long path is still
+/// rejected today, but only incidentally and *after* walking the chain (it
+/// surfaces as a downstream `Delegation not found` rather than an up-front
+/// bound), so the cap-specific assertion fails. The fix adds the early cap and
+/// removes this attribute. Unlike the foreign-tip / floor / live-head tests,
+/// this is amplification hardening, not an accept-vs-reject auth bypass.
+#[tokio::test]
+#[should_panic(expected = "expected DelegationPathTooLong, got:")]
+async fn test_delegation_path_length_capped() {
+    let (instance, delegated_tree, delegated_pubkey, _s1, snap2, main_auth) =
+        setup_delegation_with_floor(false).await;
+
+    let step = DelegationStep {
+        tree: delegated_tree.root_id().clone(),
+        tips: snap2,
+    };
+    // 11 steps > MAX_DELEGATION_STEPS (10).
+    let sig = SigKey::Delegation {
+        path: vec![step; 11],
+        hint: KeyHint::from_pubkey(&delegated_pubkey),
+    };
+    let err = AuthValidator::new()
+        .resolve_sig_key(&sig, &main_auth, Some(&instance))
+        .await
+        .expect_err("over-long delegation path must be rejected");
+    assert!(
+        err.to_string().contains("Delegation path too long"),
+        "expected DelegationPathTooLong, got: {err}"
+    );
+}
+
+/// F5a: a step claiming more tips than the cap is rejected before backend work.
+///
+/// `should_panic` documents the pre-fix behaviour: the fabricated tips are still
+/// rejected today, but only *after* backend traversal (as `InvalidDelegationTips`
+/// "don't match") rather than by an up-front per-step bound, so the cap-specific
+/// assertion fails. The fix adds the early cap and removes this attribute. Like
+/// the path test, this is amplification hardening, not an auth bypass.
+#[tokio::test]
+#[should_panic(expected = "expected DelegationTipsTooMany, got:")]
+async fn test_delegation_tips_count_capped() {
+    let (instance, delegated_tree, delegated_pubkey, _s1, _s2, main_auth) =
+        setup_delegation_with_floor(false).await;
+
+    // 65 fabricated tips > MAX_DELEGATION_TIPS (64). The cap fires before any
+    // backend traversal, so the tips not existing is irrelevant.
+    let tips: Vec<ID> = (0u16..65)
+        .map(|i| ID::from_bytes(i.to_le_bytes()))
+        .collect();
+    let sig = SigKey::Delegation {
+        path: vec![DelegationStep {
+            tree: delegated_tree.root_id().clone(),
+            tips,
+        }],
+        hint: KeyHint::from_pubkey(&delegated_pubkey),
+    };
+    let err = AuthValidator::new()
+        .resolve_sig_key(&sig, &main_auth, Some(&instance))
+        .await
+        .expect_err("over-large tip set must be rejected");
+    assert!(
+        err.to_string().contains("too many tips"),
+        "expected DelegationTipsTooMany, got: {err}"
+    );
+}
+
+/// F5b-1: a claimed tip that is a real entry of *another* tree is rejected.
+/// The prior `backend.get().is_ok()` check accepted any entry that existed
+/// anywhere in the backend; the tree-scoped check rejects it.
+///
+/// `should_panic` documents the pre-fix flaw: the foreign tip is accepted today,
+/// so the `expect_err` panics. The fix commit removes this attribute.
+#[tokio::test]
+#[should_panic(expected = "a tip from another tree must be rejected")]
+async fn test_delegation_rejects_foreign_tip() {
+    let (instance, delegated_tree, delegated_pubkey, _s1, _s2, main_auth) =
+        setup_delegation_with_floor(false).await;
+
+    // A separate, real tree. Its root is a genuine backend entry (so the old
+    // existence-only check would have passed) but it does not belong to the
+    // delegated tree.
+    let other_tree = Database::create(
+        &instance,
+        instance.signing_key().unwrap().clone(),
+        Doc::new(),
+    )
+    .await
+    .unwrap();
+    let foreign_tip = other_tree.root_id().clone();
+
+    let sig = SigKey::Delegation {
+        path: vec![DelegationStep {
+            tree: delegated_tree.root_id().clone(),
+            tips: vec![foreign_tip],
+        }],
+        hint: KeyHint::from_pubkey(&delegated_pubkey),
+    };
+    let err = AuthValidator::new()
+        .resolve_sig_key(&sig, &main_auth, Some(&instance))
+        .await
+        .expect_err("a tip from another tree must be rejected");
+    assert!(
+        err.to_string().contains("Invalid delegation tips"),
+        "expected InvalidDelegationTips, got: {err}"
+    );
+}
+
+/// Tips pin the *auth state*, not merely tip identity: when the delegated key is
+/// downgraded at a newer snapshot, an entry pinning the older snapshot must still
+/// resolve with the older (higher) permission. This is the regression test for
+/// "claimed tips were ignored" -- pre-fix, resolution read the delegated tree's
+/// live head and saw the downgrade regardless of which tips the signer claimed.
+///
+/// `should_panic` documents the pre-fix flaw: resolution reads the live-head
+/// Read downgrade instead of the pinned Admin(5), so the assertion panics. The
+/// fix commit removes this attribute.
+#[tokio::test]
+#[should_panic(expected = "pinned tips must resolve the Admin(5) state")]
+async fn test_delegation_reads_auth_state_at_pinned_tips_not_live_head() {
+    use crate::{
+        Instance,
+        auth::types::{DelegatedTreeRef, PermissionBounds, TreeReference},
+        backend::database::InMemory,
+    };
+
+    let backend = Box::new(InMemory::new());
+    let (instance, _admin) =
+        Instance::create_backend(backend, crate::NewUser::passwordless("admin"))
+            .await
+            .unwrap();
+
+    let (_, delegated_pubkey) = generate_keypair();
+
+    let delegated_tree = Database::create(
+        &instance,
+        instance.signing_key().unwrap().clone(),
+        Doc::new(),
+    )
+    .await
+    .unwrap();
+
+    // Snapshot 1: the delegated key is Admin(5).
+    let txn = delegated_tree.new_transaction().await.unwrap();
+    txn.get_settings()
+        .unwrap()
+        .set_auth_key(
+            &delegated_pubkey,
+            AuthKey::active(Some("delegated_user"), Permission::Admin(5)),
+        )
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
+    let snap1 = delegated_tree.snapshot().await.unwrap().into_tips();
+
+    // Snapshot 2: the SAME key is downgraded to Read on the live head.
+    let txn = delegated_tree.new_transaction().await.unwrap();
+    txn.get_settings()
+        .unwrap()
+        .set_auth_key(
+            &delegated_pubkey,
+            AuthKey::active(Some("delegated_user"), Permission::Read),
+        )
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
+    let snap2 = delegated_tree.snapshot().await.unwrap().into_tips();
+    assert_ne!(snap1, snap2, "the downgrade commit must advance the tips");
+
+    // Floor committed at snapshot 1, so pinning snapshot 1 sits exactly at the
+    // floor (allowed by the monotonicity check) while still being behind the
+    // live head.
+    let main_tree = Database::create(
+        &instance,
+        instance.signing_key().unwrap().clone(),
+        Doc::new(),
+    )
+    .await
+    .unwrap();
+    let txn = main_tree.new_transaction().await.unwrap();
+    txn.get_settings()
+        .unwrap()
+        .add_delegated_tree(DelegatedTreeRef {
+            permission_bounds: PermissionBounds {
+                max: Permission::Write(10),
+                min: Some(Permission::Read),
+            },
+            tree: TreeReference {
+                root: delegated_tree.root_id().clone(),
+                tips: snap1.clone(),
+            },
+        })
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
+    let main_auth = main_tree
+        .get_settings()
+        .await
+        .unwrap()
+        .auth_snapshot()
+        .await
+        .unwrap();
+
+    // Pin snapshot 1, where the key is Admin(5). Resolution must read auth state
+    // AS OF the pinned tips: Admin(5) clamped to the Write(10) bound -- NOT the
+    // live-head Read downgrade.
+    let sig = SigKey::Delegation {
+        path: vec![DelegationStep {
+            tree: delegated_tree.root_id().clone(),
+            tips: snap1,
+        }],
+        hint: KeyHint::from_pubkey(&delegated_pubkey),
+    };
+    let resolved = AuthValidator::new()
+        .resolve_sig_key(&sig, &main_auth, Some(&instance))
+        .await
+        .expect("resolution at the pinned snapshot should succeed");
+    assert_eq!(resolved.len(), 1);
+    assert_eq!(
+        resolved[0].effective_permission,
+        Permission::Write(10),
+        "pinned tips must resolve the Admin(5) state at snapshot 1, not the live-head Read downgrade"
+    );
+}

--- a/crates/lib/src/auth/validation/tests.rs
+++ b/crates/lib/src/auth/validation/tests.rs
@@ -984,12 +984,7 @@ async fn setup_delegation_with_floor(
 /// The claimed delegated-tree snapshot must not regress below the snapshot the
 /// parent tree committed (the settings-pointer floor). Pinning at the floor (or
 /// ahead of it) resolves; pinning behind it is rejected.
-///
-/// `should_panic` documents the pre-fix flaw: today the regressed snapshot is
-/// accepted, so the `expect_err` below panics. The fix commit removes this
-/// attribute and the assertion holds for real.
 #[tokio::test]
-#[should_panic(expected = "claiming a snapshot behind the committed floor must be rejected")]
 async fn test_delegation_floor_rejects_snapshot_regression() {
     // Floor committed at snapshot 2 (the newer state).
     let (instance, delegated_tree, delegated_pubkey, snap1, snap2, main_auth) =
@@ -1053,15 +1048,7 @@ async fn test_delegation_resolves_settings_at_claimed_tips() {
 }
 
 /// F5a: a delegation path longer than the cap is rejected before backend work.
-///
-/// `should_panic` documents the pre-fix behaviour: the over-long path is still
-/// rejected today, but only incidentally and *after* walking the chain (it
-/// surfaces as a downstream `Delegation not found` rather than an up-front
-/// bound), so the cap-specific assertion fails. The fix adds the early cap and
-/// removes this attribute. Unlike the foreign-tip / floor / live-head tests,
-/// this is amplification hardening, not an accept-vs-reject auth bypass.
 #[tokio::test]
-#[should_panic(expected = "expected DelegationPathTooLong, got:")]
 async fn test_delegation_path_length_capped() {
     let (instance, delegated_tree, delegated_pubkey, _s1, snap2, main_auth) =
         setup_delegation_with_floor(false).await;
@@ -1086,14 +1073,7 @@ async fn test_delegation_path_length_capped() {
 }
 
 /// F5a: a step claiming more tips than the cap is rejected before backend work.
-///
-/// `should_panic` documents the pre-fix behaviour: the fabricated tips are still
-/// rejected today, but only *after* backend traversal (as `InvalidDelegationTips`
-/// "don't match") rather than by an up-front per-step bound, so the cap-specific
-/// assertion fails. The fix adds the early cap and removes this attribute. Like
-/// the path test, this is amplification hardening, not an auth bypass.
 #[tokio::test]
-#[should_panic(expected = "expected DelegationTipsTooMany, got:")]
 async fn test_delegation_tips_count_capped() {
     let (instance, delegated_tree, delegated_pubkey, _s1, _s2, main_auth) =
         setup_delegation_with_floor(false).await;
@@ -1123,11 +1103,7 @@ async fn test_delegation_tips_count_capped() {
 /// F5b-1: a claimed tip that is a real entry of *another* tree is rejected.
 /// The prior `backend.get().is_ok()` check accepted any entry that existed
 /// anywhere in the backend; the tree-scoped check rejects it.
-///
-/// `should_panic` documents the pre-fix flaw: the foreign tip is accepted today,
-/// so the `expect_err` panics. The fix commit removes this attribute.
 #[tokio::test]
-#[should_panic(expected = "a tip from another tree must be rejected")]
 async fn test_delegation_rejects_foreign_tip() {
     let (instance, delegated_tree, delegated_pubkey, _s1, _s2, main_auth) =
         setup_delegation_with_floor(false).await;
@@ -1166,12 +1142,7 @@ async fn test_delegation_rejects_foreign_tip() {
 /// resolve with the older (higher) permission. This is the regression test for
 /// "claimed tips were ignored" -- pre-fix, resolution read the delegated tree's
 /// live head and saw the downgrade regardless of which tips the signer claimed.
-///
-/// `should_panic` documents the pre-fix flaw: resolution reads the live-head
-/// Read downgrade instead of the pinned Admin(5), so the assertion panics. The
-/// fix commit removes this attribute.
 #[tokio::test]
-#[should_panic(expected = "pinned tips must resolve the Admin(5) state")]
 async fn test_delegation_reads_auth_state_at_pinned_tips_not_live_head() {
     use crate::{
         Instance,

--- a/crates/lib/src/auth/validation/tests.rs
+++ b/crates/lib/src/auth/validation/tests.rs
@@ -1248,3 +1248,48 @@ async fn test_delegation_reads_auth_state_at_pinned_tips_not_live_head() {
         "pinned tips must resolve the Admin(5) state at snapshot 1, not the live-head Read downgrade"
     );
 }
+
+/// A delegation whose claimed tips are not present locally cannot be decided:
+/// resolution must surface a *retriable* `DelegatedTreeUnsynced` carrying the
+/// missing entries as a want-list — NOT an `InvalidDelegationTips` forgery
+/// rejection. This is the caller-side wiring of `Reachability::Indeterminate`:
+/// the entry stays unverifiable-for-now and is re-checked once `missing` syncs.
+#[tokio::test]
+async fn test_delegation_indeterminate_when_tips_unsynced() {
+    use crate::auth::errors::AuthError;
+
+    let (instance, delegated_tree, delegated_pubkey, _s1, _s2, main_auth) =
+        setup_delegation_with_floor(false).await;
+
+    // A claimed tip that exists nowhere in the local backend.
+    let ghost = ID::from_bytes("unsynced-tip");
+    let sig = SigKey::Delegation {
+        path: vec![DelegationStep {
+            tree: delegated_tree.root_id().clone(),
+            tips: vec![ghost.clone()],
+        }],
+        hint: KeyHint::from_pubkey(&delegated_pubkey),
+    };
+
+    let err = AuthValidator::new()
+        .resolve_sig_key(&sig, &main_auth, Some(&instance))
+        .await
+        .expect_err("unsynced claimed tips must not resolve");
+
+    // Must be the retriable sync-state signal, and must hand back the exact
+    // want-list so a re-verification pass knows what to fetch.
+    match err {
+        Error::Auth(ref boxed) => match &**boxed {
+            AuthError::DelegatedTreeUnsynced { missing, .. } => {
+                assert_eq!(missing, &vec![ghost], "want-list must name the missing tip");
+                assert!(
+                    !boxed.is_delegation_error(),
+                    "unsynced is a transient state, not a delegation defect"
+                );
+                assert!(boxed.is_delegated_tree_unsynced());
+            }
+            other => panic!("expected DelegatedTreeUnsynced, got: {other:?}"),
+        },
+        other => panic!("expected Auth error, got: {other:?}"),
+    }
+}

--- a/crates/lib/src/backend/mod.rs
+++ b/crates/lib/src/backend/mod.rs
@@ -125,6 +125,34 @@ pub mod errors;
 // Re-export main types for easier access
 pub use errors::BackendError;
 
+/// Verdict of a bounded, tree-scoped reachability query
+/// ([`check_targets_reachable_from`](BackendImpl::check_targets_reachable_from)).
+///
+/// The three states exist so a caller can tell a *proven* negative apart from
+/// "not enough local history to decide" — a distinction that matters for a sync
+/// system, where the latter is transient and self-heals once more of the tree
+/// arrives.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Reachability {
+    /// Every target is an ancestor-or-equal of some `from` entry, proven
+    /// against fully-present history within the height bound.
+    Reachable,
+    /// Proven negative: the region at or above the target floor was fully
+    /// present locally and at least one target is not an ancestor of `from`
+    /// (e.g. a snapshot regression, or a foreign/fabricated tip).
+    Unreachable,
+    /// Undecidable from local history: a target, a `from` tip, or an ancestor
+    /// needed to reach a target is missing locally. `missing` is the set of
+    /// entries whose absence blocked the decision — the caller should sync
+    /// these and re-check. It is the current blocking *frontier*, not
+    /// necessarily the whole gap: fetching it may reveal a further layer. The
+    /// height bound keeps this set small.
+    Indeterminate {
+        /// Entries that must be synced before the query can be decided.
+        missing: Vec<ID>,
+    },
+}
+
 /// Verification status for entries in the backend.
 ///
 /// This enum tracks whether an entry has been cryptographically verified
@@ -440,74 +468,141 @@ pub trait BackendImpl: Send + Sync + Any {
     /// - `EntryNotInTree` if any tip belongs to a different tree
     async fn get_tree_from_tips(&self, tree: &ID, tips: &[ID]) -> Result<Vec<Entry>>;
 
-    /// Within `tree`, report whether every entry in `targets` is reachable by
-    /// walking parent pointers back from `from` — i.e. each target is an
-    /// ancestor-or-equal of at least one `from` entry.
+    /// Within `tree`, decide whether every entry in `targets` is an
+    /// ancestor-or-equal of some entry in `from` — i.e. whether the `from`
+    /// snapshot is at-or-ahead-of the `targets` snapshot.
     ///
-    /// This is the cheap, boolean counterpart to
-    /// [`get_tree_from_tips`](Self::get_tree_from_tips): the walk is **bounded**,
-    /// stopping the moment every target has been seen, so the cost tracks the
-    /// distance from `from` back to the targets rather than the size of the tree.
-    /// Prefer it whenever a reachability answer is all that's needed — e.g. an
-    /// "is this snapshot at-or-ahead-of that one" check — instead of
-    /// materialising the entire ancestor set.
+    /// Returns a three-state [`Reachability`] rather than a bare bool so a
+    /// *proven* negative is distinguishable from "not enough local history to
+    /// decide" (see [`Reachability::Indeterminate`]). This is the cheap
+    /// counterpart to [`get_tree_from_tips`](Self::get_tree_from_tips) when only
+    /// an at-or-ahead-of answer is needed, not the materialised ancestor set.
     ///
-    /// `from` entries count as reachable (a target equal to a `from` entry is
-    /// reached), and an empty `targets` is vacuously reachable. Each `from` entry
-    /// is validated to be a real entry of `tree`; ancestors encountered during
-    /// the walk that are missing locally or belong to another tree are skipped
-    /// rather than erroring (a partially-synced history simply yields the tips it
-    /// can reach).
+    /// **Bounded by the target floor.** The walk never descends below the
+    /// minimum target height: an entry below every remaining target cannot be
+    /// one, nor reach one through still-lower parents (parent heights strictly
+    /// decrease). Cost therefore tracks the height gap between `from` and
+    /// `targets` on *both* the reachable and unreachable paths, not the size of
+    /// the tree — which matters because this runs on every delegated-entry
+    /// validation (and re-validation).
+    ///
+    /// **Validation is symmetric.** Both `from` and `targets` are checked to be
+    /// real entries of `tree`. An entry that exists but belongs to another tree
+    /// is a `from`/target integrity violation and errors. An entry that is
+    /// *missing locally* is not a negative: it makes the verdict
+    /// [`Indeterminate`](Reachability::Indeterminate) and is reported in
+    /// `missing`, so a partially-synced history is never mistaken for a
+    /// regression. Membership is *presence in the tree*, not
+    /// `VerificationStatus::Verified`.
+    ///
+    /// A target equal to a `from` entry is reached; an empty `targets` is
+    /// vacuously [`Reachable`](Reachability::Reachable).
     ///
     /// # Errors
-    /// - `EntryNotFound` if any `from` entry doesn't exist locally
-    /// - `EntryNotInTree` if any `from` entry belongs to a different tree
+    /// - `EntryNotInTree` if any `from` or `targets` entry exists but belongs to
+    ///   a different tree
     ///
     /// The default implementation performs the walk via [`get`](Self::get); a
     /// backend may override it with a single-query traversal.
-    async fn targets_reachable_from(&self, tree: &ID, from: &[ID], targets: &[ID]) -> Result<bool> {
+    async fn check_targets_reachable_from(
+        &self,
+        tree: &ID,
+        from: &[ID],
+        targets: &[ID],
+    ) -> Result<Reachability> {
         use std::collections::HashSet;
 
-        let mut unmet: HashSet<ID> = targets.iter().cloned().collect();
+        // An empty `from` snapshot dominates nothing: any required target is
+        // definitively unreachable. This is a *proven* negative, not
+        // Indeterminate — no amount of syncing lets an empty claim catch up to a
+        // non-empty floor, so we never load the targets to decide it.
+        if from.is_empty() && !targets.is_empty() {
+            return Ok(Reachability::Unreachable);
+        }
+
+        // Validate targets and take the height floor. A target that EXISTS but
+        // is foreign is an integrity violation; a MISSING target means we can't
+        // establish the floor, so it becomes a want-list item (Indeterminate),
+        // never a silent negative.
+        let mut unmet: HashSet<ID> = HashSet::with_capacity(targets.len());
+        let mut missing: Vec<ID> = Vec::new();
+        let mut floor_height = u64::MAX;
+        for target in targets {
+            match self.get(target).await {
+                Ok(entry) => {
+                    if !entry.in_tree(tree) {
+                        return Err(BackendError::EntryNotInTree {
+                            entry_id: target.clone(),
+                            tree_id: tree.clone(),
+                        }
+                        .into());
+                    }
+                    floor_height = floor_height.min(entry.height());
+                    unmet.insert(target.clone());
+                }
+                Err(_) => {
+                    unmet.insert(target.clone());
+                    missing.push(target.clone());
+                }
+            }
+        }
+
         let mut visited: HashSet<ID> = HashSet::with_capacity(from.len());
         let mut stack: Vec<ID> = Vec::new();
 
-        // Seed with `from`, validating tree membership on each.
+        // Seed with `from`: a foreign tip is a forgery (error); a missing tip is
+        // a want-list item. Only expand parents of entries above the floor.
         for tip in from {
-            let entry = self.get(tip).await?;
-            if !entry.in_tree(tree) {
-                return Err(BackendError::EntryNotInTree {
-                    entry_id: tip.clone(),
-                    tree_id: tree.clone(),
+            match self.get(tip).await {
+                Ok(entry) => {
+                    if !entry.in_tree(tree) {
+                        return Err(BackendError::EntryNotInTree {
+                            entry_id: tip.clone(),
+                            tree_id: tree.clone(),
+                        }
+                        .into());
+                    }
+                    if visited.insert(tip.clone()) {
+                        unmet.remove(tip);
+                        if entry.height() > floor_height {
+                            stack.extend(entry.parents()?);
+                        }
+                    }
                 }
-                .into());
-            }
-            if visited.insert(tip.clone()) {
-                unmet.remove(tip);
-                stack.extend(entry.parents().unwrap_or_default());
+                Err(_) => missing.push(tip.clone()),
             }
         }
 
-        // Walk ancestors until every target is reached, or the history is
-        // exhausted (a target that is never seen is not an ancestor → false).
+        // Bounded ancestor walk. A foreign ancestor is simply not part of this
+        // tree's history (skip); a missing one blocks the decision (want-list).
         while !unmet.is_empty() {
-            let Some(current) = stack.pop() else {
-                return Ok(false);
-            };
+            let Some(current) = stack.pop() else { break };
             if !visited.insert(current.clone()) {
                 continue;
             }
-            let Ok(entry) = self.get(&current).await else {
-                continue;
-            };
-            if !entry.in_tree(tree) {
-                continue;
+            match self.get(&current).await {
+                Ok(entry) => {
+                    if !entry.in_tree(tree) {
+                        continue;
+                    }
+                    unmet.remove(&current);
+                    if entry.height() > floor_height {
+                        stack.extend(entry.parents()?);
+                    }
+                }
+                Err(_) => missing.push(current.clone()),
             }
-            unmet.remove(&current);
-            stack.extend(entry.parents().unwrap_or_default());
         }
 
-        Ok(true)
+        Ok(if unmet.is_empty() {
+            Reachability::Reachable
+        } else if !missing.is_empty() {
+            missing.sort();
+            missing.dedup();
+            Reachability::Indeterminate { missing }
+        } else {
+            Reachability::Unreachable
+        })
     }
 
     /// Retrieves all entries belonging to a specific store at the given snapshot, sorted topologically.

--- a/crates/lib/src/backend/mod.rs
+++ b/crates/lib/src/backend/mod.rs
@@ -440,6 +440,76 @@ pub trait BackendImpl: Send + Sync + Any {
     /// - `EntryNotInTree` if any tip belongs to a different tree
     async fn get_tree_from_tips(&self, tree: &ID, tips: &[ID]) -> Result<Vec<Entry>>;
 
+    /// Within `tree`, report whether every entry in `targets` is reachable by
+    /// walking parent pointers back from `from` — i.e. each target is an
+    /// ancestor-or-equal of at least one `from` entry.
+    ///
+    /// This is the cheap, boolean counterpart to
+    /// [`get_tree_from_tips`](Self::get_tree_from_tips): the walk is **bounded**,
+    /// stopping the moment every target has been seen, so the cost tracks the
+    /// distance from `from` back to the targets rather than the size of the tree.
+    /// Prefer it whenever a reachability answer is all that's needed — e.g. an
+    /// "is this snapshot at-or-ahead-of that one" check — instead of
+    /// materialising the entire ancestor set.
+    ///
+    /// `from` entries count as reachable (a target equal to a `from` entry is
+    /// reached), and an empty `targets` is vacuously reachable. Each `from` entry
+    /// is validated to be a real entry of `tree`; ancestors encountered during
+    /// the walk that are missing locally or belong to another tree are skipped
+    /// rather than erroring (a partially-synced history simply yields the tips it
+    /// can reach).
+    ///
+    /// # Errors
+    /// - `EntryNotFound` if any `from` entry doesn't exist locally
+    /// - `EntryNotInTree` if any `from` entry belongs to a different tree
+    ///
+    /// The default implementation performs the walk via [`get`](Self::get); a
+    /// backend may override it with a single-query traversal.
+    async fn targets_reachable_from(&self, tree: &ID, from: &[ID], targets: &[ID]) -> Result<bool> {
+        use std::collections::HashSet;
+
+        let mut unmet: HashSet<ID> = targets.iter().cloned().collect();
+        let mut visited: HashSet<ID> = HashSet::with_capacity(from.len());
+        let mut stack: Vec<ID> = Vec::new();
+
+        // Seed with `from`, validating tree membership on each.
+        for tip in from {
+            let entry = self.get(tip).await?;
+            if !entry.in_tree(tree) {
+                return Err(BackendError::EntryNotInTree {
+                    entry_id: tip.clone(),
+                    tree_id: tree.clone(),
+                }
+                .into());
+            }
+            if visited.insert(tip.clone()) {
+                unmet.remove(tip);
+                stack.extend(entry.parents().unwrap_or_default());
+            }
+        }
+
+        // Walk ancestors until every target is reached, or the history is
+        // exhausted (a target that is never seen is not an ancestor → false).
+        while !unmet.is_empty() {
+            let Some(current) = stack.pop() else {
+                return Ok(false);
+            };
+            if !visited.insert(current.clone()) {
+                continue;
+            }
+            let Ok(entry) = self.get(&current).await else {
+                continue;
+            };
+            if !entry.in_tree(tree) {
+                continue;
+            }
+            unmet.remove(&current);
+            stack.extend(entry.parents().unwrap_or_default());
+        }
+
+        Ok(true)
+    }
+
     /// Retrieves all entries belonging to a specific store at the given snapshot, sorted topologically.
     ///
     /// Returns entries that are ancestors of the provided store snapshot's tips.

--- a/crates/lib/tests/it/auth/delegated_trees.rs
+++ b/crates/lib/tests/it/auth/delegated_trees.rs
@@ -389,10 +389,10 @@ async fn test_delegation_depth_limits() -> Result<()> {
     txn.commit().await?;
 
     // Create a deeply nested delegation that should exceed the limit
-    // We'll create a chain with 12 levels (exceeds MAX_DELEGATION_DEPTH of 10)
+    // We'll create a chain with 12 levels (exceeds MAX_DELEGATION_STEPS of 10)
     let mut delegation_steps = Vec::new();
 
-    // Add 12 intermediate delegation steps (exceeds MAX_DELEGATION_DEPTH of 10)
+    // Add 12 intermediate delegation steps (exceeds MAX_DELEGATION_STEPS of 10)
     for _ in 0..12 {
         delegation_steps.push(DelegationStep {
             tree: delegated_tree_root.clone(),
@@ -414,7 +414,14 @@ async fn test_delegation_depth_limits() -> Result<()> {
 
     assert!(result.is_err());
     let error_msg = result.unwrap_err().to_string();
-    assert!(error_msg.contains("Maximum delegation depth") || error_msg.contains("not found"));
+    // The path-length cap rejects the over-limit chain up front; the older
+    // "Maximum delegation depth" / "not found" branches remain valid fallbacks.
+    assert!(
+        error_msg.contains("Delegation path too long")
+            || error_msg.contains("Maximum delegation depth")
+            || error_msg.contains("not found"),
+        "unexpected error for over-limit delegation chain: {error_msg}"
+    );
 
     Ok(())
 }

--- a/crates/lib/tests/it/backend/tree_operations.rs
+++ b/crates/lib/tests/it/backend/tree_operations.rs
@@ -200,6 +200,118 @@ async fn test_backend_get_tree_from_tips() {
 }
 
 #[tokio::test]
+async fn test_backend_targets_reachable_from() {
+    let backend = test_backend().await;
+    let root_id = ID::from_bytes("tree_root");
+
+    // Same DAG as above: root -> e1 -> {e2a, e2b}
+    let root_entry = Entry::builder(root_id.clone())
+        .add_parent(root_id.clone())
+        .set_height(0)
+        .build()
+        .expect("root builds");
+    let root_entry_id = root_entry.id();
+    backend.put_verified(root_entry).await.unwrap();
+
+    let e1_entry = Entry::builder(root_id.clone())
+        .add_parent(root_entry_id.clone())
+        .set_height(1)
+        .build()
+        .expect("e1 builds");
+    let e1_id = e1_entry.id();
+    backend.put_verified(e1_entry).await.unwrap();
+
+    let e2a_entry = Entry::builder(root_id.clone())
+        .add_parent(e1_id.clone())
+        .set_subtree_data("branch", b"a")
+        .set_height(2)
+        .build()
+        .expect("e2a builds");
+    let e2a_id = e2a_entry.id();
+    backend.put_verified(e2a_entry).await.unwrap();
+
+    let e2b_entry = Entry::builder(root_id.clone())
+        .add_parent(e1_id.clone())
+        .set_subtree_data("branch", b"b")
+        .set_height(2)
+        .build()
+        .expect("e2b builds");
+    let e2b_id = e2b_entry.id();
+    backend.put_verified(e2b_entry).await.unwrap();
+
+    let reachable = |from: Vec<ID>, targets: Vec<ID>| {
+        let backend = &backend;
+        let root_id = root_id.clone();
+        async move {
+            backend
+                .targets_reachable_from(&root_id, &from, &targets)
+                .await
+        }
+    };
+
+    // Ancestors are reachable from a tip.
+    assert!(
+        reachable(vec![e2a_id.clone()], vec![root_entry_id.clone()])
+            .await
+            .unwrap()
+    );
+    assert!(
+        reachable(
+            vec![e2a_id.clone()],
+            vec![e1_id.clone(), root_entry_id.clone()]
+        )
+        .await
+        .unwrap(),
+        "all of {{e1, root}} are ancestors of e2a"
+    );
+    // A tip reaches itself (ancestor-or-equal).
+    assert!(
+        reachable(vec![e2a_id.clone()], vec![e2a_id.clone()])
+            .await
+            .unwrap()
+    );
+    // An empty target set is vacuously reachable.
+    assert!(reachable(vec![e2a_id.clone()], vec![]).await.unwrap());
+
+    // A sibling is NOT an ancestor: e2b is unreachable from e2a alone...
+    assert!(
+        !reachable(vec![e2a_id.clone()], vec![e2b_id.clone()])
+            .await
+            .unwrap(),
+        "e2b is concurrent with e2a, not an ancestor"
+    );
+    // ...but reachable once both tips are in the `from` set.
+    assert!(
+        reachable(
+            vec![e2a_id.clone(), e2b_id.clone()],
+            vec![e2b_id.clone(), e1_id.clone()]
+        )
+        .await
+        .unwrap()
+    );
+
+    // A `from` tip that doesn't exist errors (EntryNotFound).
+    let err = reachable(vec![ID::from_bytes("nope")], vec![root_entry_id.clone()])
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, Error::Backend(ref e) if matches!(**e, BackendError::EntryNotFound { .. })),
+        "expected EntryNotFound, got: {err:?}"
+    );
+
+    // A `from` tip from another tree errors (EntryNotInTree).
+    let bad_root: ID = ID::from_bytes("bad_root");
+    let err = backend
+        .targets_reachable_from(&bad_root, std::slice::from_ref(&e1_id), &[])
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, Error::Backend(ref e) if matches!(**e, BackendError::EntryNotInTree { .. })),
+        "expected EntryNotInTree, got: {err:?}"
+    );
+}
+
+#[tokio::test]
 async fn test_snapshot() {
     let backend = test_backend().await;
 

--- a/crates/lib/tests/it/backend/tree_operations.rs
+++ b/crates/lib/tests/it/backend/tree_operations.rs
@@ -1,4 +1,5 @@
 use eidetica::Error;
+use eidetica::backend::Reachability;
 use eidetica::backend::database::InMemory;
 use eidetica::backend::errors::BackendError;
 use eidetica::entry::{Entry, ID};
@@ -200,7 +201,7 @@ async fn test_backend_get_tree_from_tips() {
 }
 
 #[tokio::test]
-async fn test_backend_targets_reachable_from() {
+async fn test_backend_check_targets_reachable_from() {
     let backend = test_backend().await;
     let root_id = ID::from_bytes("tree_root");
 
@@ -244,65 +245,100 @@ async fn test_backend_targets_reachable_from() {
         let root_id = root_id.clone();
         async move {
             backend
-                .targets_reachable_from(&root_id, &from, &targets)
+                .check_targets_reachable_from(&root_id, &from, &targets)
                 .await
         }
     };
 
     // Ancestors are reachable from a tip.
-    assert!(
+    assert_eq!(
         reachable(vec![e2a_id.clone()], vec![root_entry_id.clone()])
             .await
-            .unwrap()
+            .unwrap(),
+        Reachability::Reachable
     );
-    assert!(
+    assert_eq!(
         reachable(
             vec![e2a_id.clone()],
             vec![e1_id.clone(), root_entry_id.clone()]
         )
         .await
         .unwrap(),
+        Reachability::Reachable,
         "all of {{e1, root}} are ancestors of e2a"
     );
     // A tip reaches itself (ancestor-or-equal).
-    assert!(
+    assert_eq!(
         reachable(vec![e2a_id.clone()], vec![e2a_id.clone()])
             .await
-            .unwrap()
+            .unwrap(),
+        Reachability::Reachable
     );
     // An empty target set is vacuously reachable.
-    assert!(reachable(vec![e2a_id.clone()], vec![]).await.unwrap());
+    assert_eq!(
+        reachable(vec![e2a_id.clone()], vec![]).await.unwrap(),
+        Reachability::Reachable
+    );
 
-    // A sibling is NOT an ancestor: e2b is unreachable from e2a alone...
-    assert!(
-        !reachable(vec![e2a_id.clone()], vec![e2b_id.clone()])
+    // A sibling is NOT an ancestor: e2b is provably unreachable from e2a
+    // alone (all history present, so a definite negative, not Indeterminate)...
+    assert_eq!(
+        reachable(vec![e2a_id.clone()], vec![e2b_id.clone()])
             .await
             .unwrap(),
+        Reachability::Unreachable,
         "e2b is concurrent with e2a, not an ancestor"
     );
     // ...but reachable once both tips are in the `from` set.
-    assert!(
+    assert_eq!(
         reachable(
             vec![e2a_id.clone(), e2b_id.clone()],
             vec![e2b_id.clone(), e1_id.clone()]
         )
         .await
-        .unwrap()
+        .unwrap(),
+        Reachability::Reachable
     );
 
-    // A `from` tip that doesn't exist errors (EntryNotFound).
-    let err = reachable(vec![ID::from_bytes("nope")], vec![root_entry_id.clone()])
-        .await
-        .unwrap_err();
-    assert!(
-        matches!(err, Error::Backend(ref e) if matches!(**e, BackendError::EntryNotFound { .. })),
-        "expected EntryNotFound, got: {err:?}"
+    // A `from` tip that doesn't exist is NOT a negative: it can't be decided
+    // locally, so the verdict is Indeterminate and the missing tip is reported
+    // as a want-list item (rather than the old EntryNotFound error).
+    let ghost_from = ID::from_bytes("nope");
+    assert_eq!(
+        reachable(vec![ghost_from.clone()], vec![root_entry_id.clone()])
+            .await
+            .unwrap(),
+        Reachability::Indeterminate {
+            missing: vec![ghost_from]
+        }
     );
 
-    // A `from` tip from another tree errors (EntryNotInTree).
+    // A missing *ancestor* on the path to a present target is also
+    // Indeterminate: the target exists, but the link to it is not synced.
+    // orphan(height 2) -> ghost(height 1, absent) -> root(target, present).
+    let ghost_id = ID::from_bytes("ghost");
+    let orphan_entry = Entry::builder(root_id.clone())
+        .add_parent(ghost_id.clone())
+        .set_height(2)
+        .build()
+        .expect("orphan builds");
+    let orphan_id = orphan_entry.id();
+    backend.put_verified(orphan_entry).await.unwrap();
+    assert_eq!(
+        reachable(vec![orphan_id.clone()], vec![root_entry_id.clone()])
+            .await
+            .unwrap(),
+        Reachability::Indeterminate {
+            missing: vec![ghost_id]
+        },
+        "a broken link to a present target is undecidable, not a regression"
+    );
+
+    // A `from` tip that EXISTS but belongs to another tree is a genuine
+    // integrity violation and still errors (EntryNotInTree).
     let bad_root: ID = ID::from_bytes("bad_root");
     let err = backend
-        .targets_reachable_from(&bad_root, std::slice::from_ref(&e1_id), &[])
+        .check_targets_reachable_from(&bad_root, std::slice::from_ref(&e1_id), &[])
         .await
         .unwrap_err();
     assert!(

--- a/docs/src/design/authentication.md
+++ b/docs/src/design/authentication.md
@@ -590,6 +590,26 @@ To validate entries with delegated database keys:
 
 This mechanism ensures that once a key revocation is observed in a delegated database, no entry can use an older version of that database where the key was still valid.
 
+#### Implementation Status: Snapshot Pinning and the Monotonicity Floor
+
+The "latest known tips" high-water-mark above describes the intended end state. The validation path implemented today (`crates/lib/src/auth/validation/delegation.rs`) realizes a related but narrower guarantee. It is documented here explicitly so the design above is not mistaken for the current behavior.
+
+**What is enforced today**, per delegation step:
+
+1. **Tree-membership validation.** Every claimed tip must be a real entry belonging to _that_ delegated database, verified via `get_tree_from_tips`. The earlier implementation only checked that a tip existed _somewhere_ in the backend, so a tip from an unrelated tree was accepted; that hole is closed.
+2. **Snapshot-pinned resolution.** The delegated database's auth settings are read **as of the claimed tips**, not its live head. Permissions are evaluated at the state the signer actually observed, so a later change in the delegated database does not retroactively alter how an already-signed entry resolves.
+3. **Monotonicity floor.** The claimed snapshot may not regress below the snapshot the parent database has **committed** for that delegation — the `tips` field of the `DelegatedTreeRef` (`TreeReference.tips`), which was previously dead data in validation. Equivalently, every committed-floor tip must be reachable from the claimed tips. This stops an entry from time-travelling the delegated database backwards to resurrect auth state the parent has already advanced past (for example a since-revoked key). Advancing the floor is an admin-gated `_settings` write on the parent database.
+4. **Bounded fan-out.** The wire-supplied delegation path length (`MAX_DELEGATION_STEPS`) and per-step claimed-tip count (`MAX_DELEGATION_TIPS`) are bounded, so a single signature key cannot force unbounded backend work before the authorization gate decides.
+
+**How this differs from "latest known tips" above.** The floor is a pointer the parent database commits by an explicit admin settings write, _not_ an automatically-tracked high-water-mark advanced by every observing entry (design step 4 of §Tip Tracking and Validation). It bounds regression against the last committed pointer; it does not yet pin the snapshot fully.
+
+**Known gaps (tracked follow-ups, not yet implemented):**
+
+- **Strict per-entry monotonicity.** The floor is the only monotonicity guarantee. Two sibling entries under the same parent state may still pin _different_ snapshots, provided both are at or above the committed floor.
+- **Settings-write monotonic gate.** Nothing yet forces the committed floor pointer itself to move only forward; an admin settings write could move it backwards, re-opening the regression window. Gating delegation-pointer updates to be monotonic is required to fully close this.
+
+Both gaps are marked `FIXME(security)` in `auth/validation/entry.rs` and `auth/validation/delegation.rs`.
+
 ### Key Revocation
 
 Delegated database key deletion is always treated as `revoked` status in the main database. This prevents new entries from building on the deleted key's content while preserving the historical content during merges. This approach maintains the integrity of existing entries while preventing future reliance on removed authentication credentials.
@@ -748,6 +768,8 @@ graph TD
 - **Replay Attacks**: Content-addressable IDs prevent entry duplication
 - **Administrative Hierarchy Violations**: Lower priority keys cannot modify higher priority keys (but can modify equal priority keys)
 - **Permission Boundary Violations**: Delegated database permissions are constrained within their specified min/max bounds
+- **Cross-Tree Tip Forgery**: Claimed delegation tips are validated as members of the referenced delegated database, not merely as entries existing somewhere in the backend
+- **Delegated-Tree Snapshot Regression (bounded)**: Auth resolution is pinned to the snapshot the signer claimed, and that snapshot may not regress below the parent's committed floor (see §Implementation Status). Note the residual gaps documented there — this is not yet a full per-entry pin
 - **Race Conditions**: Last Write Wins provides deterministic conflict resolution
 
 #### Requires Manual Recovery
@@ -774,6 +796,8 @@ graph TD
 #### Partial Mitigation
 
 - **DoS via Large Histories**: Priority system limits damage from compromised lower-priority keys
+- **DoS via Delegation Amplification**: Delegation path length and per-step claimed-tip count are bounded, capping the backend work an unauthenticated signature key can force before authorization; deeper amplification within those bounds is still possible
+- **Delegated-Tree Snapshot Regression**: The monotonicity floor bounds regression against the parent's committed pointer, but strict per-entry monotonicity and a monotonic gate on the committed pointer itself are not yet implemented (see §Implementation Status)
 - **Social Engineering**: Administrative hierarchy limits scope of individual key compromise
 - **Timestamp Manipulation**: LWW conflict resolution is deterministic but may be influenced by the chosen timestamp resolution algorithm
 - **Administrative Confusion**: Network partitions may result in unexpected administrative states due to LWW resolution
@@ -796,7 +820,7 @@ The current validation process:
 4. **Validate Signature**: Verify the Ed25519 signature against the entry content hash
 5. **Check Permissions**: Ensure the key has sufficient permissions for the operation
 
-**Current features include**: Direct key validation, delegated database resolution, tip validation, and permission clamping.
+**Current features include**: Direct key validation, delegated database resolution, snapshot-pinned tip validation (tree-membership checks plus the monotonicity floor described in §Implementation Status), and permission clamping.
 
 ### Verification Status vs. Signature Validity
 


### PR DESCRIPTION
Delegated Authentication has not been doing any real checks to verify that the pointed to auth is actually valid. It's a known hole in the security model.

This change partially closes that hole. Notably there are still KNOWN gaps and likely unknown ones as well. Key verification/revocation is a hard problem in this space and will take some time to get right.

With this, there is now enforcement that the snapshot of the delegated database, used to declare the authentication key is valid, is a descendant of the pinned snapshot in the Auth Settings of the original database. That's a mouthful, but it basically means that a key used for signing must have a validation chain from the keys that are in the Snapshot pointed at by the Auth Settings. This prevents a key that has been revoked at some point prior to that Snapshot from trying to claim validation on the parent DB.

An annoyance here is that the Auth Settings of the parent DB now should be updated ASAP if a key is revoked in the Delegated DB. Until that happens the revoked key could still authenticate itself with that.

