### PR TITLE
chore(deps): update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1781825982,
-        "narHash": "sha256-SlXKwIRIhrOSAcTjCB3ftPLzJWZStQIPS7J1FlZPnKk=",
+        "lastModified": 1785541369,
+        "narHash": "sha256-6VCYI5xashcnAR1lambqt9FGh0F6kYhg1P2Z0VDlr48=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "469fd08d0bcf6926321fa973c6777fbc87785dd7",
+        "rev": "508ff4829aefddee8ea62291e86b144b58365724",
         "type": "github"
       },
       "original": {
@@ -23,11 +23,11 @@
         "rust-analyzer-src": []
       },
       "locked": {
-        "lastModified": 1782813643,
-        "narHash": "sha256-+Y7z6oWSTJSKIhxPw7YKHOcIgoX/1PWgpRMZMj4AHlw=",
+        "lastModified": 1785488171,
+        "narHash": "sha256-v1ylO7biFcQ0K/hipStpTeItaPQ7XdspNdWAWPVX9S0=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "df161b9bd5f8ff444b2c213cd45410b7da6da602",
+        "rev": "080d4837db213b64169eb497a97a665773b9225c",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778716662,
-        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "lastModified": 1785454630,
+        "narHash": "sha256-LQy14TZp77TwbQf40gg1V3jo8FwJG0jGDkAH+zRHqg8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "rev": "1559d3daa3ecc813a650b79375ea61b6741b8746",
         "type": "github"
       },
       "original": {
@@ -88,11 +88,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780220602,
-        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
+        "lastModified": 1785360170,
+        "narHash": "sha256-XE1lKgQ3eIO3E7zWryqcRsax+mYXod/5RHBn4YaR9YE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
+        "rev": "d1187f8bc71fb8aab02395869ec3f5c1920f75c0",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -53,11 +53,11 @@
         };
       };
 
+      # x86_64-darwin is omitted: nixpkgs 26.11 dropped support for it.
       systems = [
         "aarch64-linux"
         "x86_64-linux"
         "aarch64-darwin"
-        "x86_64-darwin"
       ];
 
       perSystem = {

--- a/nix/packages/lint.nix
+++ b/nix/packages/lint.nix
@@ -216,10 +216,9 @@
       // {
         # Use unfiltered source so deny.toml is available (baseArgs excludes it)
         src = craneLib.cleanCargoSource ../..;
-        cargoDenyExtraArgs = "--workspace --all-features";
-        # --config must go after `check` (it's a subcommand flag);
-        # crane only interpolates cargoDenyChecks there, so we prepend it
-        cargoDenyChecks = "--config .config/deny.toml bans licenses sources";
+        # --config is a global cargo-deny flag, so it goes before `check`
+        cargoDenyExtraArgs = "--config .config/deny.toml --workspace --all-features";
+        cargoDenyChecks = "bans licenses sources";
       });
 
     # cargo-udeps: find unused dependencies


### PR DESCRIPTION
## Flake Input Update

Monthly `nix flake update` of Nix dependencies.

### Input Changes

- **crane**: [`469fd08` → `508ff48`](https://github.com/ipetkov/crane/compare/469fd08d0bcf6926321fa973c6777fbc87785dd7...508ff4829aefddee8ea62291e86b144b58365724)
- **fenix**: [`df161b9` → `080d483`](https://github.com/nix-community/fenix/compare/df161b9bd5f8ff444b2c213cd45410b7da6da602...080d4837db213b64169eb497a97a665773b9225c)
- **flake-parts**: [`f7c1a2d` → `17c9d6c`](https://github.com/hercules-ci/flake-parts/compare/f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb...17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e)
- **nixpkgs**: [`b5aa0fb` → `1559d3d`](https://github.com/nixos/nixpkgs/compare/b5aa0fbd538984f6e3d201be0005b4463d8b09f8...1559d3daa3ecc813a650b79375ea61b6741b8746)
- **treefmt-nix**: [`db94781` → `d1187f8`](https://github.com/numtide/treefmt-nix/compare/db947814a175b7ca6ded66e21383d938df01c227...d1187f8bc71fb8aab02395869ec3f5c1920f75c0)


<details>
<summary>nix flake update output</summary>

```
unpacking 'github:ipetkov/crane/508ff4829aefddee8ea62291e86b144b58365724' into the Git cache...
unpacking 'github:nix-community/fenix/080d4837db213b64169eb497a97a665773b9225c' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e' into the Git cache...
unpacking 'github:nixos/nixpkgs/1559d3daa3ecc813a650b79375ea61b6741b8746' into the Git cache...
unpacking 'github:numtide/treefmt-nix/d1187f8bc71fb8aab02395869ec3f5c1920f75c0' into the Git cache...
warning: updating lock file "/home/runner/work/eidetica/eidetica/flake.lock":
• Updated input 'crane':
    'github:ipetkov/crane/469fd08' (2026-06-18)
  → 'github:ipetkov/crane/508ff48' (2026-07-31)
• Updated input 'fenix':
    'github:nix-community/fenix/df161b9' (2026-06-30)
  → 'github:nix-community/fenix/080d483' (2026-07-31)
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/f7c1a2d' (2026-05-13)
  → 'github:hercules-ci/flake-parts/17c9d6c' (2026-07-01)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/b5aa0fb' (2026-06-29)
  → 'github:nixos/nixpkgs/1559d3d' (2026-07-30)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/db94781' (2026-05-31)
  → 'github:numtide/treefmt-nix/d1187f8' (2026-07-29)
```

</details>

### Hold

This PR is on hold until **2026-08-08** (7-day waiting period).
The `on-hold` label will be automatically removed after the hold expires.

<!-- hold-until: 2026-08-08 -->