### PR TITLE
fix(ci): deploy docs running out of disk

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,40 +1,57 @@
+# Deploys the mdbook + rustdoc site to GitHub Pages.
+#
+# Runs after Publish rather than directly on push: Publish warms the Nix binary
+# cache with the full check set, which includes doc.api. Building on push instead
+# means every flake-input bump hits a cold cache and rebuilds the whole toolchain
+# and dependency graph on a standard-2 runner, which runs it out of disk. Waiting
+# for the warm cache leaves only mdbook and the site assembly to build here.
+#
+# workflow_run carries no path filter, so this redeploys on every main push. That
+# is a cache hit plus mdbook — cheap enough not to be worth path-gating.
+
 name: Deploy Docs
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - "docs/**"
-      - "crates/**"
-      - "nix/**"
-      - "flake.nix"
-      - "flake.lock"
-      - ".github/workflows/deploy-docs.yml"
+  workflow_run:
+    workflows: ["Publish"]
+    types: [completed]
+    branches: ["main"]
   workflow_dispatch:
 
 permissions:
   contents: read
 
+# Never cancel in progress: a cancelled run can leave a half-published Pages
+# deployment, and a no-op run (upstream failed, jobs skipped) still claims the
+# group and would cancel a real deploy.
 concurrency:
   group: "pages"
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   build:
     runs-on: ubicloud-standard-2
-    if: github.repository_owner == 'arcuru'
+    # Only the CI-triggered Publish warms the cache (its warm step is itself gated
+    # on workflow_run), so a release- or dispatch-triggered Publish would send this
+    # job into a cold build on a small runner. Deploy from the main-push path only.
+    if: |
+      github.repository_owner == 'arcuru' &&
+      (github.event_name != 'workflow_run' ||
+       (github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'workflow_run'))
     permissions:
       contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
 
       - name: Setup Nix
         uses: ./.github/actions/setup-nix
 
       - name: Build documentation
-        run: nix build .#doc.site-dev -o site
+        run: nix build .#doc.site -o site
 
       - name: Setup Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
@@ -50,7 +67,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubicloud-standard-2
     needs: build
-    if: github.repository_owner == 'arcuru' && (github.event_name == 'push' || github.ref == 'refs/heads/main')
+    if: github.repository_owner == 'arcuru' && github.ref == 'refs/heads/main'
     permissions:
       contents: read
       pages: write

--- a/flake.nix
+++ b/flake.nix
@@ -73,6 +73,7 @@
           (toolchain)
           fenixStable
           fenixNightly
+          toolChainStable
           toolChainNightly
           rustSrc
           craneLib
@@ -90,7 +91,7 @@
         # Shared helpers for package definitions
         eidLib = import ./nix/lib.nix {
           inherit pkgs lib;
-          defaultToolchain = fenixStable.toolchain;
+          defaultToolchain = toolChainStable;
         };
 
         # Import package groups
@@ -316,6 +317,7 @@
         # Development shell configuration
         devShells.default = import ./nix/dev-shell.nix {
           inherit pkgs lib rustSrc toolChainNightly;
+          rustAnalyzer = fenixStable.rust-analyzer;
           # Pass the full list of packages so the devshell can pickup the dependencies
           devPackages =
             {inherit (mainPkgs) eidetica-bin;}

--- a/nix/dev-shell.nix
+++ b/nix/dev-shell.nix
@@ -3,6 +3,7 @@
   pkgs,
   lib,
   rustSrc,
+  rustAnalyzer,
   toolChainNightly,
   devPackages,
 }: let
@@ -31,6 +32,9 @@ in
       [
         # Nightly toolchain wrapper (for udeps, miri, sanitizers, etc.)
         cargo-nightly
+
+        # LSP — not part of the build toolchain, so the devshell adds it directly
+        rustAnalyzer
       ]
       ++ (with pkgs; [
         # CI/CD tools

--- a/nix/packages/doc.nix
+++ b/nix/packages/doc.nix
@@ -16,20 +16,16 @@
     filter = docsOrCargo;
   };
 
+  # API docs for the deployed site. Every rustdoc artifact this repo produces is
+  # main-branch documentation, so it always carries the dev banner — stable release
+  # docs are published by docs.rs, not built here.
+  # The header is referenced as its own store path rather than pulled in via docSrc,
+  # so editing the book doesn't invalidate rustdoc.
   # TODO: --workspace docs are broken: eidetica-bin's binary is also named "eidetica", so its docs overwrite the library's in the output directory
   doc-api = craneLib.cargoDoc (debugArgs
     // {
       cargoDocExtraArgs = "-p eidetica --all-features --no-deps";
-    });
-
-  # API docs with dev banner for deployed documentation
-  # Uses docSrc to include docs/rustdoc-header.html (filtered out by cleanCargoSource)
-  doc-api-dev = craneLib.cargoDoc (debugArgs
-    // {
-      pname = "doc-api-dev";
-      src = docSrc;
-      cargoDocExtraArgs = "-p eidetica --all-features --no-deps";
-      RUSTDOCFLAGS = "--html-in-header docs/rustdoc-header.html";
+      RUSTDOCFLAGS = "--html-in-header ${../../docs/rustdoc-header.html}";
     });
 
   # Full docs including dependencies (slow, ~20min uncached)
@@ -39,17 +35,14 @@
       cargoDocExtraArgs = "--workspace --all-features";
     });
 
-  # Combined site: mdbook + rustdoc
-  mkSite = api:
-    pkgs.runCommand "doc-site" {} ''
-      cp -r ${doc-book} $out
-      chmod -R u+w $out
-      mkdir -p $out/rustdoc
-      cp -r ${api}/share/doc/* $out/rustdoc/
-    '';
-
-  doc-site = mkSite doc-api;
-  doc-site-dev = mkSite doc-api-dev;
+  # Combined site: mdbook + rustdoc. This is both what the link check runs against
+  # and what Deploy Docs publishes.
+  doc-site = pkgs.runCommand "doc-site" {} ''
+    cp -r ${doc-book} $out
+    chmod -R u+w $out
+    mkdir -p $out/rustdoc
+    cp -r ${doc-api}/share/doc/* $out/rustdoc/
+  '';
 
   # Common lychee args for link checking
   # --exclude-path: skip directories with internal cross-references that break outside their original context
@@ -99,10 +92,8 @@
 in {
   builds = {
     api = doc-api;
-    api-dev = doc-api-dev;
     api-full = doc-api-full;
     site = doc-site;
-    site-dev = doc-site-dev;
     links = doc-links;
     test = doc-test;
     book = doc-book;

--- a/nix/toolchain.nix
+++ b/nix/toolchain.nix
@@ -5,8 +5,18 @@
   pkgs,
 }: let
   # Stable Rust toolchain for main builds (tests, linting, docs)
+  # Only the components builds actually need. `.toolchain` combines ALL stable
+  # components, which drags in rustc-docs, rust-docs, reproducible-artifacts and
+  # llvm-tools — hundreds of MB of unpacked HTML and fixtures that no build uses,
+  # and enough to exhaust the disk on smaller CI runners.
   fenixStable = inputs.fenix.packages.${system}.stable;
-  toolChainStable = fenixStable.toolchain;
+  toolChainStable = fenixStable.withComponents [
+    "cargo"
+    "rustc"
+    "rust-std"
+    "clippy"
+    "rustfmt"
+  ];
   craneLibStable = (inputs.crane.mkLib pkgs).overrideToolchain toolChainStable;
 
   # Nightly Rust toolchain for coverage (llvm-tools-preview) and sanitizers (miri, -Z flags)
@@ -206,6 +216,7 @@ in {
   inherit
     fenixStable
     fenixNightly
+    toolChainStable
     toolChainNightly
     rustSrc
     craneLib


### PR DESCRIPTION
The Deploy Docs job was trying to rebuild everything itself after a flake update. This was caused by a caching ordering problem.

This change refactors that CI flow and reorganizes some of the doc builds to improve it. It now only runs after the Publish job (which creates the cache objects) and it also benefits from simplifying the toolchain components and the nix doc build targets.