### PR TITLE
fix: bootstrap establishes initial key mapping

### DIFF
--- a/crates/bin/src/commands/serve.rs
+++ b/crates/bin/src/commands/serve.rs
@@ -544,7 +544,7 @@ async fn handle_track_database(
         // request_database_access records the User-layer SigKey mapping, so it
         // needs a write lock.
         let mut user = user_lock.write().await;
-        user.request_database_access(&sync, &ticket, &key_id, permission)
+        user.request_database_access(&sync, &ticket, &key_id, permission, None)
             .await
     };
 

--- a/crates/bin/src/commands/serve.rs
+++ b/crates/bin/src/commands/serve.rs
@@ -540,11 +540,17 @@ async fn handle_track_database(
         }
     };
 
+    // Run the network bootstrap WITHOUT holding the per-session user lock — a
+    // slow or hung peer must not freeze the rest of this session's requests.
+    let key_name = key_id.to_string();
+    let network_result = sync
+        .bootstrap_with_ticket(&ticket, &key_id, &key_name, permission, None)
+        .await;
+
+    // Re-acquire only for the cheap, local SigKey-mapping write.
     let bootstrap_result = {
-        // request_database_access records the User-layer SigKey mapping, so it
-        // needs a write lock.
         let mut user = user_lock.write().await;
-        user.request_database_access(&sync, &ticket, &key_id, permission, None)
+        user.record_database_access(ticket.database_id(), &key_id, network_result)
             .await
     };
 
@@ -552,6 +558,10 @@ async fn handle_track_database(
         Ok(_) => {
             let mut user = user_lock.write().await;
 
+            // `record_database_access` already recorded the SigKey mapping (with
+            // sync left disabled). Re-track here only to apply this daemon's sync
+            // policy; the key is unchanged so this skips re-validation and just
+            // updates settings.
             match user
                 .track_database(
                     ticket.database_id().clone(),

--- a/crates/bin/src/commands/serve.rs
+++ b/crates/bin/src/commands/serve.rs
@@ -541,7 +541,9 @@ async fn handle_track_database(
     };
 
     let bootstrap_result = {
-        let user = user_lock.read().await;
+        // request_database_access records the User-layer SigKey mapping, so it
+        // needs a write lock.
+        let mut user = user_lock.write().await;
         user.request_database_access(&sync, &ticket, &key_id, permission)
             .await
     };

--- a/crates/lib/src/sync/background/mod.rs
+++ b/crates/lib/src/sync/background/mod.rs
@@ -757,6 +757,7 @@ impl BackgroundSync {
                 requesting_key: None, // TODO: Add auth support for background sync
                 requesting_key_name: None,
                 requested_permission: None,
+                metadata: None,
             });
 
             let response = self.transport_manager.send_request(address, &request).await?;

--- a/crates/lib/src/sync/bootstrap.rs
+++ b/crates/lib/src/sync/bootstrap.rs
@@ -9,6 +9,7 @@ use super::{
 use crate::{
     Database, Result,
     auth::{Permission, crypto::PublicKey, types::AuthKey},
+    crdt::Doc,
     database::DatabaseKey,
     entry::ID,
 };
@@ -49,6 +50,7 @@ impl Sync {
         requesting_public_key: &PublicKey,
         requesting_key_name: &str,
         requested_permission: Permission,
+        metadata: Option<Doc>,
     ) -> Result<()> {
         // Validate key name is not empty
         if requesting_key_name.is_empty() {
@@ -71,6 +73,7 @@ impl Sync {
             Some(requesting_public_key),
             Some(requesting_key_name),
             Some(requested_permission),
+            metadata,
         )
         .await?;
 
@@ -115,13 +118,15 @@ impl Sync {
         requesting_key_name: &str,
         requested_permission: Permission,
     ) -> Result<()> {
-        // Delegate to internal method
+        // Delegate to internal method. This lower-level entry point carries no
+        // approver metadata; use `bootstrap_with_ticket` to attach it.
         self.sync_with_peer_for_bootstrap_internal(
             address,
             tree_id,
             requesting_public_key,
             requesting_key_name,
             requested_permission,
+            None,
         )
         .await
     }
@@ -137,6 +142,8 @@ impl Sync {
     /// * `requesting_public_key` - The formatted public key string for authentication.
     /// * `requesting_key_name` - The name/ID of the requesting key.
     /// * `requested_permission` - The permission level being requested.
+    /// * `metadata` - Optional free-form context the requester attaches for the
+    ///   approver to inspect, surfaced verbatim on the stored [`BootstrapRequest`].
     ///
     /// # Errors
     /// Returns [`SyncError::InvalidAddress`] if the ticket has no address hints.
@@ -147,6 +154,7 @@ impl Sync {
         requesting_public_key: &PublicKey,
         requesting_key_name: &str,
         requested_permission: Permission,
+        metadata: Option<Doc>,
     ) -> Result<()> {
         let database_id = ticket.database_id().clone();
         let pubkey = requesting_public_key.clone();
@@ -155,6 +163,7 @@ impl Sync {
             let db_id = database_id.clone();
             let pubkey = pubkey.clone();
             let key_name = key_name.clone();
+            let metadata = metadata.clone();
             async move {
                 sync.sync_with_peer_for_bootstrap_internal(
                     &addr,
@@ -162,6 +171,7 @@ impl Sync {
                     &pubkey,
                     &key_name,
                     requested_permission,
+                    metadata,
                 )
                 .await
             }

--- a/crates/lib/src/sync/bootstrap_request_manager.rs
+++ b/crates/lib/src/sync/bootstrap_request_manager.rs
@@ -10,6 +10,7 @@ use super::peer_types::Address;
 use crate::{
     Error, Result, Transaction,
     auth::{Permission, crypto::PublicKey},
+    crdt::Doc,
     entry::ID,
     store::{StoreError, Table},
 };
@@ -42,6 +43,10 @@ pub struct BootstrapRequest {
     pub status: RequestStatus,
     /// Address of the requesting peer (for future notifications)
     pub peer_address: Address,
+    /// Free-form context supplied by the requester for the approver to inspect
+    /// when deciding whether to grant access. Carried verbatim from the request.
+    #[serde(default)]
+    pub metadata: Option<Doc>,
 }
 
 /// Status of a bootstrap request
@@ -242,6 +247,7 @@ mod tests {
                 transport_type: "http".to_string(),
                 address: "127.0.0.1:8080".to_string(),
             },
+            metadata: None,
         }
     }
 

--- a/crates/lib/src/sync/handler.rs
+++ b/crates/lib/src/sync/handler.rs
@@ -127,6 +127,13 @@ impl SyncHandlerImpl {
                 transport_type: "unknown".to_string(),
                 address: "unknown".to_string(),
             },
+            // TODO(bootstrap-metadata-bound): `metadata` is unbounded, remote-supplied
+            // data persisted to the system sync tree before any approval decision. A
+            // hostile peer can spam large/many pending requests (storage/DoS on the
+            // multi-tenant boundary). Bound the metadata size here, and cap pending
+            // requests per peer, before this is exposed to untrusted peers. Note the
+            // `Doc` is already deserialized at the protocol layer ahead of the
+            // sync-enabled gate, so the size cap ideally belongs there too.
             metadata,
         };
 

--- a/crates/lib/src/sync/handler.rs
+++ b/crates/lib/src/sync/handler.rs
@@ -25,6 +25,7 @@ use crate::{
         KeyStatus, Permission,
         crypto::{PublicKey, create_challenge_response, generate_challenge},
     },
+    crdt::Doc,
     entry::ID,
     store::SettingsStore,
     sync::error::SyncError,
@@ -107,6 +108,7 @@ impl SyncHandlerImpl {
         requesting_key: &PublicKey,
         requesting_key_name: &str,
         requested_permission: &Permission,
+        metadata: Option<Doc>,
     ) -> Result<String> {
         let sync_tree = self.get_sync_tree().await?;
         let txn = sync_tree.new_transaction().await?;
@@ -125,6 +127,7 @@ impl SyncHandlerImpl {
                 transport_type: "unknown".to_string(),
                 address: "unknown".to_string(),
             },
+            metadata,
         };
 
         let request_id = manager.store_request(request).await?;
@@ -590,7 +593,8 @@ impl SyncHandlerImpl {
                 return self.handle_bootstrap_request(&request.tree_id,
                                                   request.requesting_key.as_ref(),
                                                   request.requesting_key_name.as_deref(),
-                                                  request.requested_permission).await;
+                                                  request.requested_permission,
+                                                  request.metadata.clone()).await;
             }
 
             // Handle incremental sync (peer has existing data, needs updates)
@@ -662,6 +666,7 @@ impl SyncHandlerImpl {
         requesting_key: Option<&PublicKey>,
         requesting_key_name: Option<&str>,
         requested_permission: Option<Permission>,
+        metadata: Option<Doc>,
     ) -> SyncResponse {
         // SECURITY: Check if database has sync enabled (FIRST CHECK - before anything else)
         // This prevents information leakage about database existence: the gate
@@ -759,7 +764,7 @@ impl SyncHandlerImpl {
 
                         // Store the bootstrap request in sync database for manual approval
                         match self
-                            .store_bootstrap_request(tree_id, key, key_name, &permission)
+                            .store_bootstrap_request(tree_id, key, key_name, &permission, metadata)
                             .await
                         {
                             Ok(request_id) => {

--- a/crates/lib/src/sync/ops.rs
+++ b/crates/lib/src/sync/ops.rs
@@ -15,7 +15,8 @@ use super::{
     user_sync_manager::UserSyncManager,
 };
 use crate::{
-    Database, Entry, Result, auth::Permission, auth::crypto::PublicKey, entry::ID, store::DocStore,
+    Database, Entry, Result, auth::Permission, auth::crypto::PublicKey, crdt::Doc, entry::ID,
+    store::DocStore,
 };
 
 use super::utils::collect_ancestors_to_send;
@@ -65,6 +66,7 @@ impl Sync {
             requesting_key: None, // TODO: Add auth support for direct sync
             requesting_key_name: None,
             requested_permission: None,
+            metadata: None,
         });
 
         // Send request via background sync command
@@ -637,6 +639,7 @@ impl Sync {
         requesting_key: Option<&PublicKey>,
         requesting_key_name: Option<&str>,
         requested_permission: Option<Permission>,
+        metadata: Option<Doc>,
     ) -> Result<()> {
         // Get peer information and address
         let peer_info = self
@@ -667,6 +670,7 @@ impl Sync {
             requesting_key: requesting_key.cloned(),
             requesting_key_name: requesting_key_name.map(|k| k.to_string()),
             requested_permission,
+            metadata,
         });
 
         // Send request via background sync command

--- a/crates/lib/src/sync/protocol.rs
+++ b/crates/lib/src/sync/protocol.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 use super::peer_types::Address;
 use crate::{
     auth::{Permission, crypto::PublicKey},
+    crdt::Doc,
     entry::{Entry, ID},
     snapshot::Snapshot,
 };
@@ -81,6 +82,11 @@ pub struct SyncTreeRequest {
     pub requesting_key_name: Option<String>,
     /// Desired permission level for bootstrap
     pub requested_permission: Option<Permission>,
+    /// Free-form context the requester attaches for the approver to inspect
+    /// when deciding whether to grant access. Carried verbatim onto the stored
+    /// `BootstrapRequest`.
+    #[serde(default)]
+    pub metadata: Option<Doc>,
 }
 
 /// Bootstrap response containing complete tree state

--- a/crates/lib/src/user/errors.rs
+++ b/crates/lib/src/user/errors.rs
@@ -61,6 +61,12 @@ pub enum UserError {
     #[error("No SigKey found for key {key_id} in database {database_id}")]
     NoSigKeyFound { key_id: String, database_id: ID },
 
+    #[error(
+        "Database access pending for {database_id}: a key mapping exists but the database has no local data yet \
+         (the bootstrap request may be awaiting approval, or the database has not synced)"
+    )]
+    DatabaseAccessPending { database_id: ID },
+
     #[error("Password required for operation: {operation}")]
     PasswordRequired { operation: String },
 

--- a/crates/lib/src/user/session/mod.rs
+++ b/crates/lib/src/user/session/mod.rs
@@ -1003,6 +1003,8 @@ impl User {
     /// * `ticket` - A ticket containing the database ID and address hints
     /// * `key_id` - The ID of this user's key to use for the request
     /// * `requested_permission` - The permission level being requested
+    /// * `metadata` - Optional free-form context for the approver to inspect on
+    ///   the stored bootstrap request when deciding whether to grant access
     ///
     /// # Returns
     /// Result indicating success or failure of the bootstrap request
@@ -1033,6 +1035,7 @@ impl User {
         ticket: &DatabaseTicket,
         key_id: &PublicKey,
         requested_permission: Permission,
+        metadata: Option<Doc>,
     ) -> Result<()> {
         if self.key_manager.get_signing_key(key_id).is_none() {
             return Err(super::errors::UserError::KeyNotFound {
@@ -1045,7 +1048,7 @@ impl User {
         let database_id = ticket.database_id().clone();
 
         let result = sync
-            .bootstrap_with_ticket(ticket, key_id, &key_name, requested_permission)
+            .bootstrap_with_ticket(ticket, key_id, &key_name, requested_permission, metadata)
             .await;
 
         // Bootstrap grants access at the sync layer (auth + entries) but does not

--- a/crates/lib/src/user/session/mod.rs
+++ b/crates/lib/src/user/session/mod.rs
@@ -995,8 +995,7 @@ impl User {
     /// When approval is still pending the request returns
     /// [`SyncError::BootstrapPending`] but a provisional mapping is recorded;
     /// opening the database before approval then fails with
-    /// [`UserError::DatabaseAccessPending`](crate::user::UserError::DatabaseAccessPending)
-    /// rather than a cryptic backend error.
+    /// [`UserError::DatabaseAccessPending`] rather than a cryptic backend error.
     ///
     /// # Arguments
     /// * `sync` - Reference to the Instance's Sync object

--- a/crates/lib/src/user/session/mod.rs
+++ b/crates/lib/src/user/session/mod.rs
@@ -1050,12 +1050,36 @@ impl User {
             .bootstrap_with_ticket(ticket, key_id, &key_name, requested_permission, metadata)
             .await;
 
+        self.record_database_access(&database_id, key_id, result)
+            .await
+    }
+
+    /// Record the User-layer SigKey mapping for a bootstrap whose network phase
+    /// has already completed, given the [`Result`] returned by
+    /// [`Sync::bootstrap_with_ticket`](crate::sync::Sync::bootstrap_with_ticket).
+    ///
+    /// [`request_database_access`](Self::request_database_access) is the usual
+    /// entry point and performs the network bootstrap for you. This split-out
+    /// method exists for callers that hold a coarse lock around the `User` (e.g.
+    /// a daemon's per-session lock): they can run the network round-trip without
+    /// the lock held and re-acquire it only for this cheap, local mapping write,
+    /// so a slow or hung peer never blocks the rest of the session. The mapping
+    /// semantics are identical to `request_database_access`.
+    ///
+    /// The `bootstrap_result` is consumed and its outcome re-raised unchanged so
+    /// callers can react to [`SyncError::BootstrapPending`] et al.
+    pub async fn record_database_access(
+        &mut self,
+        database_id: &ID,
+        key_id: &PublicKey,
+        bootstrap_result: Result<()>,
+    ) -> Result<()> {
         // Bootstrap grants access at the sync layer (auth + entries) but does not
         // establish the User-layer SigKey mapping that `open_database`/`find_key`
         // rely on. Establish it here so a successful request leaves the database
         // openable — previously the caller had to call `track_database` manually,
         // and omitting it left the database unopenable ("No key found").
-        match result {
+        match bootstrap_result {
             Ok(()) => {
                 // Access was already authorized and the database is now synced, so
                 // its auth settings are local: discover the real SigKey (which may
@@ -1064,11 +1088,11 @@ impl User {
                 // database — a repeat request must not silently disable sync — and
                 // fall back to the default only for a freshly-tracked database.
                 let sync_settings = self
-                    .database(&database_id)
+                    .database(database_id)
                     .await
                     .map(|tracked| tracked.sync_settings)
                     .unwrap_or_default();
-                self.track_database(database_id, key_id, sync_settings)
+                self.track_database(database_id.clone(), key_id, sync_settings)
                     .await?;
                 Ok(())
             }
@@ -1083,7 +1107,7 @@ impl User {
                 if let Error::Sync(sync_err) = &e
                     && matches!(sync_err.as_ref(), SyncError::BootstrapPending { .. })
                 {
-                    self.map_key(key_id, &database_id, SigKey::from_pubkey(key_id))
+                    self.map_key(key_id, database_id, SigKey::from_pubkey(key_id))
                         .await?;
                 }
                 Err(e)

--- a/crates/lib/src/user/session/mod.rs
+++ b/crates/lib/src/user/session/mod.rs
@@ -473,14 +473,33 @@ impl User {
         // the daemon so the identity sits in the connection's session
         // keyset.
         let key = DatabaseKey::with_identity(signing_key.clone(), sigkey.clone());
+        // A SigKey mapping exists (resolved above), so the database is one this
+        // user has requested access to. If its root entry isn't present, the
+        // access is still pending — the bootstrap request hasn't been approved or
+        // the database hasn't synced yet. Surface that explicitly instead of a
+        // bare backend "not found", on both the remote and local open paths.
         #[cfg(all(unix, feature = "service"))]
         if let Some(conn) = self.instance.remote_connection() {
             conn.register_session_key(signing_key).await?;
-            return Ok(Database::open_remote(&self.instance, conn, root_id, sigkey)
-                .await?
-                .with_key(key));
+            return match Database::open_remote(&self.instance, conn, root_id, sigkey).await {
+                Ok(database) => Ok(database.with_key(key)),
+                Err(e) if e.is_not_found() => {
+                    Err(super::errors::UserError::DatabaseAccessPending {
+                        database_id: root_id.clone(),
+                    }
+                    .into())
+                }
+                Err(e) => Err(e),
+            };
         }
-        Ok(Database::open(&self.instance, root_id).await?.with_key(key))
+        match Database::open(&self.instance, root_id).await {
+            Ok(database) => Ok(database.with_key(key)),
+            Err(e) if e.is_not_found() => Err(super::errors::UserError::DatabaseAccessPending {
+                database_id: root_id.clone(),
+            }
+            .into()),
+            Err(e) => Err(e),
+        }
     }
 
     /// Find databases by name among the user's tracked databases.
@@ -964,6 +983,21 @@ impl User {
     /// existing database from a new device, or when requesting access to a database
     /// shared by another user.
     ///
+    /// On a successful (already-authorized) request the database is synced and its
+    /// SigKey mapping is recorded, so [`open_database`](Self::open_database) works
+    /// immediately — no separate [`track_database`](Self::track_database) call is
+    /// needed just to open it. Note the database is tracked with sync **disabled**
+    /// by default; to keep it syncing in the background, call
+    /// [`track_database`](Self::track_database) (or [`enable_sync`](Self::enable_sync))
+    /// with your desired settings. Any settings already configured for the
+    /// database are preserved across a repeat request.
+    ///
+    /// When approval is still pending the request returns
+    /// [`SyncError::BootstrapPending`] but a provisional mapping is recorded;
+    /// opening the database before approval then fails with
+    /// [`UserError::DatabaseAccessPending`](crate::user::UserError::DatabaseAccessPending)
+    /// rather than a cryptic backend error.
+    ///
     /// # Arguments
     /// * `sync` - Reference to the Instance's Sync object
     /// * `ticket` - A ticket containing the database ID and address hints
@@ -994,7 +1028,7 @@ impl User {
     /// let database = user.open_database(ticket.database_id())?;
     /// ```
     pub async fn request_database_access(
-        &self,
+        &mut self,
         sync: &Sync,
         ticket: &DatabaseTicket,
         key_id: &PublicKey,
@@ -1008,9 +1042,51 @@ impl User {
         }
 
         let key_name = key_id.to_string();
+        let database_id = ticket.database_id().clone();
 
-        sync.bootstrap_with_ticket(ticket, key_id, &key_name, requested_permission)
-            .await
+        let result = sync
+            .bootstrap_with_ticket(ticket, key_id, &key_name, requested_permission)
+            .await;
+
+        // Bootstrap grants access at the sync layer (auth + entries) but does not
+        // establish the User-layer SigKey mapping that `open_database`/`find_key`
+        // rely on. Establish it here so a successful request leaves the database
+        // openable — previously the caller had to call `track_database` manually,
+        // and omitting it left the database unopenable ("No key found").
+        match result {
+            Ok(()) => {
+                // Access was already authorized and the database is now synced, so
+                // its auth settings are local: discover the real SigKey (which may
+                // be a direct, global-wildcard, or delegated key) and record it.
+                // Preserve any sync settings the caller already configured for this
+                // database — a repeat request must not silently disable sync — and
+                // fall back to the default only for a freshly-tracked database.
+                let sync_settings = self
+                    .database(&database_id)
+                    .await
+                    .map(|tracked| tracked.sync_settings)
+                    .unwrap_or_default();
+                self.track_database(database_id, key_id, sync_settings)
+                    .await?;
+                Ok(())
+            }
+            Err(e) => {
+                // Awaiting manual approval: the database isn't synced yet, so the
+                // SigKey can't be discovered. On approval the key is added by
+                // pubkey (see `Sync::approve_bootstrap_request_with_key`), so its
+                // SigKey will be the default pubkey identity — record that mapping
+                // provisionally. Until the database syncs, opening it surfaces
+                // `UserError::DatabaseAccessPending`. The pending error is
+                // re-raised unchanged so callers can react to it.
+                if let Error::Sync(sync_err) = &e
+                    && matches!(sync_err.as_ref(), SyncError::BootstrapPending { .. })
+                {
+                    self.map_key(key_id, &database_id, SigKey::from_pubkey(key_id))
+                        .await?;
+                }
+                Err(e)
+            }
+        }
     }
 
     // === Tracked Databases ===

--- a/crates/lib/tests/it/sync/auto_peer_registration_tests.rs
+++ b/crates/lib/tests/it/sync/auto_peer_registration_tests.rs
@@ -238,6 +238,7 @@ async fn test_bootstrap_sync_tracks_tree_peer_relationship() {
         requesting_key: Some(peer_verifying_key.clone()),
         requesting_key_name: Some("peer_key".to_string()),
         requested_permission: None,
+        metadata: None,
     };
 
     let context = RequestContext {
@@ -319,6 +320,7 @@ async fn test_incremental_sync_tracks_tree_peer_relationship() {
         requesting_key: Some(peer_verifying_key.clone()),
         requesting_key_name: Some("peer_key".to_string()),
         requested_permission: None,
+        metadata: None,
     };
 
     let context = RequestContext {
@@ -379,6 +381,7 @@ async fn test_relationship_tracking_skipped_without_peer_pubkey() {
         requesting_key: Some(peer_verifying_key.clone()),
         requesting_key_name: Some("peer_key".to_string()),
         requested_permission: None,
+        metadata: None,
     };
 
     // Context without peer_pubkey - tracking should be skipped
@@ -469,6 +472,7 @@ async fn test_multiple_trees_tracked_with_same_peer() {
         requesting_key: Some(peer_verifying_key.clone()),
         requesting_key_name: Some("peer_key".to_string()),
         requested_permission: None,
+        metadata: None,
     });
     let _response1 = handler.handle_request(&request1, &context).await;
 
@@ -480,6 +484,7 @@ async fn test_multiple_trees_tracked_with_same_peer() {
         requesting_key: Some(peer_verifying_key.clone()),
         requesting_key_name: Some("peer_key".to_string()),
         requested_permission: None,
+        metadata: None,
     });
     let _response2 = handler.handle_request(&request2, &context).await;
 
@@ -587,6 +592,7 @@ async fn test_sync_without_peer_identifier_works() {
         requesting_key: None,
         requesting_key_name: None,
         requested_permission: None,
+        metadata: None,
     };
 
     // Context also without peer_pubkey
@@ -639,6 +645,7 @@ async fn test_bootstrap_auto_detects_permission_for_authorized_key() {
         requesting_key: Some(key_id.clone()),
         requesting_key_name: Some(key_id.to_string()),
         requested_permission: None, // Should auto-detect from auth settings
+        metadata: None,
     };
 
     let context = RequestContext {
@@ -706,6 +713,7 @@ async fn test_bootstrap_rejects_unauthorized_key_when_permission_not_specified()
         requesting_key: Some(unauthorized_verifying_key.clone()),
         requesting_key_name: Some("unauthorized_key".to_string()),
         requested_permission: None,
+        metadata: None,
     };
 
     let context = RequestContext {
@@ -780,6 +788,7 @@ async fn test_bootstrap_auto_detects_global_wildcard_permission() {
         requesting_key: Some(random_verifying_key.clone()),
         requesting_key_name: Some("random_key".to_string()),
         requested_permission: None, // Should auto-detect global '*' permission
+        metadata: None,
     };
 
     let context = RequestContext {
@@ -866,6 +875,7 @@ async fn test_bootstrap_uses_highest_permission_when_key_has_multiple() {
         requesting_key: Some(special_verifying_key.clone()),
         requesting_key_name: Some("special_key".to_string()),
         requested_permission: None, // Should auto-detect highest (Write(5))
+        metadata: None,
     };
 
     let context = RequestContext {

--- a/crates/lib/tests/it/sync/bootstrap_metadata_tests.rs
+++ b/crates/lib/tests/it/sync/bootstrap_metadata_tests.rs
@@ -1,0 +1,64 @@
+//! Tests that a bootstrap request carries free-form approver metadata.
+//!
+//! The requester can attach an arbitrary `Doc` which is surfaced verbatim on
+//! the stored `BootstrapRequest` for the approver to inspect.
+
+use eidetica::{
+    auth::Permission,
+    crdt::Doc,
+    sync::{DatabaseTicket, transports::http::HttpTransport},
+};
+
+use super::helpers::*;
+
+#[tokio::test]
+async fn bootstrap_request_carries_metadata_to_approver() {
+    let (server_instance, _server_user, _server_key_id, _server_database, server_sync, tree_id) =
+        setup_manual_approval_server().await;
+    let server_addr = start_sync_server(&server_sync).await;
+
+    let (_client_instance, mut client_user, client_key_id, client_sync) =
+        setup_sync_enabled_client("client_user", "client_key").await;
+    client_sync
+        .register_transport("http", HttpTransport::builder())
+        .await
+        .unwrap();
+
+    let ticket = DatabaseTicket::with_addresses(tree_id.clone(), vec![server_addr.clone()]);
+
+    // Attach free-form context for the approver to inspect.
+    let mut metadata = Doc::new();
+    metadata.set("settings_db_id", "bafyrtestsettingsdb");
+    metadata.set("note", "matrix bridge login");
+
+    let result = client_user
+        .request_database_access(
+            &client_sync,
+            &ticket,
+            &client_key_id,
+            Permission::Write(5),
+            Some(metadata),
+        )
+        .await;
+    assert!(result.is_err(), "manual-approval request should be pending");
+
+    // The approver sees the metadata verbatim on the stored pending request.
+    let pending = server_sync.pending_bootstrap_requests().await.unwrap();
+    assert_eq!(pending.len(), 1, "exactly one pending request expected");
+    let (_request_id, request) = &pending[0];
+    let got = request
+        .metadata
+        .as_ref()
+        .expect("the stored request should carry the requester's metadata");
+    assert_eq!(
+        got.get_as::<String>("settings_db_id").as_deref(),
+        Some("bafyrtestsettingsdb")
+    );
+    assert_eq!(
+        got.get_as::<String>("note").as_deref(),
+        Some("matrix bridge login")
+    );
+
+    server_sync.stop_server().await.unwrap();
+    drop(server_instance);
+}

--- a/crates/lib/tests/it/sync/bootstrap_open_mapping_tests.rs
+++ b/crates/lib/tests/it/sync/bootstrap_open_mapping_tests.rs
@@ -1,0 +1,146 @@
+//! Regression tests for bootstrap establishing the User-layer SigKey mapping.
+//!
+//! A successful bootstrap grants access at the sync layer (auth + entries) but
+//! historically left no User-layer SigKey mapping, so `User::open_database`
+//! failed with "No key found" unless the caller manually invoked
+//! `track_database`. `User::request_database_access` now establishes the mapping
+//! itself, and opening a not-yet-approved database surfaces a clear
+//! `UserError::DatabaseAccessPending` instead of a cryptic backend error.
+
+use eidetica::{
+    Error,
+    auth::Permission,
+    store::DocStore,
+    sync::{DatabaseTicket, transports::http::HttpTransport},
+    user::UserError,
+};
+
+use super::helpers::*;
+
+/// Auto-approve server -> client `request_database_access` -> the database is
+/// immediately openable and usable WITHOUT a manual `track_database` call.
+#[tokio::test]
+async fn request_access_makes_database_openable_without_manual_track() {
+    let (_server_instance, _server_user, _server_key_id, server_database, tree_id, server_sync) =
+        setup_sync_enabled_server_with_auto_approve("server_user", "server_key", "test_db").await;
+
+    // Seed some data on the server.
+    {
+        let tx = server_database.new_transaction().await.unwrap();
+        let store = tx.get_store::<DocStore>("messages").await.unwrap();
+        store.set("msg1", "hello").await.unwrap();
+        tx.commit().await.unwrap();
+    }
+
+    let _server_addr = start_sync_server(&server_sync).await;
+    let ticket = server_sync
+        .create_ticket(&tree_id)
+        .await
+        .expect("create_ticket should succeed");
+
+    let (_client_instance, mut client_user, client_key_id, client_sync) =
+        setup_sync_enabled_client("client_user", "client_key").await;
+    client_sync
+        .register_transport("http", HttpTransport::builder())
+        .await
+        .unwrap();
+
+    client_user
+        .request_database_access(&client_sync, &ticket, &client_key_id, Permission::Write(5))
+        .await
+        .expect("request_database_access should succeed");
+
+    // No manual `track_database` call here — that omission is exactly the
+    // regression being guarded against.
+    let db = client_user
+        .open_database(&tree_id)
+        .await
+        .expect("database should be openable immediately after request_database_access");
+
+    // The resolved mapping must yield a usable, authorized key: a signed write
+    // commits successfully.
+    let tx = db.new_transaction().await.unwrap();
+    let store = tx.get_store::<DocStore>("messages").await.unwrap();
+    store.set("from_client", "world").await.unwrap();
+    tx.commit()
+        .await
+        .expect("client write should commit with the resolved key");
+
+    server_sync.stop_server().await.unwrap();
+}
+
+/// Manual-approval server -> a pending request records a provisional mapping ->
+/// opening reports a clear `DatabaseAccessPending` -> after approval + sync the
+/// database opens and the by-pubkey mapping is authorized for writes.
+#[tokio::test]
+async fn pending_access_reports_clear_error_then_opens_after_approval() {
+    let (server_instance, server_user, server_key_id, _server_database, server_sync, tree_id) =
+        setup_manual_approval_server().await;
+    let server_addr = start_sync_server(&server_sync).await;
+
+    let (_client_instance, mut client_user, client_key_id, client_sync) =
+        setup_sync_enabled_client("client_user", "client_key").await;
+    client_sync
+        .register_transport("http", HttpTransport::builder())
+        .await
+        .unwrap();
+
+    let ticket = DatabaseTicket::with_addresses(tree_id.clone(), vec![server_addr.clone()]);
+
+    // The request is stored pending and returns an error, but the provisional
+    // key mapping is still recorded.
+    let result = client_user
+        .request_database_access(&client_sync, &ticket, &client_key_id, Permission::Write(5))
+        .await;
+    assert!(
+        result.is_err(),
+        "request against a manual-approval server should be pending"
+    );
+
+    // find_key now resolves the provisional mapping, so opening reaches the data
+    // layer — and surfaces a clear "pending" error instead of a cryptic backend
+    // not-found.
+    let open_err = client_user
+        .open_database(&tree_id)
+        .await
+        .expect_err("opening a not-yet-approved database should fail");
+    assert!(
+        matches!(&open_err, Error::User(e) if matches!(**e, UserError::DatabaseAccessPending { .. })),
+        "expected DatabaseAccessPending, got: {open_err:?}"
+    );
+
+    // Approve and let the client sync.
+    let pending = server_sync.pending_bootstrap_requests().await.unwrap();
+    assert_eq!(pending.len(), 1, "exactly one pending request expected");
+    let (request_id, _) = &pending[0];
+    server_user
+        .approve_bootstrap_request(&server_sync, request_id, &server_key_id)
+        .await
+        .expect("approval should succeed");
+    server_sync.flush().await.ok();
+
+    // The client re-requests access now that it is authorized. This takes the
+    // "already authorized" path: entries sync and the real SigKey is discovered
+    // and recorded.
+    client_user
+        .request_database_access(&client_sync, &ticket, &client_key_id, Permission::Write(5))
+        .await
+        .expect("access should be granted after approval");
+    client_sync.flush().await.ok();
+
+    // The pubkey-identity mapping matches the by-pubkey grant created on
+    // approval, so the database now opens and the key is authorized for writes.
+    let db = client_user
+        .open_database(&tree_id)
+        .await
+        .expect("database should open after approval and sync");
+    let tx = db.new_transaction().await.unwrap();
+    let store = tx.get_store::<DocStore>("data").await.unwrap();
+    store.set("client_key", "client_val").await.unwrap();
+    tx.commit()
+        .await
+        .expect("client write should commit with the approved by-pubkey key");
+
+    server_sync.stop_server().await.unwrap();
+    drop(server_instance);
+}

--- a/crates/lib/tests/it/sync/bootstrap_open_mapping_tests.rs
+++ b/crates/lib/tests/it/sync/bootstrap_open_mapping_tests.rs
@@ -46,7 +46,13 @@ async fn request_access_makes_database_openable_without_manual_track() {
         .unwrap();
 
     client_user
-        .request_database_access(&client_sync, &ticket, &client_key_id, Permission::Write(5))
+        .request_database_access(
+            &client_sync,
+            &ticket,
+            &client_key_id,
+            Permission::Write(5),
+            None,
+        )
         .await
         .expect("request_database_access should succeed");
 
@@ -90,7 +96,13 @@ async fn pending_access_reports_clear_error_then_opens_after_approval() {
     // The request is stored pending and returns an error, but the provisional
     // key mapping is still recorded.
     let result = client_user
-        .request_database_access(&client_sync, &ticket, &client_key_id, Permission::Write(5))
+        .request_database_access(
+            &client_sync,
+            &ticket,
+            &client_key_id,
+            Permission::Write(5),
+            None,
+        )
         .await;
     assert!(
         result.is_err(),
@@ -123,7 +135,13 @@ async fn pending_access_reports_clear_error_then_opens_after_approval() {
     // "already authorized" path: entries sync and the real SigKey is discovered
     // and recorded.
     client_user
-        .request_database_access(&client_sync, &ticket, &client_key_id, Permission::Write(5))
+        .request_database_access(
+            &client_sync,
+            &ticket,
+            &client_key_id,
+            Permission::Write(5),
+            None,
+        )
         .await
         .expect("access should be granted after approval");
     client_sync.flush().await.ok();

--- a/crates/lib/tests/it/sync/helpers.rs
+++ b/crates/lib/tests/it/sync/helpers.rs
@@ -378,6 +378,7 @@ pub fn create_bootstrap_request(
         requesting_key: Some(PublicKey::from_prefixed_string(requesting_key).unwrap()),
         requesting_key_name: Some(key_name.to_string()),
         requested_permission: Some(permission),
+        metadata: None,
     })
 }
 
@@ -577,7 +578,7 @@ pub async fn request_and_map_database_access(
             .await?;
 
         let ticket = DatabaseTicket::with_addresses(tree_id.clone(), vec![server_addr.clone()]);
-        user.request_database_access(&client_sync, &ticket, key_id, permission)
+        user.request_database_access(&client_sync, &ticket, key_id, permission, None)
             .await?;
     } // Drop Arc before sleep
 

--- a/crates/lib/tests/it/sync/manual_approval_test.rs
+++ b/crates/lib/tests/it/sync/manual_approval_test.rs
@@ -188,6 +188,7 @@ async fn test_reject_bootstrap_request() {
         requesting_key: Some(test_key.clone()),
         requesting_key_name: Some("laptop_key".to_string()),
         requested_permission: Some(AuthPermission::Write(5)),
+        metadata: None,
     });
 
     // Handle the request to store it as pending
@@ -272,6 +273,7 @@ async fn test_list_bootstrap_requests_by_status() {
         requesting_key: Some(test_key.clone()),
         requesting_key_name: Some("test_key".to_string()),
         requested_permission: Some(AuthPermission::Write(5)),
+        metadata: None,
     });
 
     let context = RequestContext::default();
@@ -332,6 +334,7 @@ async fn test_duplicate_bootstrap_requests_same_client() {
         requesting_key: Some(test_key.clone()),
         requesting_key_name: Some("laptop_key".to_string()),
         requested_permission: Some(AuthPermission::Write(5)),
+        metadata: None,
     });
 
     // Handle first request
@@ -350,6 +353,7 @@ async fn test_duplicate_bootstrap_requests_same_client() {
         requesting_key: Some(test_key.clone()),
         requesting_key_name: Some("laptop_key".to_string()),
         requested_permission: Some(AuthPermission::Write(5)),
+        metadata: None,
     });
 
     // Handle second identical request
@@ -467,6 +471,7 @@ async fn test_malformed_permission_requests() {
             requesting_key: Some(test_key.clone()),
             requesting_key_name: Some(format!("key_for_{}", description.replace(" ", "_"))),
             requested_permission: Some(*permission),
+            metadata: None,
         });
 
         let context = RequestContext::default();

--- a/crates/lib/tests/it/sync/mod.rs
+++ b/crates/lib/tests/it/sync/mod.rs
@@ -11,6 +11,7 @@ mod basic_operations;
 mod bidirectional_sync_test;
 mod bootstrap_concurrency_tests;
 mod bootstrap_failure_tests;
+mod bootstrap_open_mapping_tests;
 mod bootstrap_sync_tests;
 mod bootstrap_with_key_tests;
 mod chat_simulation_test;

--- a/crates/lib/tests/it/sync/mod.rs
+++ b/crates/lib/tests/it/sync/mod.rs
@@ -11,6 +11,7 @@ mod basic_operations;
 mod bidirectional_sync_test;
 mod bootstrap_concurrency_tests;
 mod bootstrap_failure_tests;
+mod bootstrap_metadata_tests;
 mod bootstrap_open_mapping_tests;
 mod bootstrap_sync_tests;
 mod bootstrap_with_key_tests;

--- a/crates/lib/tests/it/sync/sync_enabled_security_tests.rs
+++ b/crates/lib/tests/it/sync/sync_enabled_security_tests.rs
@@ -226,6 +226,7 @@ async fn test_incremental_sync_rejected_when_sync_disabled() {
         requesting_key: None,
         requesting_key_name: None,
         requested_permission: None,
+        metadata: None,
     });
 
     let context = RequestContext::default();

--- a/crates/lib/tests/it/sync/ticket_sync_tests.rs
+++ b/crates/lib/tests/it/sync/ticket_sync_tests.rs
@@ -319,7 +319,13 @@ async fn test_bootstrap_with_ticket_authenticated() {
 
     // Use User API to request access via ticket
     client_user
-        .request_database_access(&client_sync, &ticket, &client_key_id, Permission::Write(5))
+        .request_database_access(
+            &client_sync,
+            &ticket,
+            &client_key_id,
+            Permission::Write(5),
+            None,
+        )
         .await
         .expect("request_database_access should succeed");
 

--- a/crates/lib/tests/it/sync/ticket_sync_tests.rs
+++ b/crates/lib/tests/it/sync/ticket_sync_tests.rs
@@ -309,7 +309,7 @@ async fn test_bootstrap_with_ticket_authenticated() {
         .expect("create_ticket should succeed");
 
     // Setup client
-    let (_client_instance, client_user, client_key_id, client_sync) =
+    let (_client_instance, mut client_user, client_key_id, client_sync) =
         setup_sync_enabled_client("client_user", "client_key").await;
 
     client_sync

--- a/crates/lib/tests/it/user/user_bootstrap_tests.rs
+++ b/crates/lib/tests/it/user/user_bootstrap_tests.rs
@@ -114,6 +114,7 @@ async fn create_pending_request(
         requesting_key: Some(client_pubkey.clone()),
         requesting_key_name: Some("laptop_key".to_string()),
         requested_permission: Some(permission),
+        metadata: None,
     });
 
     let context = RequestContext::default();

--- a/examples/chat/src/app.rs
+++ b/examples/chat/src/app.rs
@@ -188,7 +188,7 @@ impl App {
             info!("Starting bootstrap sync for room {room_id}");
 
             self.user
-                .request_database_access(&sync, &ticket, &key_id, PermissionType::Write(5))
+                .request_database_access(&sync, &ticket, &key_id, PermissionType::Write(5), None)
                 .await?;
 
             // Register the database with the User so it knows which key to use


### PR DESCRIPTION
This change improves the bootstrap requesting flow, enabling an arbitrary Doc of metadata sent alongside the request and better tracking from the client side. Before, a clients needs to request and then re-request access in the future. Now it adds the mapping and that goes through the normal Sync flow, just with access being blocked until the mapping goes into the DB.

This is a UX improvement for users and enables better bootstrapping ergonomics. I hit this when trying to setup bootstrapping for chaz bridges.