### PR TITLE
fix(ci): expand push-args inline in publish, not via env var

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -98,12 +98,13 @@ jobs:
       # pushed to the cache.
       - name: Build and push release artifacts
         env:
-          PUSH_ARGS: ${{ steps.nix.outputs.push-args }}
           SYSTEM: ${{ matrix.system }}
         run: |
-          # shellcheck disable=SC2086 # PUSH_ARGS expands into multiple flags
+          # push-args is a first-party action output carrying pre-quoted store
+          # flags; it must expand inline (quotes are not re-parsed from an env
+          # var, which corrupts the s3:// store URL).
           nix-fast-build --skip-cached --no-nom --no-link \
-            $PUSH_ARGS \
+            ${{ steps.nix.outputs.push-args }} \
             --option substituters 'https://cache.nixos.org' \
             -f ".#legacyPackages.${SYSTEM}.eidetica.release"
 
@@ -112,11 +113,9 @@ jobs:
       # release runs only build the release artifacts.
       - name: Warm CI cache
         if: github.event_name == 'workflow_run'
-        env:
-          PUSH_ARGS: ${{ steps.nix.outputs.push-args }}
         run: |
-          # shellcheck disable=SC2086 # PUSH_ARGS expands into multiple flags
-          nix-fast-build --skip-cached --no-nom --no-link $PUSH_ARGS
+          nix-fast-build --skip-cached --no-nom --no-link \
+            ${{ steps.nix.outputs.push-args }}
 
       - name: Install Bencher CLI
         if: github.event_name == 'workflow_run'


### PR DESCRIPTION
The artifact-publish hardening moved `steps.nix.outputs.push-args` into a PUSH_ARGS env var. That output is a pre-quoted multi-flag string (it carries `--option store 's3://…'`); quotes inside a variable value are not re-parsed after expansion, so the literal quote characters reached nix as part of the store URI: "Cannot parse Nix store ''s3://…''". push-args is a first-party action output, not untrusted input, so inline interpolation is safe here. Keeps the scalar env passthroughs (SYSTEM) which expand correctly.
