### PR TITLE
feat(sync): resolve bootstrap access through the delegation-aware path

### DIFF
--- a/crates/lib/src/auth/settings.rs
+++ b/crates/lib/src/auth/settings.rs
@@ -354,39 +354,6 @@ impl AuthSettings {
         }
     }
 
-    /// Check if global permission grants sufficient access
-    pub fn global_permission_grants_access(&self, requested_permission: &Permission) -> bool {
-        if let Some(global_perm) = self.get_global_permission() {
-            global_perm >= *requested_permission
-        } else {
-            false
-        }
-    }
-
-    // ==================== Access Control ====================
-
-    /// Check whether a public key has a **direct or global** grant at this
-    /// permission level.
-    ///
-    /// The cheap, synchronous, settings-only access check: it honours key
-    /// status and sees direct key entries and the global `*` grant, but it does
-    /// **not** walk delegated databases — a key whose authority arrives only
-    /// through a delegation reads as `false` here. For a delegation-aware check
-    /// use [`Database::find_sigkeys`](crate::Database::find_sigkeys), which is
-    /// what the bootstrap and signing paths resolve through.
-    pub fn can_access(&self, pubkey: &PublicKey, requested_permission: &Permission) -> bool {
-        // First check if there's a specific key entry for this pubkey
-        if let Ok(auth_key) = self.get_key_by_pubkey(pubkey)
-            && auth_key.is_active()
-            && *auth_key.permissions() >= *requested_permission
-        {
-            return true;
-        }
-
-        // Check global permission
-        self.global_permission_grants_access(requested_permission)
-    }
-
     /// Find all SigKeys that a public key can use to access this database
     ///
     /// Returns (SigKey, Permission) tuples sorted by permission (highest first)
@@ -557,12 +524,6 @@ mod tests {
             settings.get_global_permission(),
             Some(Permission::Write(10))
         );
-
-        // Test permission granting
-        assert!(settings.global_permission_grants_access(&Permission::Read));
-        assert!(settings.global_permission_grants_access(&Permission::Write(10)));
-        assert!(!settings.global_permission_grants_access(&Permission::Write(5)));
-        assert!(!settings.global_permission_grants_access(&Permission::Admin(10)));
     }
 
     #[test]
@@ -689,40 +650,6 @@ mod tests {
         let (sig_key, granted_perm) = settings.resolve_sig_key_for_operation(&pubkey).unwrap();
         assert!(sig_key.has_pubkey_hint(&pubkey));
         assert_eq!(granted_perm, Permission::Write(5));
-    }
-
-    #[test]
-    fn test_can_access() {
-        let mut settings = AuthSettings::new();
-
-        let pubkey = PublicKey::random();
-        let other_pubkey = PublicKey::random();
-
-        // No access without keys
-        assert!(!settings.can_access(&pubkey, &Permission::Read));
-
-        // Add specific key
-        settings
-            .add_key(
-                &pubkey,
-                AuthKey::active(Some("device"), Permission::Write(5)),
-            )
-            .unwrap();
-
-        // Specific key should have access
-        assert!(settings.can_access(&pubkey, &Permission::Read));
-        assert!(settings.can_access(&pubkey, &Permission::Write(5)));
-        assert!(!settings.can_access(&pubkey, &Permission::Admin(1)));
-
-        // Other key should not have access
-        assert!(!settings.can_access(&other_pubkey, &Permission::Read));
-
-        // Set global permission
-        settings.set_global_permission(AuthKey::active(None, Permission::Read));
-
-        // Other key should now have read access via global
-        assert!(settings.can_access(&other_pubkey, &Permission::Read));
-        assert!(!settings.can_access(&other_pubkey, &Permission::Write(10)));
     }
 
     #[test]

--- a/crates/lib/src/auth/settings.rs
+++ b/crates/lib/src/auth/settings.rs
@@ -365,7 +365,15 @@ impl AuthSettings {
 
     // ==================== Access Control ====================
 
-    /// Check if a public key can access the database with the requested permission
+    /// Check whether a public key has a **direct or global** grant at this
+    /// permission level.
+    ///
+    /// The cheap, synchronous, settings-only access check: it honours key
+    /// status and sees direct key entries and the global `*` grant, but it does
+    /// **not** walk delegated databases — a key whose authority arrives only
+    /// through a delegation reads as `false` here. For a delegation-aware check
+    /// use [`Database::find_sigkeys`](crate::Database::find_sigkeys), which is
+    /// what the bootstrap and signing paths resolve through.
     pub fn can_access(&self, pubkey: &PublicKey, requested_permission: &Permission) -> bool {
         // First check if there's a specific key entry for this pubkey
         if let Ok(auth_key) = self.get_key_by_pubkey(pubkey)

--- a/crates/lib/src/auth/settings.rs
+++ b/crates/lib/src/auth/settings.rs
@@ -385,8 +385,13 @@ impl AuthSettings {
     pub fn find_all_sigkeys_for_pubkey(&self, pubkey: &PublicKey) -> Vec<(SigKey, Permission)> {
         let mut results = Vec::new();
 
-        // Check if this pubkey has a direct key entry
-        if let Ok(auth_key) = self.get_key_by_pubkey(pubkey) {
+        // Check if this pubkey has an active direct key entry. A revoked or
+        // inactive key is not a usable access method, and callers treat a
+        // returned SigKey as authorization (bootstrap access checks,
+        // `open_database`, operation signing), so discovery must not offer it.
+        if let Ok(auth_key) = self.get_key_by_pubkey(pubkey)
+            && *auth_key.status() == KeyStatus::Active
+        {
             results.push((SigKey::from_pubkey(pubkey), *auth_key.permissions()));
         }
 
@@ -634,6 +639,24 @@ mod tests {
 
         let results = settings.find_all_sigkeys_for_pubkey(&pubkey);
         assert_eq!(results.len(), 2);
+
+        // A revoked direct key is not a usable access method and must not be
+        // discovered — otherwise a revoked (delegated) key could bootstrap.
+        // Checked against fresh settings so no global '*' grant masks the result.
+        let mut revoked_settings = AuthSettings::new();
+        let revoked_pubkey = PublicKey::random();
+        revoked_settings
+            .add_key(
+                &revoked_pubkey,
+                AuthKey::new(Some("revoked"), Permission::Admin(0), KeyStatus::Revoked),
+            )
+            .unwrap();
+        assert!(
+            revoked_settings
+                .find_all_sigkeys_for_pubkey(&revoked_pubkey)
+                .is_empty(),
+            "revoked direct key should not be offered as an access method"
+        );
     }
 
     #[test]

--- a/crates/lib/src/auth/settings.rs
+++ b/crates/lib/src/auth/settings.rs
@@ -369,7 +369,7 @@ impl AuthSettings {
     pub fn can_access(&self, pubkey: &PublicKey, requested_permission: &Permission) -> bool {
         // First check if there's a specific key entry for this pubkey
         if let Ok(auth_key) = self.get_key_by_pubkey(pubkey)
-            && *auth_key.status() == KeyStatus::Active
+            && auth_key.is_active()
             && *auth_key.permissions() >= *requested_permission
         {
             return true;
@@ -390,7 +390,7 @@ impl AuthSettings {
         // returned SigKey as authorization (bootstrap access checks,
         // `open_database`, operation signing), so discovery must not offer it.
         if let Ok(auth_key) = self.get_key_by_pubkey(pubkey)
-            && *auth_key.status() == KeyStatus::Active
+            && auth_key.is_active()
         {
             results.push((SigKey::from_pubkey(pubkey), *auth_key.permissions()));
         }

--- a/crates/lib/src/auth/types/keys.rs
+++ b/crates/lib/src/auth/types/keys.rs
@@ -86,6 +86,16 @@ impl AuthKey {
         &self.status
     }
 
+    /// Whether this key currently grants access.
+    ///
+    /// The single definition of "usable key" at the settings layer — mirror of
+    /// [`ResolvedAuth::grants_access`]. Callers deciding access must gate on
+    /// this rather than re-checking `status` inline, so revocation is honoured
+    /// identically on every path.
+    pub fn is_active(&self) -> bool {
+        self.status == KeyStatus::Active
+    }
+
     /// Set the status (e.g., for revocation)
     pub fn set_status(&mut self, status: KeyStatus) {
         self.status = status;
@@ -550,4 +560,16 @@ pub struct ResolvedAuth {
     pub effective_permission: Permission,
     /// Current status of the key
     pub key_status: KeyStatus,
+}
+
+impl ResolvedAuth {
+    /// Whether this resolved key may currently be used to authorize access.
+    ///
+    /// The single definition of "usable key" for every auth path — resolvers
+    /// return candidates regardless of status, so each consumer that turns
+    /// candidates into an access decision must gate on this, not re-check
+    /// `key_status` inline.
+    pub fn grants_access(&self) -> bool {
+        self.key_status == KeyStatus::Active
+    }
 }

--- a/crates/lib/src/auth/validation/entry.rs
+++ b/crates/lib/src/auth/validation/entry.rs
@@ -13,7 +13,7 @@ use crate::{
     auth::{
         crypto::verify_entry_signature,
         settings::AuthSettings,
-        types::{KeyStatus, Operation, ResolvedAuth, SigKey},
+        types::{Operation, ResolvedAuth, SigKey},
     },
     constants::SETTINGS,
 };
@@ -121,8 +121,8 @@ impl AuthValidator {
 
         // Try signature verification + permission check against each candidate
         for resolved_auth in resolved_auths {
-            // Skip keys that are not active
-            if resolved_auth.key_status != KeyStatus::Active {
+            // Skip keys that do not currently grant access
+            if !resolved_auth.grants_access() {
                 debug!("Skipping inactive key: {:?}", resolved_auth.key_status);
                 continue;
             }

--- a/crates/lib/src/auth/validation/permissions.rs
+++ b/crates/lib/src/auth/validation/permissions.rs
@@ -44,67 +44,53 @@ pub async fn resolve_identity_permission(
                     ),
                 })));
             }
-            auth_settings.get_global_permission().ok_or_else(|| {
+            let global = auth_settings.get_global_key().map_err(|_| {
                 Error::Auth(Box::new(AuthError::InvalidAuthConfiguration {
                     reason: "Global '*' permission not configured".to_string(),
                 }))
-            })
+            })?;
+            if !global.is_active() {
+                return Err(Error::Auth(Box::new(AuthError::InvalidAuthConfiguration {
+                    reason: "Global '*' permission is not active".to_string(),
+                })));
+            }
+            Ok(*global.permissions())
         }
-        SigKey::Direct { hint } => match (&hint.pubkey, &hint.name) {
-            (Some(claimed_pubkey), _) => {
-                if *claimed_pubkey != *pubkey {
-                    return Err(Error::Auth(Box::new(AuthError::SigningKeyMismatch {
-                        reason: format!("pubkey '{pubkey}' but identity claims '{claimed_pubkey}'"),
-                    })));
-                }
-                // Direct membership wins; otherwise fall back to the
-                // wildcard ('*') permission slot, which represents the
-                // tree's grant to "any key not otherwise listed". The
-                // caller already proved possession of `pubkey` (the
-                // connection's session keyset check on the wire path,
-                // signature verification on the local path), so accepting
-                // the wildcard level here is the structural intent of a
-                // global grant — no extra trust required.
-                if let Ok(auth_key) = auth_settings.get_key_by_pubkey(pubkey) {
-                    return Ok(*auth_key.permissions());
-                }
-                if let Some(global) = auth_settings.get_global_permission() {
-                    return Ok(global);
-                }
-                Err(Error::Auth(Box::new(AuthError::KeyNotFound {
-                    key_name: pubkey.to_string(),
-                })))
+        SigKey::Direct { hint } => {
+            // Anti-spoof: a pubkey-bearing hint must claim the proven key.
+            if let Some(claimed_pubkey) = &hint.pubkey
+                && *claimed_pubkey != *pubkey
+            {
+                return Err(Error::Auth(Box::new(AuthError::SigningKeyMismatch {
+                    reason: format!("pubkey '{pubkey}' but identity claims '{claimed_pubkey}'"),
+                })));
             }
-            (_, Some(name)) => {
-                let matches = auth_settings.find_keys_by_name(name);
-                if matches.is_empty() {
-                    // Named identity with no direct match falls back to
-                    // the wildcard slot, same as the pubkey-only branch
-                    // — the structural intent matches.
-                    if let Some(global) = auth_settings.get_global_permission() {
-                        return Ok(global);
-                    }
-                    return Err(Error::Auth(Box::new(AuthError::KeyNotFound {
-                        key_name: name.clone(),
-                    })));
-                }
-                let pubkey_str = pubkey.to_string();
-                let (_, auth_key) = matches
-                    .iter()
-                    .find(|(pk, _)| *pk == pubkey_str)
-                    .ok_or_else(|| {
-                        Error::Auth(Box::new(AuthError::SigningKeyMismatch {
-                            reason: format!(
-                                "pubkey '{pubkey}' but no key named '{name}' has that pubkey"
-                            ),
-                        }))
-                    })?;
-                Ok(*auth_key.permissions())
+            if hint.pubkey.is_none() && hint.name.is_none() {
+                return Err(Error::Auth(Box::new(AuthError::InvalidAuthConfiguration {
+                    reason: "identity has empty hint".to_string(),
+                })));
             }
-            _ => Err(Error::Auth(Box::new(AuthError::InvalidAuthConfiguration {
-                reason: "identity has empty hint".to_string(),
-            }))),
-        },
+            // Resolve the hint through the shared resolver, then take the
+            // highest active grant that belongs to the proven pubkey. Direct
+            // membership wins; otherwise fall back to the wildcard ('*') slot —
+            // the tree's grant to "any key not otherwise listed". The caller
+            // already proved possession of `pubkey` (session keyset check on
+            // the wire path, signature verification locally), so accepting the
+            // wildcard level is the structural intent of a global grant.
+            if let Ok(candidates) = auth_settings.resolve_hint(hint)
+                && let Some(permission) = select_effective_permission(&candidates, pubkey)
+            {
+                return Ok(permission);
+            }
+            if let Ok(global) = auth_settings.get_global_key()
+                && global.is_active()
+            {
+                return Ok(*global.permissions());
+            }
+            Err(Error::Auth(Box::new(AuthError::KeyNotFound {
+                key_name: hint.name.clone().unwrap_or_else(|| pubkey.to_string()),
+            })))
+        }
         SigKey::Delegation { .. } => {
             let mut validator = AuthValidator::new();
             let resolved_auths = validator
@@ -116,17 +102,31 @@ pub async fn resolve_identity_permission(
                     }))
                 })?;
 
-            resolved_auths
-                .into_iter()
-                .find(|ra| ra.public_key == *pubkey)
-                .map(|ra| ra.effective_permission)
-                .ok_or_else(|| {
-                    Error::Auth(Box::new(AuthError::SigningKeyMismatch {
-                        reason: format!("no resolved delegation key matches pubkey '{pubkey}'"),
-                    }))
-                })
+            select_effective_permission(&resolved_auths, pubkey).ok_or_else(|| {
+                Error::Auth(Box::new(AuthError::SigningKeyMismatch {
+                    reason: format!("no active resolved delegation key matches pubkey '{pubkey}'"),
+                }))
+            })
         }
     }
+}
+
+/// Highest permission among resolved candidates that belong to `pubkey` and
+/// currently grant access.
+///
+/// The single place auth paths turn resolved candidates into an effective
+/// permission: resolvers return candidates regardless of key status, so this is
+/// where revocation is honoured — identically for direct, wildcard, and
+/// delegated authority. Returns `None` when no active candidate matches.
+pub(crate) fn select_effective_permission(
+    candidates: &[ResolvedAuth],
+    pubkey: &PublicKey,
+) -> Option<Permission> {
+    candidates
+        .iter()
+        .filter(|ra| ra.public_key == *pubkey && ra.grants_access())
+        .map(|ra| ra.effective_permission)
+        .max()
 }
 
 /// Check if a resolved authentication has sufficient permissions for an operation

--- a/crates/lib/src/auth/validation/tests.rs
+++ b/crates/lib/src/auth/validation/tests.rs
@@ -64,6 +64,43 @@ async fn test_revoked_key_validation() {
     assert!(resolved.is_ok());
 }
 
+/// A revoked direct key must not authorize through `resolve_identity_permission`
+/// (the shared wire/local resolver): with no wildcard it is denied, and with a
+/// wildcard it falls through to the '*' grant rather than keeping its own
+/// (higher) permission.
+#[tokio::test]
+async fn test_resolve_identity_permission_revoked_direct_key() {
+    use crate::auth::validation::permissions::resolve_identity_permission;
+
+    let (_, pubkey) = generate_keypair();
+    let identity = SigKey::from_pubkey(&pubkey);
+
+    let mut settings = AuthSettings::new();
+    settings
+        .add_key(
+            &pubkey,
+            AuthKey::new(Some("dev"), Permission::Admin(0), KeyStatus::Revoked),
+        )
+        .unwrap();
+    assert!(
+        resolve_identity_permission(&pubkey, &identity, &settings, None)
+            .await
+            .is_err(),
+        "revoked direct key with no wildcard must be denied"
+    );
+
+    // Wildcard present: the revoked key drops to '*' (Read), not its own Admin.
+    settings.set_global_permission(AuthKey::active(None, Permission::Read));
+    let perm = resolve_identity_permission(&pubkey, &identity, &settings, None)
+        .await
+        .unwrap();
+    assert_eq!(
+        perm,
+        Permission::Read,
+        "revoked key must fall through to the wildcard, not retain its Admin grant"
+    );
+}
+
 #[tokio::test]
 async fn test_permission_levels() {
     let validator = AuthValidator::new();

--- a/crates/lib/src/database/mod.rs
+++ b/crates/lib/src/database/mod.rs
@@ -666,6 +666,35 @@ impl Database {
         Ok(results)
     }
 
+    /// Whether `pubkey` may access the database at `root_id` with at least
+    /// `permission`.
+    ///
+    /// This is the **pubkey-only** access decision — the caller holds a key but
+    /// has not presented a signing identity (bootstrap deciding whether a key
+    /// already qualifies, for example). It resolves the same authority
+    /// [`find_sigkeys`](Self::find_sigkeys) does — direct grants, the global
+    /// `*` grant, and delegated authority — and never counts revoked keys.
+    ///
+    /// Delegated authority is discovered **one hop deep**: only databases this
+    /// one delegates to directly are searched, so a key reachable through a
+    /// chain of delegations answers `false` here. The limit belongs to
+    /// discovery, not to delegation — when an identity *is* presented (signing
+    /// an entry, a service operation), authorization goes through the resolver
+    /// behind [`validate_key`](Self::validate_key), which walks a delegation
+    /// path of any length because the signer names the path rather than making
+    /// the resolver search for it.
+    pub async fn can_access(
+        instance: &Instance,
+        root_id: &ID,
+        pubkey: &PublicKey,
+        permission: &Permission,
+    ) -> Result<bool> {
+        let sigkeys = Self::find_sigkeys(instance, root_id, pubkey).await?;
+        Ok(sigkeys
+            .first()
+            .is_some_and(|(_, granted)| *granted >= *permission))
+    }
+
     /// Get the auth identity for this database's configured key.
     pub fn auth_identity(&self) -> Option<&SigKey> {
         self.key.as_ref().map(|k| &k.identity)

--- a/crates/lib/src/database/mod.rs
+++ b/crates/lib/src/database/mod.rs
@@ -589,7 +589,10 @@ impl Database {
         root_id: &ID,
         pubkey: &PublicKey,
     ) -> Result<Vec<(SigKey, Permission)>> {
-        use crate::auth::{permission::clamp_permission, types::DelegationStep};
+        use crate::auth::{
+            types::DelegationStep,
+            validation::{AuthValidator, permissions::select_effective_permission},
+        };
 
         // Create temporary database to load settings (no key source needed for reading)
         let temp_db = Self::open(instance, root_id).await?;
@@ -601,54 +604,59 @@ impl Database {
         // Find direct SigKeys for this pubkey
         let mut results = auth_settings.find_all_sigkeys_for_pubkey(pubkey);
 
-        // Scan single-hop delegation paths
+        // Scan single-hop delegation paths. Resolution — permission-bounds
+        // clamping, key status, the tip floor — is delegated to the validator,
+        // the single delegation walker, so this stays pure discovery: find which
+        // delegated trees list the pubkey, then resolve each through the shared
+        // path at the delegated tree's *current* tips.
         // FIXME: deep nested delegations can't use this
         if let Ok(delegated_trees) = auth_settings.get_all_delegated_trees() {
-            for (delegated_root_id, delegated_tree_ref) in &delegated_trees {
-                // Load the delegated tree's auth settings
-                let delegated_db = match Self::open(instance, delegated_root_id).await {
-                    Ok(db) => db,
+            let mut validator = AuthValidator::new();
+            for delegated_root_id in delegated_trees.keys() {
+                // Load the delegated tree's auth to see which of the pubkey's
+                // hints it lists (enumeration only — the validator re-resolves).
+                let delegated_auth = match Self::open(instance, delegated_root_id).await {
+                    Ok(db) => match db.get_settings().await {
+                        Ok(s) => match s.auth_snapshot().await {
+                            Ok(a) => a,
+                            Err(_) => continue,
+                        },
+                        Err(_) => continue,
+                    },
                     Err(_) => continue,
                 };
-                let delegated_settings = match delegated_db.get_settings().await {
-                    Ok(s) => s,
-                    Err(_) => continue,
-                };
-                let delegated_auth = match delegated_settings.auth_snapshot().await {
-                    Ok(a) => a,
-                    Err(_) => continue,
-                };
-
-                // Check if pubkey exists in the delegated tree
                 let delegated_sigkeys = delegated_auth.find_all_sigkeys_for_pubkey(pubkey);
                 if delegated_sigkeys.is_empty() {
                     continue;
                 }
 
-                // Get current tips for the delegated tree
-                let delegated_snapshot = match instance.backend().snapshot(delegated_root_id).await
-                {
-                    Ok(snap) => snap,
+                // Current tips = the "live authority" question (caller-supplied),
+                // distinct from a signature's claimed tips. They are at or above
+                // the committed floor, so the validator's floor check passes.
+                let tips = match instance.backend().snapshot(delegated_root_id).await {
+                    Ok(snap) => snap.tips().to_vec(),
                     Err(_) => continue,
                 };
-                let tips = delegated_snapshot.tips();
 
-                // For each matching key in the delegated tree, construct a delegation SigKey
-                for (delegated_sk, delegated_perm) in delegated_sigkeys {
-                    // Clamp the delegated permission through the bounds
-                    let effective_perm =
-                        clamp_permission(delegated_perm, &delegated_tree_ref.permission_bounds);
-
-                    // Construct the delegation SigKey using the hint from the direct key
+                for (delegated_sk, _) in delegated_sigkeys {
                     let delegation_sigkey = SigKey::Delegation {
                         path: vec![DelegationStep {
                             tree: delegated_root_id.clone(),
-                            tips: tips.to_vec(),
+                            tips: tips.clone(),
                         }],
                         hint: delegated_sk.hint().clone(),
                     };
-
-                    results.push((delegation_sigkey, effective_perm));
+                    // Resolve through the single delegation walker; bounds,
+                    // status, and the tip floor all live there, not here.
+                    let Ok(resolved) = validator
+                        .resolve_sig_key(&delegation_sigkey, &auth_settings, Some(instance))
+                        .await
+                    else {
+                        continue;
+                    };
+                    if let Some(perm) = select_effective_permission(&resolved, pubkey) {
+                        results.push((delegation_sigkey, perm));
+                    }
                 }
             }
         }

--- a/crates/lib/src/sync/handler.rs
+++ b/crates/lib/src/sync/handler.rs
@@ -254,12 +254,15 @@ impl SyncHandlerImpl {
 
     /// Check if the requesting key already has sufficient permissions through existing auth.
     ///
-    /// Resolves the requester's best available permission through
-    /// [`Database::find_sigkeys`] — the same discovery primitive `open_database`
-    /// and operation signing use. It resolves direct grants, the global `*`
-    /// grant, and — unlike [`AuthSettings::can_access`] — authority that reaches
-    /// this tree only through a *delegated* tree (the sync "nesting doll" model).
-    /// Without it a delegated-only key is bounced to manual approval and hangs.
+    /// Delegates to [`Database::can_access`], the pubkey-only access decision,
+    /// which resolves direct grants, the global `*` grant, and authority that
+    /// reaches this tree only through a *delegated* tree. Without the delegated
+    /// case a delegated-only key is bounced to manual approval and hangs.
+    ///
+    /// Delegation discovery is **one hop deep**: a key reachable only through a
+    /// chain of delegations still falls through to manual approval. See
+    /// [`Database::can_access`] for why bootstrap searches where entry
+    /// validation walks a named path.
     ///
     /// # Arguments
     /// * `tree_id` - The database/tree ID to check auth settings for
@@ -275,12 +278,13 @@ impl SyncHandlerImpl {
         requesting_pubkey: &PublicKey,
         requested_permission: &Permission,
     ) -> Result<bool> {
-        // Results are sorted highest-permission-first and exclude revoked keys,
-        // so the top candidate is the requester's best available authority.
-        let sigkeys = Database::find_sigkeys(&self.instance()?, tree_id, requesting_pubkey).await?;
-        let granted = sigkeys
-            .first()
-            .is_some_and(|(_, permission)| *permission >= *requested_permission);
+        let granted = Database::can_access(
+            &self.instance()?,
+            tree_id,
+            requesting_pubkey,
+            requested_permission,
+        )
+        .await?;
         if granted {
             debug!(
                 tree_id = %tree_id,

--- a/crates/lib/src/sync/handler.rs
+++ b/crates/lib/src/sync/handler.rs
@@ -254,8 +254,12 @@ impl SyncHandlerImpl {
 
     /// Check if the requesting key already has sufficient permissions through existing auth.
     ///
-    /// This uses the AuthSettings.can_access() method to check if the requesting key
-    /// already has sufficient permissions (including through global '*' permissions).
+    /// Resolves the requester's best available permission through
+    /// [`Database::find_sigkeys`] — the same discovery primitive `open_database`
+    /// and operation signing use. It resolves direct grants, the global `*`
+    /// grant, and — unlike [`AuthSettings::can_access`] — authority that reaches
+    /// this tree only through a *delegated* tree (the sync "nesting doll" model).
+    /// Without it a delegated-only key is bounced to manual approval and hangs.
     ///
     /// # Arguments
     /// * `tree_id` - The database/tree ID to check auth settings for
@@ -271,23 +275,21 @@ impl SyncHandlerImpl {
         requesting_pubkey: &PublicKey,
         requested_permission: &Permission,
     ) -> Result<bool> {
-        let database = Database::open(&self.instance()?, tree_id).await?;
-        let settings_store = database.get_settings().await?;
-
-        let auth_settings = settings_store.auth_snapshot().await?;
-
-        // Use the AuthSettings.can_access() method to check permissions
-        if auth_settings.can_access(requesting_pubkey, requested_permission) {
+        // Results are sorted highest-permission-first and exclude revoked keys,
+        // so the top candidate is the requester's best available authority.
+        let sigkeys = Database::find_sigkeys(&self.instance()?, tree_id, requesting_pubkey).await?;
+        let granted = sigkeys
+            .first()
+            .is_some_and(|(_, permission)| *permission >= *requested_permission);
+        if granted {
             debug!(
                 tree_id = %tree_id,
                 requesting_pubkey = %requesting_pubkey,
                 requested_permission = ?requested_permission,
                 "Key has sufficient permission for bootstrap access"
             );
-            return Ok(true);
         }
-
-        Ok(false)
+        Ok(granted)
     }
 
     /// Check if a database requires authentication for unauthenticated requests.

--- a/crates/lib/src/sync/handler.rs
+++ b/crates/lib/src/sync/handler.rs
@@ -22,7 +22,7 @@ use super::{
 use crate::{
     Database, Entry, Error, Instance, Result, WeakInstance,
     auth::{
-        KeyStatus, Permission,
+        Permission,
         crypto::{PublicKey, create_challenge_response, generate_challenge},
     },
     crdt::Doc,
@@ -324,7 +324,7 @@ impl SyncHandlerImpl {
 
         // Auth is configured - check if there's an Active global permission
         if let Ok(global_key) = auth_settings.get_global_key()
-            && *global_key.status() == KeyStatus::Active
+            && global_key.is_active()
         {
             debug!(
                 tree_id = %tree_id,

--- a/crates/lib/tests/it/auth/delegated_trees.rs
+++ b/crates/lib/tests/it/auth/delegated_trees.rs
@@ -348,6 +348,29 @@ async fn test_delegated_tree_with_revoked_keys() -> Result<()> {
     assert_eq!(resolved_auth_revoked.len(), 1);
     assert_eq!(resolved_auth_revoked[0].key_status, KeyStatus::Revoked);
 
+    // The shared resolver must not grant a delegated key once it is revoked,
+    // resolved at the delegated tree's *current* tips (post-revocation).
+    let revoked_tips = delegated_tree.snapshot().await?.into_tips();
+    let revoked_delegation_id = SigKey::Delegation {
+        path: vec![DelegationStep {
+            tree: delegated_tree_root.clone(),
+            tips: revoked_tips,
+        }],
+        hint: KeyHint::from_pubkey(&delegated_user_key),
+    };
+    let main_auth_now = main_tree.get_settings().await?.auth_snapshot().await?;
+    let denied = eidetica::auth::validation::permissions::resolve_identity_permission(
+        &delegated_user_key,
+        &revoked_delegation_id,
+        &main_auth_now,
+        Some(&db),
+    )
+    .await;
+    assert!(
+        denied.is_err(),
+        "revoked delegated key must not resolve to a permission at current tips"
+    );
+
     Ok(())
 }
 

--- a/crates/lib/tests/it/sync/manual_approval_test.rs
+++ b/crates/lib/tests/it/sync/manual_approval_test.rs
@@ -816,10 +816,7 @@ async fn test_bootstrap_with_existing_global_permission_no_duplicate() {
 ///
 /// Before the fix the bootstrap check used the delegation-blind
 /// `AuthSettings::can_access`, so K2 was bounced to manual approval and hung.
-/// This test is `#[should_panic]` at the commit that introduces it (documenting
-/// the current bug) and holds for real once the resolver is wired in.
 #[tokio::test]
-#[should_panic(expected = "delegated-only key was bounced to manual approval")]
 async fn test_bootstrap_with_delegated_only_key_auto_approval() {
     use eidetica::auth::types::{DelegatedTreeRef, PermissionBounds, TreeReference};
 

--- a/crates/lib/tests/it/sync/manual_approval_test.rs
+++ b/crates/lib/tests/it/sync/manual_approval_test.rs
@@ -814,8 +814,9 @@ async fn test_bootstrap_with_existing_global_permission_no_duplicate() {
 /// - K2 is `Admin` on D but has **no** direct grant on T
 /// - K2 requests bootstrap access to T presenting only its pubkey
 ///
-/// Before the fix the bootstrap check used the delegation-blind
-/// `AuthSettings::can_access`, so K2 was bounced to manual approval and hung.
+/// Before the fix the bootstrap check used a delegation-blind settings-level
+/// access check, so K2 was bounced to manual approval and hung. It now resolves
+/// through `Database::can_access`.
 #[tokio::test]
 async fn test_bootstrap_with_delegated_only_key_auto_approval() {
     use eidetica::auth::types::{DelegatedTreeRef, PermissionBounds, TreeReference};

--- a/crates/lib/tests/it/sync/manual_approval_test.rs
+++ b/crates/lib/tests/it/sync/manual_approval_test.rs
@@ -806,6 +806,118 @@ async fn test_bootstrap_with_existing_global_permission_no_duplicate() {
     );
 }
 
+/// A key whose only authority on the target tree flows through a *delegated*
+/// tree must bootstrap-access it, just like it can already sign entries there.
+///
+/// Topology (mirrors chaz's standalone-bridge split):
+/// - session tree T grants `Write` directly to K1 and delegates to agent tree D
+/// - K2 is `Admin` on D but has **no** direct grant on T
+/// - K2 requests bootstrap access to T presenting only its pubkey
+///
+/// Before the fix the bootstrap check used the delegation-blind
+/// `AuthSettings::can_access`, so K2 was bounced to manual approval and hung.
+/// This test is `#[should_panic]` at the commit that introduces it (documenting
+/// the current bug) and holds for real once the resolver is wired in.
+#[tokio::test]
+#[should_panic(expected = "delegated-only key was bounced to manual approval")]
+async fn test_bootstrap_with_delegated_only_key_auto_approval() {
+    use eidetica::auth::types::{DelegatedTreeRef, PermissionBounds, TreeReference};
+
+    // Server owns both the session tree (T) and the agent tree (D).
+    let (server_instance, mut server_user, server_key_id) =
+        crate::helpers::test_local_instance_with_user_and_key("server_user", Some("server_admin"))
+            .await;
+    server_instance.enable_sync().await.unwrap();
+
+    // Agent tree D: K2 is Admin on it, with no relationship to T except the
+    // delegation T will declare below.
+    let k2 = PublicKey::random();
+    let mut d_settings = Doc::new();
+    d_settings.set("name", "Agent DB (delegated tree)");
+    let agent_db = server_user
+        .create_database(d_settings, &server_key_id)
+        .await
+        .unwrap();
+    crate::helpers::add_auth_key(
+        &agent_db,
+        &k2,
+        AuthKey::active(Some("daemon"), AuthPermission::Admin(5)),
+    )
+    .await;
+
+    // Session tree T: direct Write grant to an unrelated K1, plus a delegation
+    // to D capped at Write (session delegations cap below Admin by design).
+    let k1 = PublicKey::random();
+    let mut t_settings = Doc::new();
+    t_settings.set("name", "Session DB (target tree)");
+    let session_db = server_user
+        .create_database(t_settings, &server_key_id)
+        .await
+        .unwrap();
+    crate::helpers::add_auth_key(
+        &session_db,
+        &k1,
+        AuthKey::active(Some("bridge"), AuthPermission::Write(10)),
+    )
+    .await;
+
+    // Declare the delegation on T, pinned to D's current tips (which now
+    // include K2's key entry).
+    let delegation_ref = DelegatedTreeRef {
+        permission_bounds: PermissionBounds {
+            max: AuthPermission::Write(10),
+            min: None,
+        },
+        tree: TreeReference {
+            root: agent_db.root_id().clone(),
+            tips: agent_db.snapshot().await.unwrap().into_tips(),
+        },
+    };
+    let txn = session_db.new_transaction().await.unwrap();
+    txn.get_settings()
+        .unwrap()
+        .add_delegated_tree(delegation_ref)
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
+    let tree_id = session_db.root_id().clone();
+
+    // Stand up the sync handler for T.
+    let sync = Sync::new(server_instance.clone()).await.unwrap();
+    enable_sync_for_instance_database(&sync, &tree_id)
+        .await
+        .unwrap();
+    let sync_handler = create_test_sync_handler(&sync);
+
+    // K2 bootstraps T with only its pubkey; its Admin-on-D clamps to Write(10).
+    let sync_request = create_bootstrap_request(
+        &tree_id,
+        &k2.to_string(),
+        "daemon_key",
+        AuthPermission::Write(10),
+    );
+    let context = RequestContext::default();
+    let response = sync_handler.handle_request(&sync_request, &context).await;
+
+    match response {
+        SyncResponse::Bootstrap(bootstrap_response) => {
+            assert!(
+                bootstrap_response.key_approved,
+                "delegated-only key should be auto-approved"
+            );
+            assert_eq!(
+                bootstrap_response.granted_permission,
+                Some(AuthPermission::Write(10)),
+                "granted permission should be the delegated authority, clamped to Write(10)"
+            );
+        }
+        SyncResponse::BootstrapPending { .. } => {
+            panic!("delegated-only key was bounced to manual approval");
+        }
+        other => panic!("Expected Bootstrap response, got: {other:?}"),
+    }
+}
+
 /// Test that demonstrates client-side key discovery issue: clients approved via global
 /// permission need a way to discover which SigKey to use for creating entries.
 ///

--- a/docs/src/design/authentication.md
+++ b/docs/src/design/authentication.md
@@ -915,7 +915,7 @@ The current system uses entry metadata to reference settings tips. With authenti
    - Add/update/get authentication keys
    - Convert between settings storage and auth types
    - Validate authentication operations
-   - Check permission access with `can_access()` method for both specific and wildcard keys
+   - Resolve keys and permissions for access decisions (direct and wildcard); delegation-aware access resolves through `Database::find_sigkeys`/`Database::can_access`
 
 4. **Permission Module** (`auth/permission.rs`): Permission logic
    - Permission checking for operations

--- a/docs/src/internal/bootstrap.md
+++ b/docs/src/internal/bootstrap.md
@@ -4,7 +4,7 @@ Secure key management and access control for new devices joining existing databa
 
 ## Architecture
 
-Bootstrap requests are stored in the sync database (`_sync`), not target databases. The system supports automatic approval via global `*` permissions or manual approval workflow.
+Bootstrap requests are stored in the sync database (`_sync`), not target databases. A request is auto-approved when the requesting key already holds sufficient authority on the target database; otherwise it enters the manual approval workflow.
 
 ## Request Flow
 
@@ -15,9 +15,9 @@ sequenceDiagram
     participant Database
 
     Client->>Handler: Bootstrap Request (key, permission)
-    Handler->>Handler: Check global '*' permission
+    Handler->>Handler: Resolve existing authority (direct / global '*' / delegated)
 
-    alt Global Permission Sufficient
+    alt Existing authority sufficient
         Handler-->>Client: BootstrapResponse (approved)
     else Need Manual Approval
         Handler->>Handler: Store request
@@ -27,14 +27,28 @@ sequenceDiagram
     end
 ```
 
-## Global Permission Auto-Approval
+## Existing-Authority Auto-Approval
 
-If the database has a global `*` permission that satisfies the request, approval is immediate without adding a new key. The device uses the global permission for all operations.
+If the requesting key already has sufficient permission on the target database, approval is immediate without adding a new key. The check resolves authority through the same discovery path the rest of the auth layer uses (`Database::find_sigkeys`), so it recognizes:
+
+- a **direct** key entry for the requesting pubkey,
+- a **global `*`** grant, and
+- authority reaching the database **only through a delegated database** — the requesting key is a member of a database this one delegates to.
+
+Revoked keys are never treated as sufficient. When no existing authority satisfies the request, it falls through to the manual approval workflow below.
 
 Permission hierarchy uses **lower numbers = higher priority**:
 
 - Global `Write(10)` allows requests for `Read`, `Write(11)`, `Write(15)`
 - Global `Write(10)` rejects requests for `Write(5)`, `Admin(*)`
+
+### Delegation discovery is one hop deep
+
+Discovery searches only the databases the target database delegates to **directly**. A key whose authority arrives through a chain — the target delegates to A, A delegates to B, and the key is held in B — is not found, and the request falls through to manual approval.
+
+This is a limitation of _discovery_, not of delegation itself. Entry validation resolves delegation paths of arbitrary length, because a signer names its own path in the signature and the resolver merely walks it, clamping permission bounds at each step. Bootstrap has no such path: the client presents a bare public key, so the server has to search for one, and the search is currently a single level.
+
+Lifting the limit means either making discovery recursive or letting the client supply its delegation path in the request as a search hint. The latter is cheaper, and safe for the same reason the named path is safe during validation — every step is checked against the server's own settings and tips, so a hint can only fail to resolve, never grant.
 
 ## Manual Approval API
 


### PR DESCRIPTION
Bootstrap resolved access through `AuthSettings::can_access`, which only ever
sees direct key entries and the global `*` grant. A key whose authority reaches
the tree through a delegated tree failed that check, so the handler filed a
pending manual-approval request and the requester hung even though the
delegation engine could decide the question.

Bootstrap now resolves through the same discovery path entry validation uses, so
delegated authority is honored wherever it is checked. The access decision moves
onto `Database::can_access`, the pubkey-only entry point: direct grants, the
global grant, and delegated trees, with revoked keys never counted.

The supporting refactors remove the second implementation rather than adding a
branch to it — `find_sigkeys` discovery routes through the one delegation walker,
and the key-status rule lives in a single place so `resolve_identity_permission`
reports what it actually resolved.

Opens with a failing test for delegated-only bootstrap access.
