### PR TITLE
ci(deps): adopt arcuru/actions v0.4.0

### DIFF
--- a/.github/workflows/actions-audit.yml
+++ b/.github/workflows/actions-audit.yml
@@ -19,6 +19,6 @@ permissions:
 
 jobs:
   audit:
-    uses: arcuru/actions/.github/workflows/actions-audit.yml@863120f2dbc739f0b9a66c5c01e85b87d7551ac8 # v0.3.1
+    uses: arcuru/actions/.github/workflows/actions-audit.yml@ec6897e9561bdefa62d5eb364d49b41bcba122a5 # v0.4.0
     with:
       runs-on: ubicloud-standard-2

--- a/.github/workflows/actions-update.yml
+++ b/.github/workflows/actions-update.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   actions-update:
-    uses: arcuru/actions/.github/workflows/actions-update.yml@45540c9d68eb9d2812bd4c85b43888fa05b22ef8 # main
+    uses: arcuru/actions/.github/workflows/actions-update.yml@ec6897e9561bdefa62d5eb364d49b41bcba122a5 # v0.4.0
     with:
       hold-days: ${{ inputs.hold_days || '7' }}
       runs-on: ubicloud-standard-2

--- a/.github/workflows/cargo-update.yml
+++ b/.github/workflows/cargo-update.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   cargo-update:
-    uses: arcuru/actions/.github/workflows/cargo-update.yml@c8144123ad5a2c6316b7becab8233b68dfa637d9 # v0.2.1
+    uses: arcuru/actions/.github/workflows/cargo-update.yml@ec6897e9561bdefa62d5eb364d49b41bcba122a5 # v0.4.0
     with:
       hold-days: ${{ inputs.hold_days || '7' }}
       runs-on: ubicloud-standard-2

--- a/.github/workflows/codeberg.yml
+++ b/.github/workflows/codeberg.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   mirror:
-    uses: arcuru/actions/.github/workflows/codeberg-mirror.yml@c8144123ad5a2c6316b7becab8233b68dfa637d9 # v0.2.1
+    uses: arcuru/actions/.github/workflows/codeberg-mirror.yml@ec6897e9561bdefa62d5eb364d49b41bcba122a5 # v0.4.0
     with:
       runs-on: ubicloud-standard-2
       environment: mirror

--- a/.github/workflows/dependency-hold.yml
+++ b/.github/workflows/dependency-hold.yml
@@ -15,6 +15,6 @@ permissions:
 
 jobs:
   hold:
-    uses: arcuru/actions/.github/workflows/dependency-hold.yml@c8144123ad5a2c6316b7becab8233b68dfa637d9 # v0.2.1
+    uses: arcuru/actions/.github/workflows/dependency-hold.yml@ec6897e9561bdefa62d5eb364d49b41bcba122a5 # v0.4.0
     with:
       runs-on: ubicloud-standard-2

--- a/.github/workflows/flake-update.yml
+++ b/.github/workflows/flake-update.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   flake-update:
-    uses: arcuru/actions/.github/workflows/flake-update.yml@c8144123ad5a2c6316b7becab8233b68dfa637d9 # v0.2.1
+    uses: arcuru/actions/.github/workflows/flake-update.yml@ec6897e9561bdefa62d5eb364d49b41bcba122a5 # v0.4.0
     with:
       hold-days: ${{ inputs.hold_days || '7' }}
       runs-on: ubicloud-standard-2

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   audit:
-    uses: arcuru/actions/.github/workflows/security-audit.yml@c8144123ad5a2c6316b7becab8233b68dfa637d9 # v0.2.1
+    uses: arcuru/actions/.github/workflows/security-audit.yml@ec6897e9561bdefa62d5eb364d49b41bcba122a5 # v0.4.0
     with:
       runs-on: ubicloud-standard-2
       enable-magic-cache: "false"

--- a/.github/workflows/update-hold.yml
+++ b/.github/workflows/update-hold.yml
@@ -1,7 +1,13 @@
 # Daily release of expired dependency holds: scans open PRs labeled "on-hold",
-# parses the hold-until date from the PR body, and removes the label once it is
-# reached, then posts a passing "Dependency Hold" check so the required status
-# is satisfied. Delegates to the arcuru/actions reusable workflow.
+# parses the hold-until date from the PR body, re-verifies the PR's pinned
+# actions, and removes the label once the date is reached. Removing the label
+# re-triggers the Hold Gate, which clears its own failing check. Delegates to
+# the arcuru/actions reusable workflow.
+#
+# The label removal needs PAT_TOKEN: a GITHUB_TOKEN-authored event does not
+# trigger other workflows, so the Hold Gate would never re-run and its check
+# would stay red. PAT_TOKEN is reachable only through `environment: automation`
+# plus `secrets: inherit`.
 name: "Deps: Hold Expiry"
 
 on:
@@ -12,10 +18,11 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  checks: write
 
 jobs:
   update-hold:
-    uses: arcuru/actions/.github/workflows/update-hold.yml@45540c9d68eb9d2812bd4c85b43888fa05b22ef8 # main
+    uses: arcuru/actions/.github/workflows/update-hold.yml@ec6897e9561bdefa62d5eb364d49b41bcba122a5 # v0.4.0
     with:
       runs-on: ubicloud-standard-2
+      environment: automation
+    secrets: inherit

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -28,6 +28,7 @@ rules:
       - actions-update.yml:24
       - cargo-update.yml:24
       - flake-update.yml:24
+      - update-hold.yml:24
   ref-version-mismatch:
     ignore:
       # dtolnay/rust-toolchain publishes no releases and distributes via


### PR DESCRIPTION
Picks up the hold-gate fix. The expiry job now removes the on-hold label with PAT_TOKEN so the unlabeled event re-triggers the Hold Gate, which clears its own failing check; previously the label was removed with GITHUB_TOKEN, whose events do not trigger other workflows, and a forged "Dependency Hold" check run stood in for the gate. That forged name never matched the real context, which a reusable workflow reports as "hold / Dependency Hold".

update-hold therefore needs PAT_TOKEN, which is reachable only via the automation environment, so the wrapper now passes `environment: automation` and `secrets: inherit`. Its `checks: write` grant goes away with the forged check run.

Also bumps the remaining arcuru/actions references off their mixed v0.2.1 and main pins onto the same release.
