### PR TITLE
chore(deps): update GitHub Actions versions

### DIFF
--- a/.forgejo/workflows/nix.yml
+++ b/.forgejo/workflows/nix.yml
@@ -44,7 +44,7 @@ jobs:
         run: nix-env -iA nixpkgs.nodejs
 
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Nix
         run: ./.forgejo/scripts/setup-nix.sh --attic nixpkgs#nix-fast-build
@@ -70,7 +70,7 @@ jobs:
         run: nix-env -iA nixpkgs.nodejs
 
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Nix
         run: ./.forgejo/scripts/setup-nix.sh --attic nixpkgs#nix-fast-build
@@ -94,7 +94,7 @@ jobs:
         run: nix-env -iA nixpkgs.nodejs
 
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Nix
         run: ./.forgejo/scripts/setup-nix.sh --attic nixpkgs#nix-fast-build
@@ -128,7 +128,7 @@ jobs:
         run: nix-env -iA nixpkgs.nodejs
 
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Nix
         run: ./.forgejo/scripts/setup-nix.sh --attic nixpkgs#nix-fast-build
@@ -158,7 +158,7 @@ jobs:
         run: nix-env -iA nixpkgs.nodejs
 
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Nix
         run: ./.forgejo/scripts/setup-nix.sh --attic nixpkgs#nix-fast-build
@@ -207,7 +207,7 @@ jobs:
         run: nix-env -iA nixpkgs.nodejs
 
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Nix
         run: ./.forgejo/scripts/setup-nix.sh --attic nixpkgs#nix-fast-build
@@ -236,7 +236,7 @@ jobs:
         run: nix-env -iA nixpkgs.nodejs
 
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Nix
         run: ./.forgejo/scripts/setup-nix.sh --attic --cachix

--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -15,7 +15,7 @@ runs:
   using: composite
   steps:
     - name: Install Nix
-      uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21
+      uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
       with:
         extra-conf: |
           accept-flake-config = true

--- a/.github/workflows/actions-update.yml
+++ b/.github/workflows/actions-update.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   actions-update:
-    uses: arcuru/actions/.github/workflows/actions-update.yml@45540c9d68eb9d2812bd4c85b43888fa05b22ef8 # main
+    uses: arcuru/actions/.github/workflows/actions-update.yml@c7ea79aaf3a4d0f07da752df4c115239befb996f # main
     with:
       hold-days: ${{ inputs.hold_days || '7' }}
       runs-on: ubicloud-standard-2

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.repository_owner == 'arcuru'
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -23,7 +23,7 @@ jobs:
         uses: ./.github/actions/setup-nix
 
       - name: Install Bencher CLI
-        uses: bencherdev/bencher@5f9d4cf890255c35e0354af1ed325108a6a0babd # v0.6.8
+        uses: bencherdev/bencher@4c83b25441d145ee273adaf74be30f2382e6ba85 # v0.6.11
 
       - name: Run Benchmarks
         if: github.event_name == 'schedule' || github.ref == 'refs/heads/main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubicloud-standard-8
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubicloud-standard-16-arm
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.repository_owner == 'arcuru'
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -44,7 +44,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.ref }}
           persist-credentials: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -93,7 +93,7 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ steps.ref.outputs.ref }}
           persist-credentials: false
@@ -130,7 +130,7 @@ jobs:
 
       - name: Install Bencher CLI
         if: github.event_name == 'workflow_run'
-        uses: bencherdev/bencher@5f9d4cf890255c35e0354af1ed325108a6a0babd # v0.6.8
+        uses: bencherdev/bencher@4c83b25441d145ee273adaf74be30f2382e6ba85 # v0.6.11
 
       - name: Track artifact sizes
         if: github.event_name == 'workflow_run'
@@ -159,14 +159,14 @@ jobs:
             "echo '{}'"
 
       - name: Log in to GHCR
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY_GHCR }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -191,7 +191,7 @@ jobs:
           echo "base_image=${BASE_IMAGE}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Determine tags
         id: tags
@@ -254,22 +254,22 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY_GHCR }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/release-plz-pr.yml
+++ b/.github/workflows/release-plz-pr.yml
@@ -26,12 +26,12 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
           toolchain: stable
       - name: Rust Cache
@@ -48,7 +48,7 @@ jobs:
 
       - name: Run release-plz
         if: github.event_name == 'workflow_dispatch' || steps.check-pr.outputs.exists != '0'
-        uses: release-plz/action@e8792575c7f2366cf6ff3ccc33ead9ace5b691c7 # v0.5.130
+        uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9 # v0.5.131
         with:
           command: release-pr
           config: .config/release-plz.toml

--- a/.github/workflows/release-plz-release.yml
+++ b/.github/workflows/release-plz-release.yml
@@ -35,12 +35,12 @@ jobs:
       actions: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
           toolchain: stable
       - name: Rust Cache
@@ -52,7 +52,7 @@ jobs:
 
       - name: Run release-plz
         id: release-plz
-        uses: release-plz/action@e8792575c7f2366cf6ff3ccc33ead9ace5b691c7 # v0.5.130
+        uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9 # v0.5.131
         with:
           command: release
           config: .config/release-plz.toml

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.repository_owner == 'arcuru'
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/update-hold.yml
+++ b/.github/workflows/update-hold.yml
@@ -16,6 +16,6 @@ permissions:
 
 jobs:
   update-hold:
-    uses: arcuru/actions/.github/workflows/update-hold.yml@45540c9d68eb9d2812bd4c85b43888fa05b22ef8 # main
+    uses: arcuru/actions/.github/workflows/update-hold.yml@c7ea79aaf3a4d0f07da752df4c115239befb996f # main
     with:
       runs-on: ubicloud-standard-2


### PR DESCRIPTION
## GitHub Actions Update

Monthly update of GitHub Actions to latest versions.

### Updated Actions

- `actions/checkout`: v7.0.0 → v7.0.1 (in `release-plz-pr.yml`)
- `dtolnay/rust-toolchain`: updated master SHA (in `release-plz-pr.yml`)
- `release-plz/action`: v0.5.130 → v0.5.131 (in `release-plz-pr.yml`)
- `arcuru/actions/.github/workflows/actions-update.yml`: updated main SHA (in `actions-update.yml`)
- `actions/checkout`: v7.0.0 → v7.0.1 (in `release-plz-release.yml`)
- `dtolnay/rust-toolchain`: updated master SHA (in `release-plz-release.yml`)
- `release-plz/action`: v0.5.130 → v0.5.131 (in `release-plz-release.yml`)
- `actions/checkout`: v7.0.0 → v7.0.1 (in `deploy-docs.yml`)
- `arcuru/actions/.github/workflows/update-hold.yml`: updated main SHA (in `update-hold.yml`)
- `actions/checkout`: v7.0.0 → v7.0.1 (in `coverage.yml`)
- `actions/checkout`: v7.0.0 → v7.0.1 (in `sanitizers.yml`)
- `actions/checkout`: v7.0.0 → v7.0.1 (in `ci.yml`)
- `actions/checkout`: v7.0.0 → v7.0.1 (in `benchmarks.yml`)
- `bencherdev/bencher`: v0.6.8 → v0.6.11 (in `benchmarks.yml`)
- `actions/checkout`: v7.0.0 → v7.0.1 (in `publish.yml`)
- `bencherdev/bencher`: v0.6.8 → v0.6.11 (in `publish.yml`)
- `docker/login-action`: v4.2.0 → v4.6.0 (in `publish.yml`)
- `docker/setup-buildx-action`: v4.1.0 → v4.2.0 (in `publish.yml`)
- `actions/checkout`: v4 → v7.0.1 (in `nix.yml`)
- `DeterminateSystems/nix-installer-action`: v21 → v22 (in `action.yml`)


### Hold

This PR is on hold until **2026-08-08** (7-day waiting period).
The `on-hold` label will be automatically removed after the hold expires.

<!-- hold-until: 2026-08-08 -->