### PR TITLE
fix(sync): authorize entry-serving sync requests against a proven key

### DIFF
--- a/crates/bin/src/commands/serve.rs
+++ b/crates/bin/src/commands/serve.rs
@@ -526,14 +526,26 @@ async fn handle_track_database(
         }
     };
 
-    let key_id = {
+    let (key_id, signing_key) = {
         let user = user_lock.read().await;
-        match user.get_default_key() {
+        let key_id = match user.get_default_key() {
             Ok(key) => key,
             Err(e) => {
                 return (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     format!("Failed to get default key: {e}"),
+                )
+                    .into_response();
+            }
+        };
+        // Taken under the same lock: the bootstrap request is signed with this
+        // key to prove we hold it.
+        match user.get_signing_key(&key_id) {
+            Ok(signing_key) => (key_id, signing_key),
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Failed to get signing key: {e}"),
                 )
                     .into_response();
             }
@@ -544,7 +556,7 @@ async fn handle_track_database(
     // slow or hung peer must not freeze the rest of this session's requests.
     let key_name = key_id.to_string();
     let network_result = sync
-        .bootstrap_with_ticket(&ticket, &key_id, &key_name, permission, None)
+        .bootstrap_with_ticket(&ticket, &signing_key, &key_name, permission, None)
         .await;
 
     // Re-acquire only for the cheap, local SigKey-mapping write.

--- a/crates/lib/src/sync/background/mod.rs
+++ b/crates/lib/src/sync/background/mod.rs
@@ -17,7 +17,7 @@ use super::{
     handler::SyncHandlerImpl,
     peer_manager::PeerManager,
     peer_types::{Address, PeerId, PeerStatus},
-    protocol::{SyncRequest, SyncResponse, SyncTreeRequest},
+    protocol::{SyncRequest, SyncRequestAuth, SyncResponse, SyncTreeRequest},
     queue::SyncQueue,
     transport_manager::TransportManager,
 };
@@ -749,15 +749,23 @@ impl BackgroundSync {
 
             debug!(peer = %peer_id, tree = %tree_id, our_tips = our_tips.len(), "Sending sync tree request");
 
-            // Send unified sync request
+            // Send unified sync request, signed so the peer can authorize the pull
+            let auth = SyncRequestAuth::sign(
+                instance.signing_key()?,
+                peer_id.public_key(),
+                tree_id,
+                &our_tips,
+                instance.clock().now_millis(),
+            );
             let request = SyncRequest::SyncTree(SyncTreeRequest {
                 tree_id: tree_id.clone(),
                 our_tips,
                 peer_pubkey: our_device_pubkey,
-                requesting_key: None, // TODO: Add auth support for background sync
+                requesting_key: None,
                 requesting_key_name: None,
                 requested_permission: None,
                 metadata: None,
+                auth: Some(auth),
             });
 
             let response = self.transport_manager.send_request(address, &request).await?;

--- a/crates/lib/src/sync/bootstrap.rs
+++ b/crates/lib/src/sync/bootstrap.rs
@@ -8,7 +8,7 @@ use super::{
 };
 use crate::{
     Database, Result,
-    auth::{Permission, crypto::PublicKey, types::AuthKey},
+    auth::{Permission, crypto::PrivateKey, types::AuthKey},
     crdt::Doc,
     database::DatabaseKey,
     entry::ID,
@@ -33,7 +33,7 @@ impl Sync {
     /// # Arguments
     /// * `address` - The transport address of the peer to sync with
     /// * `tree_id` - The ID of the tree to sync
-    /// * `requesting_public_key` - The formatted public key string for authentication
+    /// * `requesting_key` - The private key to sign the request with and request access for
     /// * `requesting_key_name` - The name/ID of the requesting key
     /// * `requested_permission` - The permission level being requested
     ///
@@ -47,7 +47,7 @@ impl Sync {
         &self,
         address: &Address,
         tree_id: &ID,
-        requesting_public_key: &PublicKey,
+        requesting_key: &PrivateKey,
         requesting_key_name: &str,
         requested_permission: Permission,
         metadata: Option<Doc>,
@@ -70,7 +70,7 @@ impl Sync {
         self.sync_tree_with_peer_auth(
             &peer_pubkey,
             tree_id,
-            Some(requesting_public_key),
+            Some(requesting_key),
             Some(requesting_key_name),
             Some(requested_permission),
             metadata,
@@ -91,7 +91,7 @@ impl Sync {
     /// # Arguments
     /// * `address` - The transport address of the peer to sync with
     /// * `tree_id` - The ID of the tree to sync
-    /// * `requesting_public_key` - The formatted public key string (e.g., "ed25519:base64...")
+    /// * `requesting_key` - The private key to sign the request with and request access for
     /// * `requesting_key_name` - The name/ID of the requesting key for audit trail
     /// * `requested_permission` - The permission level being requested
     ///
@@ -101,11 +101,11 @@ impl Sync {
     /// # Example
     /// ```rust,ignore
     /// // With User API managed keys:
-    /// let public_key = user.get_public_key(user_key_id)?;
+    /// let signing_key = user.get_signing_key(user_key_id)?;
     /// sync.sync_with_peer_for_bootstrap_with_key(
     ///     &Address::http("127.0.0.1:8080"),
     ///     &tree_id,
-    ///     &public_key,
+    ///     &signing_key,
     ///     user_key_id,
     ///     Permission::Write(5),
     /// ).await?;
@@ -114,7 +114,7 @@ impl Sync {
         &self,
         address: &Address,
         tree_id: &ID,
-        requesting_public_key: &PublicKey,
+        requesting_key: &PrivateKey,
         requesting_key_name: &str,
         requested_permission: Permission,
     ) -> Result<()> {
@@ -123,7 +123,7 @@ impl Sync {
         self.sync_with_peer_for_bootstrap_internal(
             address,
             tree_id,
-            requesting_public_key,
+            requesting_key,
             requesting_key_name,
             requested_permission,
             None,
@@ -139,7 +139,7 @@ impl Sync {
     ///
     /// # Arguments
     /// * `ticket` - A ticket containing the database ID and address hints.
-    /// * `requesting_public_key` - The formatted public key string for authentication.
+    /// * `requesting_key` - The private key to sign the request with and request access for.
     /// * `requesting_key_name` - The name/ID of the requesting key.
     /// * `requested_permission` - The permission level being requested.
     /// * `metadata` - Optional free-form context the requester attaches for the
@@ -151,24 +151,24 @@ impl Sync {
     pub async fn bootstrap_with_ticket(
         &self,
         ticket: &DatabaseTicket,
-        requesting_public_key: &PublicKey,
+        requesting_key: &PrivateKey,
         requesting_key_name: &str,
         requested_permission: Permission,
         metadata: Option<Doc>,
     ) -> Result<()> {
         let database_id = ticket.database_id().clone();
-        let pubkey = requesting_public_key.clone();
+        let signing_key = requesting_key.clone();
         let key_name = requesting_key_name.to_string();
         self.try_addresses_concurrently(ticket.addresses(), |sync, addr| {
             let db_id = database_id.clone();
-            let pubkey = pubkey.clone();
+            let signing_key = signing_key.clone();
             let key_name = key_name.clone();
             let metadata = metadata.clone();
             async move {
                 sync.sync_with_peer_for_bootstrap_internal(
                     &addr,
                     &db_id,
-                    &pubkey,
+                    &signing_key,
                     &key_name,
                     requested_permission,
                     metadata,

--- a/crates/lib/src/sync/error.rs
+++ b/crates/lib/src/sync/error.rs
@@ -136,6 +136,18 @@ pub enum SyncError {
         actual_permission: Permission,
     },
 
+    /// A request that would be served data carried no proof of key possession.
+    #[error("Authentication required to read database '{0}'")]
+    AuthenticationRequired(String),
+
+    /// The proof of key possession did not hold up.
+    #[error("Authentication failed: {0}")]
+    AuthenticationFailed(String),
+
+    /// The caller proved its key, but that key has no read access.
+    #[error("Permission denied: {0}")]
+    PermissionDenied(String),
+
     /// Invalid public key provided.
     #[error("Invalid public key: {reason}")]
     InvalidPublicKey { reason: String },

--- a/crates/lib/src/sync/handler.rs
+++ b/crates/lib/src/sync/handler.rs
@@ -4,7 +4,10 @@
 //! sync requests and generate responses. These handlers can be
 //! used by any transport implementation through the SyncHandler trait.
 
-use std::collections::BTreeMap;
+use std::{
+    collections::{BTreeMap, HashMap},
+    sync::Mutex,
+};
 
 use async_trait::async_trait;
 use tracing::{Instrument, debug, error, info, info_span, trace, warn};
@@ -53,10 +56,22 @@ pub trait SyncHandler: Send + std::marker::Sync {
     -> SyncResponse;
 }
 
+/// How far a request's timestamp may sit from our clock, in either direction.
+///
+/// Bounds how long a captured signature stays useful. Peers with clocks further
+/// apart than this cannot sync — the window trades clock tolerance against
+/// replay exposure.
+const MAX_REQUEST_AGE_MS: u64 = 60_000;
+
 /// Default implementation of SyncHandler with database backend access.
 pub struct SyncHandlerImpl {
     instance: WeakInstance,
     sync_tree_id: ID,
+    /// Nonces spent within the freshness window, keyed by the claiming key.
+    ///
+    /// Makes each signature single-use: without this, anyone who observes a
+    /// signed request can replay it verbatim until it ages out.
+    spent_nonces: Mutex<HashMap<(PublicKey, Vec<u8>), u64>>,
 }
 
 impl SyncHandlerImpl {
@@ -69,7 +84,80 @@ impl SyncHandlerImpl {
         Self {
             instance: instance.downgrade(),
             sync_tree_id,
+            spent_nonces: Mutex::new(HashMap::new()),
         }
+    }
+
+    /// Authenticate a request that is about to be served data.
+    ///
+    /// Returns the key the caller has proven it holds. Checks, in order:
+    /// the signature covers *this* request to *us*, the request is fresh, and
+    /// its nonce has not been spent.
+    ///
+    /// This does not decide authorization — see [`Database::can_access`].
+    fn authenticate_request(&self, request: &SyncTreeRequest) -> Result<PublicKey> {
+        let auth = request
+            .auth
+            .as_ref()
+            .ok_or_else(|| SyncError::AuthenticationRequired(request.tree_id.to_string()))?;
+
+        let instance = self.instance()?;
+        auth.verify(&instance.id(), &request.tree_id, &request.our_tips)
+            .map_err(|_| {
+                SyncError::AuthenticationFailed("invalid request signature".to_string())
+            })?;
+
+        let now = instance.clock().now_millis();
+        if now.abs_diff(auth.timestamp_ms) > MAX_REQUEST_AGE_MS {
+            return Err(SyncError::AuthenticationFailed(
+                "request timestamp outside the freshness window".to_string(),
+            )
+            .into());
+        }
+
+        // The map holds one entry per verified request in the last window, so
+        // it is bounded by request rate, not by uptime. Cap it if a peer can
+        // ever outrun that.
+        let mut spent = self
+            .spent_nonces
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        spent.retain(|_, spent_at| now.abs_diff(*spent_at) <= MAX_REQUEST_AGE_MS);
+        if spent
+            .insert((auth.key.clone(), auth.nonce.clone()), auth.timestamp_ms)
+            .is_some()
+        {
+            return Err(
+                SyncError::AuthenticationFailed("request nonce already spent".to_string()).into(),
+            );
+        }
+
+        Ok(auth.key.clone())
+    }
+
+    /// Whether this request may be served entries from `tree_id`.
+    ///
+    /// A database with no auth configured, or with a global `*` grant, is
+    /// world-readable by design and needs no credentials. Otherwise the caller
+    /// must prove it holds a key that [`Database::can_access`] accepts —
+    /// directly, through the global grant, or through a delegated tree.
+    async fn authorize_read(&self, request: &SyncTreeRequest) -> Result<()> {
+        if !self.check_if_database_has_auth(&request.tree_id).await? {
+            return Ok(());
+        }
+
+        let key = self.authenticate_request(request)?;
+        if !Database::can_access(&self.instance()?, &request.tree_id, &key, &Permission::Read)
+            .await?
+        {
+            return Err(SyncError::PermissionDenied(format!(
+                "key {key} is not authorized to read {}",
+                request.tree_id
+            ))
+            .into());
+        }
+
+        Ok(())
     }
 
     /// Upgrade the weak instance reference to a strong reference.
@@ -252,32 +340,73 @@ impl SyncHandlerImpl {
         Ok(Some(results[0].1))
     }
 
-    /// Check if the requesting key already has sufficient permissions through existing auth.
+    /// Check that the caller signed this request with `claimed_key`.
     ///
-    /// Delegates to [`Database::can_access`], the pubkey-only access decision,
-    /// which resolves direct grants, the global `*` grant, and authority that
-    /// reaches this tree only through a *delegated* tree. Without the delegated
-    /// case a delegated-only key is bounced to manual approval and hangs.
+    /// `requesting_key` is a name the client picks; it decides which key an
+    /// approval would grant, and on its own it must never unlock data. Anything
+    /// that serves entries on the strength of a claimed key needs this first.
+    fn prove_possession_if_required(
+        &self,
+        request: &SyncTreeRequest,
+        claimed_key: &PublicKey,
+        auth_configured: bool,
+    ) -> Result<()> {
+        if !auth_configured {
+            // World-readable database: nothing is being protected, so there is
+            // nothing to prove.
+            return Ok(());
+        }
+        self.prove_possession(request, claimed_key)
+    }
+
+    /// Check that the caller signed this request with `claimed_key`.
+    fn prove_possession(&self, request: &SyncTreeRequest, claimed_key: &PublicKey) -> Result<()> {
+        let proven = self.authenticate_request(request)?;
+        if proven != *claimed_key {
+            return Err(SyncError::AuthenticationFailed(format!(
+                "request is signed by {proven}, which is not the claimed key {claimed_key}"
+            ))
+            .into());
+        }
+        Ok(())
+    }
+
+    /// Check if the caller holds a key that already has sufficient permissions.
+    ///
+    /// Possession first, then authority. Authority resolves through
+    /// [`Database::can_access`], the pubkey-only access decision, which covers
+    /// direct grants, the global `*` grant, and authority that reaches this
+    /// tree only through a *delegated* tree. Without the delegated case a
+    /// delegated-only key is bounced to manual approval and hangs.
     ///
     /// Delegation discovery is **one hop deep**: a key reachable only through a
     /// chain of delegations still falls through to manual approval. See
     /// [`Database::can_access`] for why bootstrap searches where entry
     /// validation walks a named path.
     ///
-    /// # Arguments
-    /// * `tree_id` - The database/tree ID to check auth settings for
-    /// * `requesting_pubkey` - The public key making the request
-    /// * `requested_permission` - The permission level being requested
-    ///
     /// # Returns
-    /// - `Ok(true)` if key has sufficient permission
-    /// - `Ok(false)` if key lacks sufficient permission or auth check fails
-    async fn check_existing_auth_permission(
+    /// - `Ok(true)` if the caller proved a key with sufficient permission
+    /// - `Ok(false)` if possession failed, or the key lacks permission
+    async fn check_proven_auth_permission(
         &self,
-        tree_id: &ID,
+        request: &SyncTreeRequest,
         requesting_pubkey: &PublicKey,
         requested_permission: &Permission,
+        auth_configured: bool,
     ) -> Result<bool> {
+        let tree_id = &request.tree_id;
+        if let Err(e) =
+            self.prove_possession_if_required(request, requesting_pubkey, auth_configured)
+        {
+            warn!(
+                tree_id = %tree_id,
+                requesting_pubkey = %requesting_pubkey,
+                error = %e,
+                "Bootstrap key claim not proven - falling back to the approval queue"
+            );
+            return Ok(false);
+        }
+
         let granted = Database::can_access(
             &self.instance()?,
             tree_id,
@@ -603,16 +732,12 @@ impl SyncHandlerImpl {
             // Check if peer needs bootstrap (empty tips indicates no local data)
             if request.our_tips.is_empty() {
                 debug!(tree_id = %request.tree_id, "Peer needs bootstrap - sending full tree");
-                return self.handle_bootstrap_request(&request.tree_id,
-                                                  request.requesting_key.as_ref(),
-                                                  request.requesting_key_name.as_deref(),
-                                                  request.requested_permission,
-                                                  request.metadata.clone()).await;
+                return self.handle_bootstrap_request(request).await;
             }
 
             // Handle incremental sync (peer has existing data, needs updates)
             debug!(tree_id = %request.tree_id, peer_tips = request.our_tips.len(), "Handling incremental sync");
-            self.handle_incremental_sync(&request.tree_id, &request.our_tips).await
+            self.handle_incremental_sync(request).await
         }
         .instrument(info_span!("handle_sync_tree", tree = %request.tree_id))
         .await
@@ -673,14 +798,13 @@ impl SyncHandlerImpl {
     /// - `BootstrapResponse`: Contains entries and approval status (key_approved, granted_permission)
     /// - `BootstrapPending`: Manual approval required (request queued)
     /// - `Error`: Tree not found, auth required, key not authorized, or processing failure
-    async fn handle_bootstrap_request(
-        &self,
-        tree_id: &ID,
-        requesting_key: Option<&PublicKey>,
-        requesting_key_name: Option<&str>,
-        requested_permission: Option<Permission>,
-        metadata: Option<Doc>,
-    ) -> SyncResponse {
+    async fn handle_bootstrap_request(&self, request: &SyncTreeRequest) -> SyncResponse {
+        let tree_id = &request.tree_id;
+        let requesting_key = request.requesting_key.as_ref();
+        let requesting_key_name = request.requesting_key_name.as_deref();
+        let requested_permission = request.requested_permission;
+        let metadata = request.metadata.clone();
+
         // SECURITY: Check if database has sync enabled (FIRST CHECK - before anything else)
         // This prevents information leakage about database existence: the gate
         // returns false both for databases that are absent and for databases that
@@ -758,7 +882,7 @@ impl SyncHandlerImpl {
 
                 // Check if the requesting key already has sufficient permissions through existing auth
                 match self
-                    .check_existing_auth_permission(tree_id, key, &permission)
+                    .check_proven_auth_permission(request, key, &permission, auth_configured)
                     .await
                 {
                     Ok(true) => {
@@ -819,6 +943,16 @@ impl SyncHandlerImpl {
                     "Auto-detecting permission from auth settings for bootstrap request"
                 );
 
+                if let Err(e) = self.prove_possession_if_required(request, key, auth_configured) {
+                    warn!(
+                        tree_id = %tree_id,
+                        requesting_key = %key,
+                        error = %e,
+                        "Bootstrap request rejected: caller did not prove it holds the key it claims"
+                    );
+                    return SyncResponse::Error(e.to_string());
+                }
+
                 match self.get_key_highest_permission(tree_id, key).await {
                     Ok(Some(permission)) => {
                         info!(
@@ -860,6 +994,21 @@ impl SyncHandlerImpl {
                 (false, None)
             }
         };
+
+        // A database with auth configured serves entries only to a caller that
+        // proved it holds a key with read access. Cases that fall through
+        // without approval (no credentials, or a key with no key name) must not
+        // be served just because they reached this point.
+        if auth_configured && !key_approved {
+            warn!(
+                tree_id = %tree_id,
+                requesting_key = ?requesting_key,
+                "Bootstrap request rejected: no proven authority for a database that requires authentication"
+            );
+            return SyncResponse::Error(
+                SyncError::AuthenticationRequired(tree_id.to_string()).to_string(),
+            );
+        }
 
         // NOW collect all entries after key approval (so we get the updated database state)
         let all_entries = match self.collect_all_entries_for_bootstrap(tree_id).await {
@@ -908,8 +1057,16 @@ impl SyncHandlerImpl {
         })
     }
 
-    /// Handle incremental sync request
-    async fn handle_incremental_sync(&self, tree_id: &ID, peer_tips: &[ID]) -> SyncResponse {
+    /// Handle incremental sync request.
+    ///
+    /// The caller selects this path by sending any non-empty tip list, so it
+    /// enforces the same read policy bootstrap does. Without that, a single
+    /// fabricated tip — which matches nothing in our DAG and therefore never
+    /// stops the ancestor walk — returns the entire tree.
+    async fn handle_incremental_sync(&self, request: &SyncTreeRequest) -> SyncResponse {
+        let tree_id = &request.tree_id;
+        let peer_tips = request.our_tips.tips();
+
         // SECURITY: Check if database has sync enabled (FIRST CHECK - before anything else)
         // This prevents information leakage about database existence: the gate
         // returns false both for databases that are absent and for databases that
@@ -922,6 +1079,16 @@ impl SyncHandlerImpl {
                 "Incremental sync request rejected: database is absent or has no user with sync enabled (responding as not-found)"
             );
             return SyncResponse::Error(format!("Tree not found: {tree_id}"));
+        }
+
+        if let Err(e) = self.authorize_read(request).await {
+            warn!(
+                tree_id = %tree_id,
+                peer_tip_count = peer_tips.len(),
+                error = %e,
+                "Incremental sync request rejected: caller is not authorized to read this database"
+            );
+            return SyncResponse::Error(e.to_string());
         }
 
         // Get our current tips

--- a/crates/lib/src/sync/ops.rs
+++ b/crates/lib/src/sync/ops.rs
@@ -11,11 +11,15 @@ use super::{
     background::SyncCommand,
     peer_manager::PeerManager,
     peer_types,
-    protocol::{self, SyncRequest, SyncResponse, SyncTreeRequest},
+    protocol::{self, SyncRequest, SyncRequestAuth, SyncResponse, SyncTreeRequest},
     user_sync_manager::UserSyncManager,
 };
 use crate::{
-    Database, Entry, Result, auth::Permission, auth::crypto::PublicKey, crdt::Doc, entry::ID,
+    Database, Entry, Result,
+    auth::Permission,
+    auth::crypto::{PrivateKey, PublicKey},
+    crdt::Doc,
+    entry::ID,
     store::DocStore,
 };
 
@@ -37,6 +41,23 @@ impl Sync {
     /// # Returns
     /// A Result indicating success or failure of the sync operation.
     pub async fn sync_tree_with_peer(&self, peer_pubkey: &PublicKey, tree_id: &ID) -> Result<()> {
+        self.sync_tree_with_peer_as(peer_pubkey, tree_id, None)
+            .await
+    }
+
+    /// Synchronize a tree with a peer, signing the request with `signing_key`.
+    ///
+    /// The peer authorizes the pull against the key that signed it, so this must
+    /// be a key with read access on `tree_id`. `None` uses this instance's device
+    /// key, which is right when the device itself holds the access (directly or
+    /// through a delegated tree). A database that instead granted a *user* key —
+    /// the usual outcome of bootstrapping with one — needs that key here.
+    pub async fn sync_tree_with_peer_as(
+        &self,
+        peer_pubkey: &PublicKey,
+        tree_id: &ID,
+        signing_key: Option<&PrivateKey>,
+    ) -> Result<()> {
         // Get peer information and address
         let peer_info = self
             .get_peer_info(peer_pubkey)
@@ -58,15 +79,24 @@ impl Sync {
         // Get our device public key for automatic peer tracking
         let our_device_pubkey = self.get_device_pubkey().ok();
 
-        // Send unified sync request
+        // Send unified sync request, signed so the peer can authorize the pull
+        let instance = self.instance()?;
+        let auth = SyncRequestAuth::sign(
+            signing_key.unwrap_or(instance.signing_key()?),
+            peer_pubkey,
+            tree_id,
+            &our_tips,
+            instance.clock().now_millis(),
+        );
         let request = SyncRequest::SyncTree(SyncTreeRequest {
             tree_id: tree_id.clone(),
             our_tips,
             peer_pubkey: our_device_pubkey,
-            requesting_key: None, // TODO: Add auth support for direct sync
+            requesting_key: None,
             requesting_key_name: None,
             requested_permission: None,
             metadata: None,
+            auth: Some(auth),
         });
 
         // Send request via background sync command
@@ -583,6 +613,19 @@ impl Sync {
     /// # Returns
     /// Result indicating success or failure.
     pub async fn sync_with_peer(&self, address: &Address, tree_id: Option<&ID>) -> Result<()> {
+        self.sync_with_peer_as(address, tree_id, None).await
+    }
+
+    /// Sync with a peer, signing requests with `signing_key`.
+    ///
+    /// See [`sync_tree_with_peer_as`](Self::sync_tree_with_peer_as) for which
+    /// key to pass.
+    pub async fn sync_with_peer_as(
+        &self,
+        address: &Address,
+        tree_id: Option<&ID>,
+        signing_key: Option<&PrivateKey>,
+    ) -> Result<()> {
         // Connect to peer if not already connected
         let peer_pubkey = self.connect_to_peer(address).await?;
 
@@ -591,7 +634,8 @@ impl Sync {
 
         if let Some(tree_id) = tree_id {
             // Sync specific tree
-            self.sync_tree_with_peer(&peer_pubkey, tree_id).await?;
+            self.sync_tree_with_peer_as(&peer_pubkey, tree_id, signing_key)
+                .await?;
         } else {
             // TODO: Sync all available trees
             tracing::warn!(
@@ -632,7 +676,7 @@ impl Sync {
     /// # Arguments
     /// * `peer_pubkey` - The public key of the peer to sync with
     /// * `tree_id` - The ID of the tree to sync
-    /// * `requesting_key` - Optional public key requesting access (for bootstrap)
+    /// * `requesting_key` - Optional private key to sign with and request access for
     /// * `requesting_key_name` - Optional name/ID of the requesting key
     /// * `requested_permission` - Optional permission level being requested
     ///
@@ -642,7 +686,7 @@ impl Sync {
         &self,
         peer_pubkey: &PublicKey,
         tree_id: &ID,
-        requesting_key: Option<&PublicKey>,
+        requesting_key: Option<&PrivateKey>,
         requesting_key_name: Option<&str>,
         requested_permission: Option<Permission>,
         metadata: Option<Doc>,
@@ -668,15 +712,27 @@ impl Sync {
         // Get our device public key for automatic peer tracking
         let our_device_pubkey = self.get_device_pubkey().ok();
 
-        // Send unified sync request with auth parameters
+        // Send unified sync request with auth parameters. The signature proves
+        // we hold our device key; a bootstrap that asks for a *different* key
+        // cannot be proven and stays on the manual approval path.
+        let instance = self.instance()?;
+        let signing_key = requesting_key.unwrap_or(instance.signing_key()?);
+        let auth = SyncRequestAuth::sign(
+            signing_key,
+            peer_pubkey,
+            tree_id,
+            &our_tips,
+            instance.clock().now_millis(),
+        );
         let request = SyncRequest::SyncTree(SyncTreeRequest {
             tree_id: tree_id.clone(),
             our_tips,
             peer_pubkey: our_device_pubkey,
-            requesting_key: requesting_key.cloned(),
+            requesting_key: requesting_key.map(|k| k.public_key()),
             requesting_key_name: requesting_key_name.map(|k| k.to_string()),
             requested_permission,
             metadata,
+            auth: Some(auth),
         });
 
         // Send request via background sync command

--- a/crates/lib/src/sync/protocol.rs
+++ b/crates/lib/src/sync/protocol.rs
@@ -7,7 +7,13 @@ use serde::{Deserialize, Serialize};
 
 use super::peer_types::Address;
 use crate::{
-    auth::{Permission, crypto::PublicKey},
+    auth::{
+        AuthError, Permission,
+        crypto::{
+            PrivateKey, PublicKey, create_challenge_response, generate_challenge,
+            verify_challenge_response,
+        },
+    },
     crdt::Doc,
     entry::{Entry, ID},
     snapshot::Snapshot,
@@ -74,8 +80,8 @@ pub struct SyncTreeRequest {
     pub our_tips: Snapshot,
     /// Device public key of the requesting peer (used for automatic tree/peer relationship tracking)
     pub peer_pubkey: Option<PublicKey>,
-    // Note: requesting_key is unverified but this is safe - see handler.rs
-    // handle_bootstrap_request() for detailed explanation.
+    // Note: requesting_key is unverified. It selects which key an approval
+    // would grant; it never authorizes serving data — `auth` does that.
     /// Authentication key requesting access (for bootstrap)
     pub requesting_key: Option<PublicKey>,
     /// Key name/identifier for the requesting key
@@ -87,7 +93,112 @@ pub struct SyncTreeRequest {
     /// `BootstrapRequest`.
     #[serde(default)]
     pub metadata: Option<Doc>,
+    /// Proof that the caller holds the private half of the key it is claiming.
+    ///
+    /// Required before any entry is served from a database that has auth
+    /// configured. Absent on requests that only *ask* for access (the manual
+    /// approval queue), which disclose nothing.
+    #[serde(default)]
+    pub auth: Option<SyncRequestAuth>,
 }
+
+/// A caller's proof of key possession for one sync request.
+///
+/// The signature covers the responding server, the tree, the claimed tips, and
+/// a timestamp/nonce pair, so a captured request cannot be replayed to the same
+/// server, redirected to a different one, or reused for a different tree.
+///
+/// # What this does not defend against
+///
+/// This authenticates the *requester to the server*; it does not protect the
+/// channel. Over a plaintext transport an attacker on the network path still
+/// reads the served entries and can relay a live signed request to keep the
+/// response for itself. Confidentiality against a network attacker requires an
+/// encrypted transport (Iroh's QUIC), not this signature.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct SyncRequestAuth {
+    /// The key whose authority the caller is claiming on the tree.
+    pub key: PublicKey,
+    /// Milliseconds since the Unix epoch, from the caller's clock.
+    pub timestamp_ms: u64,
+    /// Random per-request value; makes each signature single-use.
+    pub nonce: Vec<u8>,
+    /// Signature over [`SyncRequestAuth::signing_bytes`].
+    pub signature: Vec<u8>,
+}
+
+impl SyncRequestAuth {
+    /// Sign a request to `server_pubkey` for `tree_id` at `tips`.
+    pub fn sign(
+        signing_key: &PrivateKey,
+        server_pubkey: &PublicKey,
+        tree_id: &ID,
+        tips: &Snapshot,
+        timestamp_ms: u64,
+    ) -> Self {
+        let nonce = generate_challenge();
+        let signature = create_challenge_response(
+            Self::signing_bytes(server_pubkey, tree_id, tips, timestamp_ms, &nonce),
+            signing_key,
+        );
+        Self {
+            key: signing_key.public_key(),
+            timestamp_ms,
+            nonce,
+            signature,
+        }
+    }
+
+    /// Verify the signature against the request it claims to cover.
+    ///
+    /// Freshness and single-use are the caller's responsibility — a valid
+    /// signature says nothing about when it was made.
+    pub fn verify(
+        &self,
+        server_pubkey: &PublicKey,
+        tree_id: &ID,
+        tips: &Snapshot,
+    ) -> Result<(), AuthError> {
+        verify_challenge_response(
+            Self::signing_bytes(server_pubkey, tree_id, tips, self.timestamp_ms, &self.nonce),
+            &self.signature,
+            &self.key,
+        )
+    }
+
+    /// The exact bytes covered by the signature.
+    ///
+    /// Every field is length-prefixed so that no two distinct requests can
+    /// produce the same byte string.
+    fn signing_bytes(
+        server_pubkey: &PublicKey,
+        tree_id: &ID,
+        tips: &Snapshot,
+        timestamp_ms: u64,
+        nonce: &[u8],
+    ) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        let mut push = |field: &[u8]| {
+            bytes.extend_from_slice(&(field.len() as u64).to_be_bytes());
+            bytes.extend_from_slice(field);
+        };
+
+        push(SYNC_REQUEST_DOMAIN);
+        push(server_pubkey.to_string().as_bytes());
+        push(tree_id.to_string().as_bytes());
+        push(&(tips.len() as u64).to_be_bytes());
+        for tip in tips.tips() {
+            push(tip.to_string().as_bytes());
+        }
+        push(&timestamp_ms.to_be_bytes());
+        push(nonce);
+        bytes
+    }
+}
+
+/// Domain separator, so a sync signature can never be mistaken for a signature
+/// over an entry or a handshake challenge.
+const SYNC_REQUEST_DOMAIN: &[u8] = b"eidetica/sync/tree-request/v1";
 
 /// Bootstrap response containing complete tree state
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -164,7 +275,10 @@ pub struct RequestContext {
     /// The remote address from which this request originated.
     /// Extracted from the transport layer's connection metadata.
     pub remote_address: Option<Address>,
-    /// The public key of the peer making this request.
-    /// Set after successful handshake to identify the authenticated peer.
+    /// The public key the peer claims for relationship tracking.
+    ///
+    /// **Unverified.** Transports copy it out of the request body; nothing
+    /// proves the sender holds the matching private key. Authorization uses
+    /// [`SyncTreeRequest::auth`], never this field.
     pub peer_pubkey: Option<PublicKey>,
 }

--- a/crates/lib/src/testing.rs
+++ b/crates/lib/src/testing.rs
@@ -55,11 +55,18 @@
 //!
 //! // Peer 1 bootstraps with its own key, then converges against peer 0.
 //! let key1 = net.peer(1).key_id().clone();
+//! let signing_key1 = net.peer(1).user().get_signing_key(&key1)?;
 //! let name1 = net.peer(1).key_name().to_string();
 //! let addr0 = net.peer(0).address().clone();
 //! net.peer(1)
 //!     .sync()
-//!     .sync_with_peer_for_bootstrap_with_key(&addr0, &room, &key1, &name1, Permission::Write(10))
+//!     .sync_with_peer_for_bootstrap_with_key(
+//!         &addr0,
+//!         &room,
+//!         &signing_key1,
+//!         &name1,
+//!         Permission::Write(10),
+//!     )
 //!     .await?;
 //! net.peer_mut(1)
 //!     .user_mut()
@@ -244,9 +251,19 @@ impl Cluster {
     ) -> Result<()> {
         let from_addr = self.peers[from].address.clone();
         let to_key = self.peers[to].key_id.clone();
+        let to_signing_key = self.peers[to]
+            .user
+            .get_signing_key(&to_key)
+            .expect("peer key must be unlocked");
         self.peers[to]
             .sync
-            .sync_with_peer_for_bootstrap_with_key(&from_addr, tree, &to_key, KEY_NAME, permission)
+            .sync_with_peer_for_bootstrap_with_key(
+                &from_addr,
+                tree,
+                &to_signing_key,
+                KEY_NAME,
+                permission,
+            )
             .await?;
         self.peers[to].sync.flush().await?;
         self.peers[to]

--- a/crates/lib/src/user/session/mod.rs
+++ b/crates/lib/src/user/session/mod.rs
@@ -856,12 +856,15 @@ impl User {
 
     /// Get a signing key by its ID.
     ///
+    /// Hands out key material from this session's unlocked key manager. Callers
+    /// that sign on the user's behalf need it — signing a sync request as the
+    /// key whose access they are claiming, for example.
+    ///
     /// # Arguments
     /// * `key_id` - The public key identifier
     ///
     /// # Returns
     /// The PrivateKey if found
-    #[cfg(any(test, feature = "testing"))]
     pub fn get_signing_key(&self, key_id: &PublicKey) -> Result<crate::auth::crypto::PrivateKey> {
         self.key_manager
             .get_signing_key(key_id)
@@ -1036,18 +1039,27 @@ impl User {
         requested_permission: Permission,
         metadata: Option<Doc>,
     ) -> Result<()> {
-        if self.key_manager.get_signing_key(key_id).is_none() {
-            return Err(super::errors::UserError::KeyNotFound {
+        // The request is signed with this key, so the peer can tell an actual
+        // key holder from someone naming a key they don't have.
+        let signing_key = self
+            .key_manager
+            .get_signing_key(key_id)
+            .ok_or_else(|| super::errors::UserError::KeyNotFound {
                 key_id: key_id.to_string(),
-            }
-            .into());
-        }
+            })?
+            .clone();
 
         let key_name = key_id.to_string();
         let database_id = ticket.database_id().clone();
 
         let result = sync
-            .bootstrap_with_ticket(ticket, key_id, &key_name, requested_permission, metadata)
+            .bootstrap_with_ticket(
+                ticket,
+                &signing_key,
+                &key_name,
+                requested_permission,
+                metadata,
+            )
             .await;
 
         self.record_database_access(&database_id, key_id, result)

--- a/crates/lib/tests/it/sync/auto_peer_registration_tests.rs
+++ b/crates/lib/tests/it/sync/auto_peer_registration_tests.rs
@@ -4,6 +4,7 @@
 //! during handshakes and sync tree requests.
 
 use eidetica::{
+    Clock, FixedClock,
     auth::{
         Permission,
         crypto::{generate_challenge, generate_keypair},
@@ -15,8 +16,8 @@ use eidetica::{
         Address, PeerId,
         handler::{SyncHandler, SyncHandlerImpl},
         protocol::{
-            HandshakeRequest, PROTOCOL_VERSION, RequestContext, SyncRequest, SyncResponse,
-            SyncTreeRequest,
+            HandshakeRequest, PROTOCOL_VERSION, RequestContext, SyncRequest, SyncRequestAuth,
+            SyncResponse, SyncTreeRequest,
         },
         transports::{SyncTransport, http::HttpTransport},
     },
@@ -239,6 +240,7 @@ async fn test_bootstrap_sync_tracks_tree_peer_relationship() {
         requesting_key_name: Some("peer_key".to_string()),
         requested_permission: None,
         metadata: None,
+        auth: None,
     };
 
     let context = RequestContext {
@@ -321,6 +323,7 @@ async fn test_incremental_sync_tracks_tree_peer_relationship() {
         requesting_key_name: Some("peer_key".to_string()),
         requested_permission: None,
         metadata: None,
+        auth: None,
     };
 
     let context = RequestContext {
@@ -365,23 +368,32 @@ async fn test_relationship_tracking_skipped_without_peer_pubkey() {
         .unwrap();
 
     let sync_tree_id = sync.sync_tree_root_id().clone();
+    let server_pubkey = instance.id();
     let handler = SyncHandlerImpl::new(instance, sync_tree_id);
 
-    let (_, peer_verifying_key) = generate_keypair();
+    let (peer_signing_key, peer_verifying_key) = generate_keypair();
 
     // Register the peer first (would normally happen during handshake)
     sync.register_peer(&peer_verifying_key, Some("Test Peer"))
         .await
         .unwrap();
 
+    let our_tips: eidetica::Snapshot = Vec::new().into();
     let sync_request = SyncTreeRequest {
         tree_id: tree_id.clone(),
-        our_tips: Vec::new().into(),
+        our_tips: our_tips.clone(),
         peer_pubkey: None,
         requesting_key: Some(peer_verifying_key.clone()),
         requesting_key_name: Some("peer_key".to_string()),
         requested_permission: None,
         metadata: None,
+        auth: Some(SyncRequestAuth::sign(
+            &peer_signing_key,
+            &server_pubkey,
+            &tree_id,
+            &our_tips,
+            FixedClock::default().now_millis(),
+        )),
     };
 
     // Context without peer_pubkey - tracking should be skipped
@@ -473,6 +485,7 @@ async fn test_multiple_trees_tracked_with_same_peer() {
         requesting_key_name: Some("peer_key".to_string()),
         requested_permission: None,
         metadata: None,
+        auth: None,
     });
     let _response1 = handler.handle_request(&request1, &context).await;
 
@@ -485,6 +498,7 @@ async fn test_multiple_trees_tracked_with_same_peer() {
         requesting_key_name: Some("peer_key".to_string()),
         requested_permission: None,
         metadata: None,
+        auth: None,
     });
     let _response2 = handler.handle_request(&request2, &context).await;
 
@@ -593,6 +607,7 @@ async fn test_sync_without_peer_identifier_works() {
         requesting_key_name: None,
         requested_permission: None,
         metadata: None,
+        auth: None,
     };
 
     // Context also without peer_pubkey
@@ -638,14 +653,22 @@ async fn test_bootstrap_auto_detects_permission_for_authorized_key() {
     let handler = SyncHandlerImpl::new(instance.clone(), sync_tree_id);
 
     // Bootstrap request with authorized key but no requested_permission
+    let our_tips: eidetica::Snapshot = Vec::new().into();
     let sync_request = SyncTreeRequest {
         tree_id: tree_id.clone(),
-        our_tips: Vec::new().into(),
+        our_tips: our_tips.clone(),
         peer_pubkey: None,
         requesting_key: Some(key_id.clone()),
         requesting_key_name: Some(key_id.to_string()),
         requested_permission: None, // Should auto-detect from auth settings
         metadata: None,
+        auth: Some(SyncRequestAuth::sign(
+            &user.get_signing_key(&key_id).unwrap(),
+            &instance.id(),
+            &tree_id,
+            &our_tips,
+            FixedClock::default().now_millis(),
+        )),
     };
 
     let context = RequestContext {
@@ -700,20 +723,29 @@ async fn test_bootstrap_rejects_unauthorized_key_when_permission_not_specified()
         .unwrap();
 
     let sync_tree_id = sync.sync_tree_root_id().clone();
+    let server_pubkey = instance.id();
     let handler = SyncHandlerImpl::new(instance, sync_tree_id);
 
     // Generate an unauthorized key
-    let (_, unauthorized_verifying_key) = generate_keypair();
+    let (unauthorized_signing_key, unauthorized_verifying_key) = generate_keypair();
 
     // Bootstrap request with unauthorized key and no requested_permission
+    let our_tips: eidetica::Snapshot = Vec::new().into();
     let sync_request = SyncTreeRequest {
         tree_id: tree_id.clone(),
-        our_tips: Vec::new().into(),
+        our_tips: our_tips.clone(),
         peer_pubkey: None,
         requesting_key: Some(unauthorized_verifying_key.clone()),
         requesting_key_name: Some("unauthorized_key".to_string()),
         requested_permission: None,
         metadata: None,
+        auth: Some(SyncRequestAuth::sign(
+            &unauthorized_signing_key,
+            &server_pubkey,
+            &tree_id,
+            &our_tips,
+            FixedClock::default().now_millis(),
+        )),
     };
 
     let context = RequestContext {
@@ -789,6 +821,7 @@ async fn test_bootstrap_auto_detects_global_wildcard_permission() {
         requesting_key_name: Some("random_key".to_string()),
         requested_permission: None, // Should auto-detect global '*' permission
         metadata: None,
+        auth: None,
     };
 
     let context = RequestContext {
@@ -876,6 +909,7 @@ async fn test_bootstrap_uses_highest_permission_when_key_has_multiple() {
         requesting_key_name: Some("special_key".to_string()),
         requested_permission: None, // Should auto-detect highest (Write(5))
         metadata: None,
+        auth: None,
     };
 
     let context = RequestContext {

--- a/crates/lib/tests/it/sync/bootstrap_failure_tests.rs
+++ b/crates/lib/tests/it/sync/bootstrap_failure_tests.rs
@@ -64,7 +64,7 @@ async fn test_bootstrap_permission_denied_insufficient_admin() {
     };
 
     // Setup client with its own key
-    let (client_instance, _client_user, client_key_id) =
+    let (client_instance, client_user, client_key_id) =
         test_instance_with_user_and_key("client_user", Some("unauthorized_client")).await;
     client_instance
         .enable_sync()
@@ -86,7 +86,7 @@ async fn test_bootstrap_permission_denied_insufficient_admin() {
             .sync_with_peer_for_bootstrap_with_key(
                 &server_addr,
                 &restricted_tree_id,
-                &client_key_id,
+                &client_user.get_signing_key(&client_key_id).unwrap(),
                 "unauthorized_client", // Client's key name
                 Permission::Write(10), // Requested permission level
             )
@@ -184,7 +184,7 @@ async fn test_bootstrap_permission_denied_no_auth_config() {
     };
 
     // Setup client
-    let (client_instance, _client_user, client_key_id) =
+    let (client_instance, client_user, client_key_id) =
         test_instance_with_user_and_key("client_user", Some("client_key")).await;
     client_instance
         .enable_sync()
@@ -203,7 +203,7 @@ async fn test_bootstrap_permission_denied_no_auth_config() {
             .sync_with_peer_for_bootstrap_with_key(
                 &server_addr,
                 &unprotected_tree_id,
-                &client_key_id,
+                &client_user.get_signing_key(&client_key_id).unwrap(),
                 "client_key",
                 Permission::Write(10),
             )
@@ -297,7 +297,7 @@ async fn test_bootstrap_invalid_public_key_format() {
     };
 
     // Setup client with malformed key name (this tests key validation during bootstrap)
-    let (client_instance, _client_user, client_key_id) =
+    let (client_instance, client_user, client_key_id) =
         test_instance_with_user_and_key("client_user", Some("client_with_spaces_and_symbols!@#"))
             .await;
     client_instance
@@ -320,7 +320,7 @@ async fn test_bootstrap_invalid_public_key_format() {
         .sync_with_peer_for_bootstrap_with_key(
             &server_addr,
             &tree_id,
-            &client_key_id,
+            &client_user.get_signing_key(&client_key_id).unwrap(),
             "client_with_spaces_and_symbols!@#",
             Permission::Write(10),
         )
@@ -401,7 +401,7 @@ async fn test_bootstrap_with_revoked_key() {
     };
 
     // Setup different client instance (to simulate external client using revoked key)
-    let (client_instance, _client_user, client_key_id) =
+    let (client_instance, client_user, client_key_id) =
         test_instance_with_user_and_key("client_user", Some("attempting_revoked_access")).await;
     client_instance
         .enable_sync()
@@ -422,7 +422,7 @@ async fn test_bootstrap_with_revoked_key() {
         .sync_with_peer_for_bootstrap_with_key(
             &server_addr,
             &tree_id,
-            &client_key_id,
+            &client_user.get_signing_key(&client_key_id).unwrap(),
             "attempting_revoked_access",
             Permission::Write(10),
         )
@@ -495,7 +495,7 @@ async fn test_bootstrap_exceeds_granted_permissions() {
     };
 
     // Setup client requesting Admin permissions (should be excessive)
-    let (client_instance, _client_user, client_key_id) =
+    let (client_instance, client_user, client_key_id) =
         test_instance_with_user_and_key("client_user", Some("greedy_client")).await;
     client_instance
         .enable_sync()
@@ -513,7 +513,7 @@ async fn test_bootstrap_exceeds_granted_permissions() {
         .sync_with_peer_for_bootstrap_with_key(
             &server_addr,
             &tree_id,
-            &client_key_id,
+            &client_user.get_signing_key(&client_key_id).unwrap(),
             "greedy_client",
             Permission::Admin(0), // Requesting highest admin level
         )

--- a/crates/lib/tests/it/sync/bootstrap_sync_tests.rs
+++ b/crates/lib/tests/it/sync/bootstrap_sync_tests.rs
@@ -286,7 +286,7 @@ async fn test_bootstrap_malformed_request_data() {
         .unwrap();
 
     // Generate a test keypair for bootstrap requests
-    let (_, test_verifying_key) = generate_keypair();
+    let (test_signing_key, _test_verifying_key) = generate_keypair();
 
     // Test 1: Invalid tree ID format
     let malformed_tree_id = ID::from_bytes("invalid_tree_format");
@@ -294,7 +294,7 @@ async fn test_bootstrap_malformed_request_data() {
         .sync_with_peer_for_bootstrap_with_key(
             &server_addr,
             &malformed_tree_id,
-            &test_verifying_key,
+            &test_signing_key,
             "client_key",
             Permission::Write(5),
         )
@@ -311,7 +311,7 @@ async fn test_bootstrap_malformed_request_data() {
         .sync_with_peer_for_bootstrap_with_key(
             &server_addr,
             &test_tree_id,
-            &test_verifying_key,
+            &test_signing_key,
             "", // Empty key name
             Permission::Write(5),
         )
@@ -350,7 +350,7 @@ async fn test_bootstrap_conflicting_tree_ids() {
         .unwrap();
 
     // Generate a test keypair for bootstrap request
-    let (_, test_verifying_key) = generate_keypair();
+    let (test_signing_key, _test_verifying_key) = generate_keypair();
 
     // Try to bootstrap with a different tree ID than what exists
     let different_tree_id = ID::from_bytes("different_tree_that_doesnt_exist");
@@ -358,7 +358,7 @@ async fn test_bootstrap_conflicting_tree_ids() {
         .sync_with_peer_for_bootstrap_with_key(
             &server_addr,
             &different_tree_id,
-            &test_verifying_key,
+            &test_signing_key,
             "client_key",
             Permission::Write(5),
         )

--- a/crates/lib/tests/it/sync/bootstrap_with_key_tests.rs
+++ b/crates/lib/tests/it/sync/bootstrap_with_key_tests.rs
@@ -42,7 +42,7 @@ async fn test_bootstrap_with_provided_key() {
     let server_addr = start_sync_server(&server_sync).await;
 
     // Setup client with a key we'll manage manually (not in backend)
-    let (_client_signing_key, client_verifying_key) = generate_keypair();
+    let (client_signing_key, client_verifying_key) = generate_keypair();
     let client_key_id = client_verifying_key.to_string();
 
     let (client_instance, client_sync) = setup().await;
@@ -63,7 +63,7 @@ async fn test_bootstrap_with_provided_key() {
         .sync_with_peer_for_bootstrap_with_key(
             &server_addr,
             &tree_id,
-            &client_verifying_key,
+            &client_signing_key,
             &client_key_id,
             Permission::Write(5),
         )
@@ -113,7 +113,7 @@ async fn test_bootstrap_with_provided_key_succeeds() {
     let server_addr = start_sync_server(&server_sync).await;
 
     // Setup client with user-managed key
-    let (_client_signing_key, client_verifying_key) = generate_keypair();
+    let (client_signing_key, client_verifying_key) = generate_keypair();
     let client_key_id = client_verifying_key.to_string();
 
     let (_client_instance, client_sync) = setup().await;
@@ -127,7 +127,7 @@ async fn test_bootstrap_with_provided_key_succeeds() {
         .sync_with_peer_for_bootstrap_with_key(
             &server_addr,
             &tree_id,
-            &client_verifying_key,
+            &client_signing_key,
             &client_key_id,
             Permission::Read,
         )
@@ -171,7 +171,7 @@ async fn test_bootstrap_with_invalid_key_fails() {
     let server_addr = start_sync_server(&server_sync).await;
 
     // Setup client with a signing key
-    let (_client_signing_key, client_verifying_key) = generate_keypair();
+    let (client_signing_key, client_verifying_key) = generate_keypair();
     let client_key_id = client_verifying_key.to_string();
 
     let (_client_instance, client_sync) = setup().await;
@@ -187,7 +187,7 @@ async fn test_bootstrap_with_invalid_key_fails() {
         .sync_with_peer_for_bootstrap_with_key(
             &server_addr,
             &fake_tree_id,
-            &client_verifying_key,
+            &client_signing_key,
             &client_key_id,
             Permission::Write(5),
         )
@@ -228,17 +228,17 @@ async fn test_multiple_clients_with_different_keys() {
     // Setup three clients with different user-managed keys
     let mut clients = Vec::new();
     for i in 0..3 {
-        let (_signing_key, verifying_key) = generate_keypair();
+        let (signing_key, verifying_key) = generate_keypair();
         let key_id = verifying_key.to_string();
         let (instance, sync) = setup().await;
         sync.register_transport("http", HttpTransport::builder())
             .await
             .unwrap();
-        clients.push((instance, sync, verifying_key, key_id, i));
+        clients.push((instance, sync, signing_key, verifying_key, key_id, i));
     }
 
     // Each client bootstraps with their own key
-    for (instance, sync, verifying_key, key_id, i) in clients {
+    for (instance, sync, signing_key, _verifying_key, key_id, i) in clients {
         println!("🧪 Client {i} bootstrapping...");
 
         // Verify client doesn't have database initially
@@ -251,7 +251,7 @@ async fn test_multiple_clients_with_different_keys() {
         sync.sync_with_peer_for_bootstrap_with_key(
             &server_addr,
             &tree_id,
-            &verifying_key,
+            &signing_key,
             &key_id,
             Permission::Read,
         )
@@ -306,7 +306,7 @@ async fn test_bootstrap_with_different_permissions() {
     for (perm_name, permission) in permissions {
         println!("🧪 Testing bootstrap with {perm_name} permission");
 
-        let (_signing_key, verifying_key) = generate_keypair();
+        let (signing_key, verifying_key) = generate_keypair();
         let key_id = verifying_key.to_string();
 
         let (_instance, sync) = setup().await;
@@ -318,7 +318,7 @@ async fn test_bootstrap_with_different_permissions() {
         sync.sync_with_peer_for_bootstrap_with_key(
             &server_addr,
             &tree_id,
-            &verifying_key,
+            &signing_key,
             &key_id,
             permission,
         )
@@ -369,14 +369,14 @@ async fn test_bootstrap_with_invalid_keys() {
         .unwrap();
 
     // Generate a valid public key for testing
-    let (_signing_key, verifying_key) = generate_keypair();
+    let (signing_key, _verifying_key) = generate_keypair();
 
     println!("🧪 TEST: Testing empty key name");
     let result = sync
         .sync_with_peer_for_bootstrap_with_key(
             &server_addr,
             &tree_id,
-            &verifying_key,
+            &signing_key,
             "", // Empty key name
             Permission::Write(5),
         )
@@ -417,7 +417,7 @@ async fn test_full_e2e_bootstrap_with_database_instances() {
     let server_addr = start_sync_server(&server_sync).await;
 
     // Setup client with user-managed key (simulating User API)
-    let (_client_signing_key, client_verifying_key) = generate_keypair();
+    let (client_signing_key, client_verifying_key) = generate_keypair();
     let client_key_id = client_verifying_key.to_string();
 
     let (client_instance, client_sync) = setup().await;
@@ -439,7 +439,7 @@ async fn test_full_e2e_bootstrap_with_database_instances() {
         .sync_with_peer_for_bootstrap_with_key(
             &server_addr,
             &tree_id,
-            &client_verifying_key,
+            &client_signing_key,
             &client_key_id,
             Permission::Read,
         )
@@ -521,7 +521,7 @@ async fn test_incremental_sync_after_bootstrap_with_key() {
     let server_addr = start_sync_server(&server_sync).await;
 
     // Setup client with user-managed key
-    let (_client_signing_key, client_verifying_key) = generate_keypair();
+    let (client_signing_key, client_verifying_key) = generate_keypair();
     let client_key_id = client_verifying_key.to_string();
 
     let (_client_instance, client_sync) = setup().await;
@@ -535,7 +535,7 @@ async fn test_incremental_sync_after_bootstrap_with_key() {
         .sync_with_peer_for_bootstrap_with_key(
             &server_addr,
             &tree_id,
-            &client_verifying_key,
+            &client_signing_key,
             &client_key_id,
             Permission::Write(5),
         )

--- a/crates/lib/tests/it/sync/chat_simulation_test.rs
+++ b/crates/lib/tests/it/sync/chat_simulation_test.rs
@@ -88,7 +88,7 @@ async fn test_chat_app_authenticated_bootstrap() {
         .sync_with_peer_for_bootstrap_with_key(
             &server_addr,
             &tree_id,
-            &client_key_id,
+            &client_user.get_signing_key(&client_key_id).unwrap(),
             "client_key",
             Permission::Write(10),
         )
@@ -125,7 +125,7 @@ async fn test_chat_app_authenticated_bootstrap() {
         .sync_with_peer_for_bootstrap_with_key(
             &server_addr,
             &tree_id,
-            &client_key_id,
+            &client_user.get_signing_key(&client_key_id).unwrap(),
             "client_key",
             Permission::Write(10),
         )
@@ -199,9 +199,13 @@ async fn test_chat_app_authenticated_bootstrap() {
             .expect("Client should commit with registered key");
     }
 
-    // Sync back to server
+    // Sync back to server, signing as the key the server granted during bootstrap
     client_sync
-        .sync_with_peer(&server_addr, Some(&tree_id))
+        .sync_with_peer_as(
+            &server_addr,
+            Some(&tree_id),
+            Some(&client_user.get_signing_key(&client_key_id).unwrap()),
+        )
         .await
         .unwrap();
     client_sync.flush().await.ok();
@@ -368,7 +372,7 @@ async fn test_multiple_databases_sync() {
     let server_addr = start_sync_server(&server_sync).await;
 
     // Setup client
-    let (client_instance, _client_user, client_key_id, client_sync) =
+    let (client_instance, client_user, client_key_id, client_sync) =
         setup_sync_enabled_client("client_user", "client_key").await;
     client_sync
         .register_transport("http", HttpTransport::builder())
@@ -381,7 +385,7 @@ async fn test_multiple_databases_sync() {
             .sync_with_peer_for_bootstrap_with_key(
                 &server_addr,
                 room_id,
-                &client_key_id,
+                &client_user.get_signing_key(&client_key_id).unwrap(),
                 "client_key",
                 Permission::Write(10),
             )

--- a/crates/lib/tests/it/sync/helpers.rs
+++ b/crates/lib/tests/it/sync/helpers.rs
@@ -365,6 +365,37 @@ pub async fn start_sync_server(sync: &Sync) -> Address {
 }
 
 /// Create a SyncTreeRequest for bootstrap testing
+/// Create a bootstrap request signed by the key it claims, as a real client sends it.
+///
+/// Timestamps come from [`FixedClock::default`] because test instances run on
+/// that clock, not the system one.
+pub fn create_signed_bootstrap_request(
+    tree_id: &ID,
+    signing_key: &eidetica::auth::crypto::PrivateKey,
+    key_name: &str,
+    permission: AuthPermission,
+    server_pubkey: &PublicKey,
+) -> SyncRequest {
+    let our_tips: eidetica::Snapshot = Vec::new().into();
+    let auth = eidetica::sync::protocol::SyncRequestAuth::sign(
+        signing_key,
+        server_pubkey,
+        tree_id,
+        &our_tips,
+        eidetica::Clock::now_millis(&eidetica::FixedClock::default()),
+    );
+    SyncRequest::SyncTree(SyncTreeRequest {
+        tree_id: tree_id.clone(),
+        our_tips,
+        peer_pubkey: None,
+        requesting_key: Some(signing_key.public_key()),
+        requesting_key_name: Some(key_name.to_string()),
+        requested_permission: Some(permission),
+        metadata: None,
+        auth: Some(auth),
+    })
+}
+
 pub fn create_bootstrap_request(
     tree_id: &ID,
     requesting_key: &str,
@@ -379,6 +410,7 @@ pub fn create_bootstrap_request(
         requesting_key_name: Some(key_name.to_string()),
         requested_permission: Some(permission),
         metadata: None,
+        auth: None,
     })
 }
 

--- a/crates/lib/tests/it/sync/incremental_auth_tests.rs
+++ b/crates/lib/tests/it/sync/incremental_auth_tests.rs
@@ -1,0 +1,166 @@
+//! Authorization tests for the incremental sync path.
+//!
+//! Bootstrap (empty tips) enforces the database's auth policy. Incremental
+//! (non-empty tips) is the branch the *caller* selects by sending any tip at
+//! all, so it must enforce the same policy — otherwise a fabricated tip is a
+//! complete bypass of manual approval.
+
+use eidetica::{
+    Entry,
+    crdt::Doc,
+    entry::ID,
+    store::DocStore,
+    sync::{
+        handler::SyncHandler,
+        protocol::{RequestContext, SyncRequest, SyncResponse, SyncTreeRequest},
+    },
+};
+
+use super::helpers;
+
+const SECRET: &str = "TOP_SECRET_VALUE";
+
+/// Write a recognizable secret into the database so disclosure is detectable.
+async fn write_secret(database: &eidetica::Database) {
+    let txn = database.new_transaction().await.unwrap();
+    let store = txn.get_store::<DocStore>("data").await.unwrap();
+    store.set("secret", SECRET).await.unwrap();
+    txn.commit().await.unwrap();
+}
+
+/// An incremental request carrying a tip we have never seen.
+///
+/// `our_tips` is non-empty, so the handler takes the incremental branch; the
+/// tip matches nothing in our DAG, so it never stops the ancestor walk.
+fn fabricated_tip_request(tree_id: &ID) -> SyncRequest {
+    SyncRequest::SyncTree(SyncTreeRequest {
+        tree_id: tree_id.clone(),
+        our_tips: vec![ID::from_bytes("nonexistent_tip")].into(),
+        peer_pubkey: None,
+        requesting_key: None,
+        requesting_key_name: None,
+        requested_permission: None,
+        metadata: None,
+    })
+}
+
+/// Entries served by this response, or an empty slice if it served none.
+fn served_entries(response: &SyncResponse) -> &[Entry] {
+    match response {
+        SyncResponse::Incremental(incremental) => &incremental.missing_entries,
+        _ => &[],
+    }
+}
+
+/// Whether any served entry carries the secret in any of its subtrees.
+///
+/// Checks the decoded subtree payloads. `Entry`'s `Debug` renders payloads as
+/// byte arrays, so string-matching a `{:?}` dump reports "clean" while the
+/// secret is plainly present — do not simplify this into a Debug match.
+fn discloses_secret(response: &SyncResponse) -> bool {
+    served_entries(response).iter().any(|entry| {
+        entry.subtrees().iter().any(|subtree| {
+            entry
+                .data(subtree)
+                .is_ok_and(|data| String::from_utf8_lossy(data).contains(SECRET))
+        })
+    })
+}
+
+/// An unauthorized caller must not be served by the incremental path.
+///
+/// The caller presents no credentials at all and never touches bootstrap:
+/// no handshake, no `requesting_key`, never approved.
+#[tokio::test]
+// Expected-failure marker: the incremental path enforces no authorization yet.
+#[should_panic = "served database contents to an unauthorized caller"]
+async fn unauthenticated_incremental_pull_is_refused() {
+    let (_instance, _user, _key_id, database, sync, tree_id) =
+        helpers::setup_manual_approval_server().await;
+    write_secret(&database).await;
+
+    let handler = helpers::create_test_sync_handler(&sync);
+    let response = handler
+        .handle_request(&fabricated_tip_request(&tree_id), &RequestContext::default())
+        .await;
+
+    assert!(
+        !discloses_secret(&response),
+        "incremental sync served database contents to an unauthorized caller: {response:?}"
+    );
+    assert!(
+        served_entries(&response).is_empty(),
+        "incremental sync served {} entries to an unauthorized caller",
+        served_entries(&response).len()
+    );
+}
+
+/// The auth key list is as sensitive as the data: it discloses the member set
+/// and each member's permission level, which is targeting information.
+#[tokio::test]
+// Expected-failure marker: the incremental path enforces no authorization yet.
+#[should_panic = "disclosed _settings"]
+async fn unauthenticated_incremental_pull_does_not_leak_auth_settings() {
+    let (_instance, _user, _key_id, _database, sync, tree_id) =
+        helpers::setup_manual_approval_server().await;
+
+    let handler = helpers::create_test_sync_handler(&sync);
+    let response = handler
+        .handle_request(&fabricated_tip_request(&tree_id), &RequestContext::default())
+        .await;
+
+    assert!(
+        !served_entries(&response)
+            .iter()
+            .any(|entry| entry.data("_settings").is_ok()),
+        "incremental sync disclosed _settings (auth key list) to an unauthorized caller"
+    );
+}
+
+/// A database with a global wildcard grant is legitimately world-readable and
+/// documented as a supported mode. Gating the incremental path must not break it.
+#[tokio::test]
+async fn public_database_still_serves_incremental() {
+    let (_instance, _user, _key_id, database, sync, tree_id) =
+        helpers::setup_global_wildcard_server().await;
+    write_secret(&database).await;
+
+    let handler = helpers::create_test_sync_handler(&sync);
+    let response = handler
+        .handle_request(&fabricated_tip_request(&tree_id), &RequestContext::default())
+        .await;
+
+    assert!(
+        matches!(response, SyncResponse::Incremental(_)),
+        "public database refused an incremental request: {response:?}"
+    );
+    assert!(
+        discloses_secret(&response),
+        "public database served no data: {response:?}"
+    );
+}
+
+/// Positive control for the two refusal tests above: the probe must be able to
+/// observe disclosure when it happens, or a passing refusal test proves nothing.
+///
+/// Uses the same fabricated tip against a public database — same code path,
+/// same assertions, authorization deliberately satisfied.
+#[tokio::test]
+async fn probe_detects_disclosure_when_it_occurs() {
+    let (_instance, _user, _key_id, database, sync, tree_id) =
+        helpers::setup_global_wildcard_server().await;
+    write_secret(&database).await;
+
+    let handler = helpers::create_test_sync_handler(&sync);
+    let response = handler
+        .handle_request(&fabricated_tip_request(&tree_id), &RequestContext::default())
+        .await;
+
+    assert!(discloses_secret(&response), "probe cannot detect a positive");
+    assert!(
+        served_entries(&response)
+            .iter()
+            .any(|entry| entry.data("_settings").is_ok()),
+        "probe cannot detect _settings disclosure"
+    );
+}

--- a/crates/lib/tests/it/sync/incremental_auth_tests.rs
+++ b/crates/lib/tests/it/sync/incremental_auth_tests.rs
@@ -6,13 +6,13 @@
 //! complete bypass of manual approval.
 
 use eidetica::{
-    Entry,
-    crdt::Doc,
+    Clock, Entry, FixedClock,
+    auth::{Permission, crypto::PrivateKey, generate_keypair, types::AuthKey},
     entry::ID,
     store::DocStore,
     sync::{
         handler::SyncHandler,
-        protocol::{RequestContext, SyncRequest, SyncResponse, SyncTreeRequest},
+        protocol::{RequestContext, SyncRequest, SyncRequestAuth, SyncResponse, SyncTreeRequest},
     },
 };
 
@@ -41,6 +41,7 @@ fn fabricated_tip_request(tree_id: &ID) -> SyncRequest {
         requesting_key_name: None,
         requested_permission: None,
         metadata: None,
+        auth: None,
     })
 }
 
@@ -72,8 +73,6 @@ fn discloses_secret(response: &SyncResponse) -> bool {
 /// The caller presents no credentials at all and never touches bootstrap:
 /// no handshake, no `requesting_key`, never approved.
 #[tokio::test]
-// Expected-failure marker: the incremental path enforces no authorization yet.
-#[should_panic = "served database contents to an unauthorized caller"]
 async fn unauthenticated_incremental_pull_is_refused() {
     let (_instance, _user, _key_id, database, sync, tree_id) =
         helpers::setup_manual_approval_server().await;
@@ -81,7 +80,10 @@ async fn unauthenticated_incremental_pull_is_refused() {
 
     let handler = helpers::create_test_sync_handler(&sync);
     let response = handler
-        .handle_request(&fabricated_tip_request(&tree_id), &RequestContext::default())
+        .handle_request(
+            &fabricated_tip_request(&tree_id),
+            &RequestContext::default(),
+        )
         .await;
 
     assert!(
@@ -98,15 +100,16 @@ async fn unauthenticated_incremental_pull_is_refused() {
 /// The auth key list is as sensitive as the data: it discloses the member set
 /// and each member's permission level, which is targeting information.
 #[tokio::test]
-// Expected-failure marker: the incremental path enforces no authorization yet.
-#[should_panic = "disclosed _settings"]
 async fn unauthenticated_incremental_pull_does_not_leak_auth_settings() {
     let (_instance, _user, _key_id, _database, sync, tree_id) =
         helpers::setup_manual_approval_server().await;
 
     let handler = helpers::create_test_sync_handler(&sync);
     let response = handler
-        .handle_request(&fabricated_tip_request(&tree_id), &RequestContext::default())
+        .handle_request(
+            &fabricated_tip_request(&tree_id),
+            &RequestContext::default(),
+        )
         .await;
 
     assert!(
@@ -127,7 +130,10 @@ async fn public_database_still_serves_incremental() {
 
     let handler = helpers::create_test_sync_handler(&sync);
     let response = handler
-        .handle_request(&fabricated_tip_request(&tree_id), &RequestContext::default())
+        .handle_request(
+            &fabricated_tip_request(&tree_id),
+            &RequestContext::default(),
+        )
         .await;
 
     assert!(
@@ -138,6 +144,179 @@ async fn public_database_still_serves_incremental() {
         discloses_secret(&response),
         "public database served no data: {response:?}"
     );
+}
+
+/// The current time on the same clock the test instances run on.
+///
+/// Test instances are built with [`FixedClock::default`], not the system clock,
+/// so a real epoch timestamp would land years outside the freshness window.
+fn now_ms() -> u64 {
+    FixedClock::default().now_millis()
+}
+
+/// A request signed by `key`, addressed to `server_pubkey`.
+fn signed_request(
+    key: &PrivateKey,
+    server_pubkey: &eidetica::auth::crypto::PublicKey,
+    tree_id: &ID,
+    timestamp_ms: u64,
+) -> SyncRequest {
+    let our_tips: eidetica::Snapshot = vec![ID::from_bytes("nonexistent_tip")].into();
+    let auth = SyncRequestAuth::sign(key, server_pubkey, tree_id, &our_tips, timestamp_ms);
+    SyncRequest::SyncTree(SyncTreeRequest {
+        tree_id: tree_id.clone(),
+        our_tips,
+        peer_pubkey: None,
+        requesting_key: None,
+        requesting_key_name: None,
+        requested_permission: None,
+        metadata: None,
+        auth: Some(auth),
+    })
+}
+
+/// Grant `pubkey` read access on the database.
+async fn grant_read(database: &eidetica::Database, pubkey: &eidetica::auth::crypto::PublicKey) {
+    let txn = database.new_transaction().await.unwrap();
+    let settings = txn.get_settings().unwrap();
+    settings
+        .set_auth_key(pubkey, AuthKey::active(Some("client"), Permission::Read))
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
+}
+
+/// A caller holding an authorized key still syncs normally.
+#[tokio::test]
+async fn authorized_signed_incremental_pull_is_served() {
+    let (instance, _user, _key_id, database, sync, tree_id) =
+        helpers::setup_manual_approval_server().await;
+    write_secret(&database).await;
+
+    let (client_key, client_pubkey) = generate_keypair();
+    grant_read(&database, &client_pubkey).await;
+
+    let handler = helpers::create_test_sync_handler(&sync);
+    let response = handler
+        .handle_request(
+            &signed_request(&client_key, &instance.id(), &tree_id, now_ms()),
+            &RequestContext::default(),
+        )
+        .await;
+
+    assert!(
+        discloses_secret(&response),
+        "authorized peer was not served: {response:?}"
+    );
+}
+
+/// A valid signature from a key with no grant on this tree proves identity,
+/// not authority.
+#[tokio::test]
+async fn signed_pull_from_unauthorized_key_is_refused() {
+    let (instance, _user, _key_id, database, sync, tree_id) =
+        helpers::setup_manual_approval_server().await;
+    write_secret(&database).await;
+
+    let (stranger_key, _stranger_pubkey) = generate_keypair();
+
+    let handler = helpers::create_test_sync_handler(&sync);
+    let response = handler
+        .handle_request(
+            &signed_request(&stranger_key, &instance.id(), &tree_id, now_ms()),
+            &RequestContext::default(),
+        )
+        .await;
+
+    assert!(
+        served_entries(&response).is_empty(),
+        "a key with no grant was served: {response:?}"
+    );
+}
+
+/// A captured request must not work a second time: without this, anyone who
+/// observes one legitimate signed request on a plaintext transport can pull the
+/// database at will.
+#[tokio::test]
+async fn replayed_signed_request_is_refused() {
+    let (instance, _user, _key_id, database, sync, tree_id) =
+        helpers::setup_manual_approval_server().await;
+    write_secret(&database).await;
+
+    let (client_key, client_pubkey) = generate_keypair();
+    grant_read(&database, &client_pubkey).await;
+
+    let handler = helpers::create_test_sync_handler(&sync);
+    let request = signed_request(&client_key, &instance.id(), &tree_id, now_ms());
+
+    let first = handler
+        .handle_request(&request, &RequestContext::default())
+        .await;
+    assert!(
+        discloses_secret(&first),
+        "the original request should have been served: {first:?}"
+    );
+
+    let replay = handler
+        .handle_request(&request, &RequestContext::default())
+        .await;
+    assert!(
+        served_entries(&replay).is_empty(),
+        "a replayed request was served: {replay:?}"
+    );
+}
+
+/// Signatures age out, so a capture kept past the window is worthless even
+/// against a server that has since restarted and forgotten the nonce.
+#[tokio::test]
+async fn stale_signed_request_is_refused() {
+    let (instance, _user, _key_id, database, sync, tree_id) =
+        helpers::setup_manual_approval_server().await;
+    write_secret(&database).await;
+
+    let (client_key, client_pubkey) = generate_keypair();
+    grant_read(&database, &client_pubkey).await;
+
+    let handler = helpers::create_test_sync_handler(&sync);
+    let stale = now_ms() - 10 * 60 * 1000;
+    let response = handler
+        .handle_request(
+            &signed_request(&client_key, &instance.id(), &tree_id, stale),
+            &RequestContext::default(),
+        )
+        .await;
+
+    assert!(
+        served_entries(&response).is_empty(),
+        "a stale request was served: {response:?}"
+    );
+}
+
+/// The signature names the server it was made for, so a request captured en
+/// route to one peer cannot be relayed to another that holds the same tree.
+#[tokio::test]
+async fn request_signed_for_another_server_is_refused() {
+    let (instance, _user, _key_id, database, sync, tree_id) =
+        helpers::setup_manual_approval_server().await;
+    write_secret(&database).await;
+
+    let (client_key, client_pubkey) = generate_keypair();
+    grant_read(&database, &client_pubkey).await;
+    let (_other_server_key, other_server_pubkey) = generate_keypair();
+
+    let handler = helpers::create_test_sync_handler(&sync);
+    let response = handler
+        .handle_request(
+            &signed_request(&client_key, &other_server_pubkey, &tree_id, now_ms()),
+            &RequestContext::default(),
+        )
+        .await;
+
+    assert!(
+        served_entries(&response).is_empty(),
+        "a request addressed to a different server was served: {response:?}"
+    );
+    assert_ne!(instance.id(), other_server_pubkey);
 }
 
 /// Positive control for the two refusal tests above: the probe must be able to
@@ -153,10 +332,16 @@ async fn probe_detects_disclosure_when_it_occurs() {
 
     let handler = helpers::create_test_sync_handler(&sync);
     let response = handler
-        .handle_request(&fabricated_tip_request(&tree_id), &RequestContext::default())
+        .handle_request(
+            &fabricated_tip_request(&tree_id),
+            &RequestContext::default(),
+        )
         .await;
 
-    assert!(discloses_secret(&response), "probe cannot detect a positive");
+    assert!(
+        discloses_secret(&response),
+        "probe cannot detect a positive"
+    );
     assert!(
         served_entries(&response)
             .iter()

--- a/crates/lib/tests/it/sync/manual_approval_test.rs
+++ b/crates/lib/tests/it/sync/manual_approval_test.rs
@@ -189,6 +189,7 @@ async fn test_reject_bootstrap_request() {
         requesting_key_name: Some("laptop_key".to_string()),
         requested_permission: Some(AuthPermission::Write(5)),
         metadata: None,
+        auth: None,
     });
 
     // Handle the request to store it as pending
@@ -274,6 +275,7 @@ async fn test_list_bootstrap_requests_by_status() {
         requesting_key_name: Some("test_key".to_string()),
         requested_permission: Some(AuthPermission::Write(5)),
         metadata: None,
+        auth: None,
     });
 
     let context = RequestContext::default();
@@ -335,6 +337,7 @@ async fn test_duplicate_bootstrap_requests_same_client() {
         requesting_key_name: Some("laptop_key".to_string()),
         requested_permission: Some(AuthPermission::Write(5)),
         metadata: None,
+        auth: None,
     });
 
     // Handle first request
@@ -354,6 +357,7 @@ async fn test_duplicate_bootstrap_requests_same_client() {
         requesting_key_name: Some("laptop_key".to_string()),
         requested_permission: Some(AuthPermission::Write(5)),
         metadata: None,
+        auth: None,
     });
 
     // Handle second identical request
@@ -472,6 +476,7 @@ async fn test_malformed_permission_requests() {
             requesting_key_name: Some(format!("key_for_{}", description.replace(" ", "_"))),
             requested_permission: Some(*permission),
             metadata: None,
+            auth: None,
         });
 
         let context = RequestContext::default();
@@ -638,7 +643,7 @@ async fn test_bootstrap_with_existing_specific_key_permission() {
             .await;
     server_instance.enable_sync().await.unwrap();
 
-    let test_key = PublicKey::random();
+    let (test_signing_key, test_key) = eidetica::auth::generate_keypair();
 
     // Create database with both admin key and the test key with Write(5) permission
     let mut settings = Doc::new();
@@ -669,11 +674,12 @@ async fn test_bootstrap_with_existing_specific_key_permission() {
     let sync_handler = create_test_sync_handler(&sync);
 
     // Now try to bootstrap with the same key requesting Write(10) permission (should succeed)
-    let sync_request = create_bootstrap_request(
+    let sync_request = create_signed_bootstrap_request(
         &tree_id,
-        &test_key.to_string(),
+        &test_signing_key,
         "laptop_key",
         AuthPermission::Write(10),
+        &server_instance.id(),
     );
 
     let context = RequestContext::default();
@@ -829,7 +835,7 @@ async fn test_bootstrap_with_delegated_only_key_auto_approval() {
 
     // Agent tree D: K2 is Admin on it, with no relationship to T except the
     // delegation T will declare below.
-    let k2 = PublicKey::random();
+    let (k2_signing_key, k2) = eidetica::auth::generate_keypair();
     let mut d_settings = Doc::new();
     d_settings.set("name", "Agent DB (delegated tree)");
     let agent_db = server_user
@@ -888,11 +894,12 @@ async fn test_bootstrap_with_delegated_only_key_auto_approval() {
     let sync_handler = create_test_sync_handler(&sync);
 
     // K2 bootstraps T with only its pubkey; its Admin-on-D clamps to Write(10).
-    let sync_request = create_bootstrap_request(
+    let sync_request = create_signed_bootstrap_request(
         &tree_id,
-        &k2.to_string(),
+        &k2_signing_key,
         "daemon_key",
         AuthPermission::Write(10),
+        &server_instance.id(),
     );
     let context = RequestContext::default();
     let response = sync_handler.handle_request(&sync_request, &context).await;
@@ -966,7 +973,7 @@ async fn test_bootstrap_global_permission_client_cannot_create_entries_bug() {
     let tree_id = database.root_id().clone();
 
     // Setup client instance
-    let (client_instance, mut _client_user, client_key_id) =
+    let (client_instance, _client_user, client_key_id) =
         crate::helpers::test_local_instance_with_user_and_key("client_user", Some("client_key"))
             .await;
     client_instance.enable_sync().await.unwrap();
@@ -1234,7 +1241,7 @@ async fn test_client_retry_after_approval() {
     let server_addr = start_sync_server(&server_sync).await;
 
     // Setup client with User API
-    let (client_instance, _client_user, client_key_id, client_sync) =
+    let (client_instance, client_user, client_key_id, client_sync) =
         setup_sync_enabled_client("test_client", "client_key").await;
     client_sync
         .register_transport("http", HttpTransport::builder())
@@ -1248,7 +1255,7 @@ async fn test_client_retry_after_approval() {
         .sync_with_peer_for_bootstrap_with_key(
             &server_addr,
             &tree_id,
-            &client_key_id,
+            &client_user.get_signing_key(&client_key_id).unwrap(),
             &client_key_str,
             AuthPermission::Write(5),
         )
@@ -1288,7 +1295,7 @@ async fn test_client_retry_after_approval() {
         .sync_with_peer_for_bootstrap_with_key(
             &server_addr,
             &tree_id,
-            &client_key_id,
+            &client_user.get_signing_key(&client_key_id).unwrap(),
             &client_key_str,
             AuthPermission::Write(5),
         )
@@ -1342,7 +1349,7 @@ async fn test_client_denied_after_rejection() {
     let server_addr = start_sync_server(&server_sync).await;
 
     // Setup client with User API
-    let (client_instance, _client_user, client_key_id, client_sync) =
+    let (client_instance, client_user, client_key_id, client_sync) =
         setup_sync_enabled_client("test_client", "client_key").await;
     client_sync
         .register_transport("http", HttpTransport::builder())
@@ -1356,7 +1363,7 @@ async fn test_client_denied_after_rejection() {
         .sync_with_peer_for_bootstrap_with_key(
             &server_addr,
             &tree_id,
-            &client_key_id,
+            &client_user.get_signing_key(&client_key_id).unwrap(),
             &client_key_str,
             AuthPermission::Write(5),
         )
@@ -1395,7 +1402,7 @@ async fn test_client_denied_after_rejection() {
         .sync_with_peer_for_bootstrap_with_key(
             &server_addr,
             &tree_id,
-            &client_key_id,
+            &client_user.get_signing_key(&client_key_id).unwrap(),
             &client_key_str,
             AuthPermission::Write(5),
         )
@@ -1443,7 +1450,7 @@ async fn test_bootstrap_api_equivalence() {
 
     // Client: Use sync_with_peer_for_bootstrap_with_key (user-provided key)
     println!("🔍 Client: Testing user-provided key API...");
-    let (client_instance, _client_user, client_key_id, client_sync) =
+    let (client_instance, client_user, client_key_id, client_sync) =
         setup_sync_enabled_client("client", "client_key").await;
     client_sync
         .register_transport("http", HttpTransport::builder())
@@ -1455,7 +1462,7 @@ async fn test_bootstrap_api_equivalence() {
         .sync_with_peer_for_bootstrap_with_key(
             &server_addr,
             &tree_id,
-            &client_key_id,
+            &client_user.get_signing_key(&client_key_id).unwrap(),
             &client_key_str,
             AuthPermission::Write(5),
         )

--- a/crates/lib/tests/it/sync/mod.rs
+++ b/crates/lib/tests/it/sync/mod.rs
@@ -23,6 +23,7 @@ mod declarative_api_tests;
 mod device_id_tests;
 pub mod helpers;
 mod http_transport_tests;
+mod incremental_auth_tests;
 mod integration_tests;
 mod invariant_assertions_tests;
 mod iroh_e2e_test;

--- a/crates/lib/tests/it/sync/sync_enabled_security_tests.rs
+++ b/crates/lib/tests/it/sync/sync_enabled_security_tests.rs
@@ -227,6 +227,7 @@ async fn test_incremental_sync_rejected_when_sync_disabled() {
         requesting_key_name: None,
         requested_permission: None,
         metadata: None,
+        auth: None,
     });
 
     let context = RequestContext::default();

--- a/crates/lib/tests/it/user/user_bootstrap_tests.rs
+++ b/crates/lib/tests/it/user/user_bootstrap_tests.rs
@@ -115,6 +115,7 @@ async fn create_pending_request(
         requesting_key_name: Some("laptop_key".to_string()),
         requested_permission: Some(permission),
         metadata: None,
+        auth: None,
     });
 
     let context = RequestContext::default();

--- a/docs/src/design/bootstrap.md
+++ b/docs/src/design/bootstrap.md
@@ -286,13 +286,15 @@ impl Sync {
         rejecting_key_id: &str,
     ) -> Result<()>;
 
-    /// Request bootstrap access (low-level, requires key details)
+    /// Request bootstrap access (low-level, requires key details).
+    /// Signs the request with `requesting_key`, so the peer can tell a key
+    /// holder from a caller naming a key it does not have.
     pub async fn sync_with_peer_for_bootstrap_with_key(
         &self,
         address: &Address,
         tree_id: &ID,
-        public_key: &str,
-        key_id: &str,
+        requesting_key: &PrivateKey,
+        requesting_key_name: &str,
         requested_permission: Permission,
     ) -> Result<()>;
 }


### PR DESCRIPTION
TLDR: Closing some obvious holes in the Sync API

`handle_incremental_sync` performed no authorization — it gated only on whether the database had sync enabled, and the caller picks that branch by sending any non-empty tip list. A tip we have never seen never stops the ancestor walk, so one fabricated tip returned the whole tree, auth key list included, to a caller that never touched bootstrap and was never approved. Bootstrap had the same defect in narrower form: it served whenever the *claimed* key already had access, and nothing checked that claim. There was nothing trustworthy to check it against — the handshake proves the server to the client and never the reverse, and both transports copy `peer_pubkey` out of the request body.

Serving entries from a database with auth configured now requires a signature over the request plus a key `Database::can_access` accepts; public and wildcard databases are unchanged. `SyncRequestAuth` covers the responding server's key, the tree, the tips, a timestamp and a nonce, so a captured request cannot be replayed, relayed to another peer holding the same tree, or reused elsewhere. It authenticates the requester to the server and does not protect the channel: on a plaintext transport a path attacker still reads the response. Clients sign with the key whose access they claim, so the low-level bootstrap entry points take a `&PrivateKey` where they took a `&PublicKey` — `User::request_database_access` is unchanged. Rustdoc on `SyncRequestAuth`, `MAX_REQUEST_AGE_MS`, and `sync_tree_with_peer_as` carries the detail, including the known gap: background sync signs with the device key, so a database that granted a *user* key needs that key passed explicitly.
