### PR TITLE
ci(deps): adopt action pin verification from arcuru/actions

### DIFF
--- a/.github/workflows/actions-update.yml
+++ b/.github/workflows/actions-update.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   actions-update:
-    uses: arcuru/actions/.github/workflows/actions-update.yml@c8144123ad5a2c6316b7becab8233b68dfa637d9 # v0.2.1
+    uses: arcuru/actions/.github/workflows/actions-update.yml@45540c9d68eb9d2812bd4c85b43888fa05b22ef8 # main
     with:
       hold-days: ${{ inputs.hold_days || '7' }}
       runs-on: ubicloud-standard-2

--- a/.github/workflows/pin-audit.yml
+++ b/.github/workflows/pin-audit.yml
@@ -1,0 +1,20 @@
+# Daily audit of SHA-pinned GitHub Actions against upstream tags and the GitHub
+# Advisory Database. Opens or updates a GitHub issue labeled "security" on
+# findings and auto-closes it when they clear. Delegates to the arcuru/actions
+# reusable workflow.
+name: "Deps: Pin Audit"
+
+on:
+  schedule:
+    - cron: "0 5 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  audit:
+    uses: arcuru/actions/.github/workflows/pin-audit.yml@45540c9d68eb9d2812bd4c85b43888fa05b22ef8 # main
+    with:
+      runs-on: ubicloud-standard-2

--- a/.github/workflows/update-hold.yml
+++ b/.github/workflows/update-hold.yml
@@ -10,11 +10,12 @@ on:
   workflow_dispatch:
 
 permissions:
+  contents: read
   pull-requests: write
   checks: write
 
 jobs:
   update-hold:
-    uses: arcuru/actions/.github/workflows/update-hold.yml@c8144123ad5a2c6316b7becab8233b68dfa637d9 # v0.2.1
+    uses: arcuru/actions/.github/workflows/update-hold.yml@45540c9d68eb9d2812bd4c85b43888fa05b22ef8 # main
     with:
       runs-on: ubicloud-standard-2


### PR DESCRIPTION
The hold gate now re-verifies a dependency PR's pinned actions before releasing its on-hold label, instead of only waiting out the hold period, and the monthly actions-update runs the fixed reference scanner. A new daily pin-audit opens a tracking issue if a pinned action's tag is re-pointed upstream or a matching advisory is published — the tag-integrity check fires from public API data without waiting for an advisory.

update-hold gains contents: read: the reusable workflow reads the PR head to scan its pins, and a caller job caps the token scope it can grant.

These three pins track arcuru/actions main, matching the dtolnay/rust-toolchain shape already used here; the other reusable-workflow pins stay on v0.2.1.

Assisted-by: Claude Opus 4.8 <noreply@anthropic.com>