### PR TITLE
chore(deps): update GitHub Actions versions

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -15,13 +15,13 @@ jobs:
     if: github.repository_owner == 'arcuru'
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Nix
         uses: ./.github/actions/setup-nix
 
       - name: Install Bencher CLI
-        uses: bencherdev/bencher@8151077aa7b1bceaac11c4b308265417cae60e2b # v0.5.10
+        uses: bencherdev/bencher@5f9d4cf890255c35e0354af1ed325108a6a0babd # v0.6.8
 
       - name: Run Benchmarks
         if: github.event_name == 'schedule' || github.ref == 'refs/heads/main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubicloud-standard-8
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Nix
         uses: ./.github/actions/setup-nix
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubicloud-standard-16-arm
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Nix
         uses: ./.github/actions/setup-nix

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.repository_owner == 'arcuru'
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Nix
         uses: ./.github/actions/setup-nix
@@ -33,7 +33,7 @@ jobs:
           cp "$(nix build --no-link --print-out-paths '.#legacyPackages.x86_64-linux.coverage.postgres')/lcov.info" coverage/postgres/lcov.info
 
       - name: Upload coverage (sqlite)
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: sqlite
@@ -41,7 +41,7 @@ jobs:
           fail_ci_if_error: false
 
       - name: Upload coverage (inmemory)
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: inmemory
@@ -49,7 +49,7 @@ jobs:
           fail_ci_if_error: false
 
       - name: Upload coverage (postgres)
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: postgres

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -28,7 +28,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Nix
         uses: ./.github/actions/setup-nix
@@ -37,10 +37,10 @@ jobs:
         run: nix build .#doc.site-dev -o site
 
       - name: Setup Pages
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: "site"
 
@@ -58,4 +58,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -83,7 +83,7 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ steps.ref.outputs.ref }}
 
@@ -119,7 +119,7 @@ jobs:
 
       - name: Install Bencher CLI
         if: github.event_name == 'workflow_run'
-        uses: bencherdev/bencher@8151077aa7b1bceaac11c4b308265417cae60e2b # v0.5.10
+        uses: bencherdev/bencher@5f9d4cf890255c35e0354af1ed325108a6a0babd # v0.6.8
 
       - name: Track artifact sizes
         if: github.event_name == 'workflow_run'
@@ -148,14 +148,14 @@ jobs:
             "echo '{}'"
 
       - name: Log in to GHCR
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY_GHCR }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -180,7 +180,7 @@ jobs:
           echo "base_image=${BASE_IMAGE}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Determine tags
         id: tags
@@ -243,20 +243,20 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY_GHCR }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/release-plz-pr.yml
+++ b/.github/workflows/release-plz-pr.yml
@@ -26,15 +26,15 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
           toolchain: stable
       - name: Rust Cache
-        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Check if release PR exists
         id: check-pr
@@ -47,7 +47,7 @@ jobs:
 
       - name: Run release-plz
         if: github.event_name == 'workflow_dispatch' || steps.check-pr.outputs.exists != '0'
-        uses: release-plz/action@f708778669256143d984cce4b23592637532e040 # v0.5.127
+        uses: release-plz/action@e8792575c7f2366cf6ff3ccc33ead9ace5b691c7 # v0.5.130
         with:
           command: release-pr
           config: .config/release-plz.toml

--- a/.github/workflows/release-plz-release.yml
+++ b/.github/workflows/release-plz-release.yml
@@ -35,23 +35,23 @@ jobs:
       actions: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
           toolchain: stable
       - name: Rust Cache
-        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Authenticate with crates.io
-        uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
         id: cratesio-auth
 
       - name: Run release-plz
         id: release-plz
-        uses: release-plz/action@f708778669256143d984cce4b23592637532e040 # v0.5.127
+        uses: release-plz/action@e8792575c7f2366cf6ff3ccc33ead9ace5b691c7 # v0.5.130
         with:
           command: release
           config: .config/release-plz.toml

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.repository_owner == 'arcuru'
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Nix
         uses: ./.github/actions/setup-nix


### PR DESCRIPTION
## GitHub Actions Update

Monthly update of GitHub Actions to latest versions.

### Updated Actions

- `actions/checkout`: v6.0.2 → v7.0.0 (in `benchmarks.yml`)
- `bencherdev/bencher`: v0.5.10 → v0.6.8 (in `benchmarks.yml`)
- `actions/checkout`: v6.0.2 → v7.0.0 (in `ci.yml`)
- `actions/checkout`: v6.0.2 → v7.0.0 (in `ci.yml`)
- `actions/checkout`: v6.0.2 → v7.0.0 (in `coverage.yml`)
- `codecov/codecov-action`: v5 → v7.0.0 (in `coverage.yml`)
- `codecov/codecov-action`: v5 → v7.0.0 (in `coverage.yml`)
- `codecov/codecov-action`: v5 → v7.0.0 (in `coverage.yml`)
- `actions/checkout`: v6.0.2 → v7.0.0 (in `deploy-docs.yml`)
- `actions/configure-pages`: v5 → v6.0.0 (in `deploy-docs.yml`)
- `actions/upload-pages-artifact`: v4 → v5.0.0 (in `deploy-docs.yml`)
- `actions/deploy-pages`: v4 → v5.0.0 (in `deploy-docs.yml`)
- `actions/checkout`: v6.0.2 → v7.0.0 (in `publish.yml`)
- `bencherdev/bencher`: v0.5.10 → v0.6.8 (in `publish.yml`)
- `docker/login-action`: v3.7.0 → v4.2.0 (in `publish.yml`)
- `docker/login-action`: v3.7.0 → v4.2.0 (in `publish.yml`)
- `docker/setup-buildx-action`: v3 → v4.1.0 (in `publish.yml`)
- `actions/checkout`: v6.0.2 → v7.0.0 (in `publish.yml`)
- `docker/setup-buildx-action`: v3 → v4.1.0 (in `publish.yml`)
- `docker/login-action`: v3.7.0 → v4.2.0 (in `publish.yml`)
- `docker/login-action`: v3.7.0 → v4.2.0 (in `publish.yml`)
- `actions/checkout`: v6.0.2 → v7.0.0 (in `release-plz-pr.yml`)
- `dtolnay/rust-toolchain`: updated master SHA (in `release-plz-pr.yml`)
- `Swatinem/rust-cache`: v2 → v2.9.1 (in `release-plz-pr.yml`)
- `release-plz/action`: v0.5.127 → v0.5.130 (in `release-plz-pr.yml`)
- `actions/checkout`: v6.0.2 → v7.0.0 (in `release-plz-release.yml`)
- `dtolnay/rust-toolchain`: updated master SHA (in `release-plz-release.yml`)
- `Swatinem/rust-cache`: v2 → v2.9.1 (in `release-plz-release.yml`)
- `rust-lang/crates-io-auth-action`: v1.0.4 → v1.0.5 (in `release-plz-release.yml`)
- `release-plz/action`: v0.5.127 → v0.5.130 (in `release-plz-release.yml`)
- `actions/checkout`: v6.0.2 → v7.0.0 (in `sanitizers.yml`)


### Hold

This PR is on hold until **2026-07-08** (7-day waiting period).
The `on-hold` label will be automatically removed after the hold expires.

<!-- hold-until: 2026-07-08 -->