### PR TITLE
ci(mirror): point the git mirror at code.jackson.dev

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,4 +1,4 @@
-name: Codeberg
+name: Mirror
 
 on:
   push:
@@ -14,6 +14,8 @@ jobs:
     with:
       runs-on: ubicloud-standard-2
       environment: mirror
-      destination: git@codeberg.org:arcuru/eidetica.git
+      destination: git@code.jackson.dev:arcuru/eidetica.git
+      host: code.jackson.dev
+      host-key: "code.jackson.dev ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDPsnswuXB8WNSv756SxOsNjoUirmyUJiZgysoCU8EZk"
     secrets:
       ssh-private-key: ${{ secrets.GIT_SSH_PRIVATE_KEY }}

--- a/README.md
+++ b/README.md
@@ -83,10 +83,3 @@ Eventually, you will be able to sparsely checkout just particular Stores within 
 ## Contributing
 
 At this time, outside contributions will not be accepted due to [licensing considerations](https://jackson.dev/post/oss-licensing-sucks).
-
-## Repository
-
-Mirrored on [GitHub](https://github.com/arcuru/eidetica) and [Codeberg](https://codeberg.org/arcuru/eidetica).
-
-For practical reasons GitHub is the official repo, but use either repo to contribute.
-Issues can't be synced so there may be some duplicates.

--- a/docs/src/internal/ci.md
+++ b/docs/src/internal/ci.md
@@ -19,7 +19,7 @@ The primary CI runs on GitHub with these workflows:
 - **[coverage.yml](https://github.com/arcuru/eidetica/blob/main/.github/workflows/coverage.yml)**: Multi-backend code coverage tracking via Codecov
 - **[deploy-docs.yml](https://github.com/arcuru/eidetica/blob/main/.github/workflows/deploy-docs.yml)**: Documentation deployment to GitHub Pages
 - **[release-plz.yml](https://github.com/arcuru/eidetica/blob/main/.github/workflows/release-plz.yml)**: Automated releases and crates.io publishing
-- **[codeberg.yml](https://github.com/arcuru/eidetica/blob/main/.github/workflows/codeberg.yml)**: Codeberg mirror sync (main branch only)
+- **[mirror.yml](https://github.com/arcuru/eidetica/blob/main/.github/workflows/mirror.yml)**: Forgejo mirror sync (main branch only)
 - **[security-audit.yml](https://github.com/arcuru/eidetica/blob/main/.github/workflows/security-audit.yml)**: Daily advisory scanning
 - **[cargo-update.yml](https://github.com/arcuru/eidetica/blob/main/.github/workflows/cargo-update.yml)**: Monthly cargo dependency updates
 - **[flake-update.yml](https://github.com/arcuru/eidetica/blob/main/.github/workflows/flake-update.yml)**: Monthly Nix flake input updates
@@ -29,7 +29,7 @@ The primary CI runs on GitHub with these workflows:
 
 ### Forgejo CI
 
-A dedicated Forgejo runner provides CI redundancy on [Codeberg](https://codeberg.org/arcuru/eidetica). The Forgejo workflows mirror the testing in the GitHub Actions setup with minor adaptations for the Forgejo environment.
+A dedicated Forgejo runner provides CI redundancy on [code.jackson.dev](https://code.jackson.dev/arcuru/eidetica). The Forgejo workflows mirror the testing in the GitHub Actions setup with minor adaptations for the Forgejo environment.
 
 ## Nix Flake
 
@@ -182,7 +182,7 @@ Secrets are scoped to [GitHub Environments](https://docs.github.com/en/actions/d
 | `publish`      | `NIX_CACHE_ACCESS_KEY_ID`, `NIX_CACHE_SECRET_ACCESS_KEY`, `NIX_CACHE_SIGNING_KEY`, `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN` | Release builds, cache push, container publishing |
 | `release`      | `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN`                                                                                    | Container manifest creation                      |
 | `automation`   | `PAT_TOKEN`                                                                                                                | PR creation with elevated permissions            |
-| `mirror`       | `GIT_SSH_PRIVATE_KEY`                                                                                                      | Codeberg mirror sync                             |
+| `mirror`       | `GIT_SSH_PRIVATE_KEY`                                                                                                      | Forgejo mirror sync                              |
 | _(repo-level)_ | `CODECOV_TOKEN`, `BENCHER_API_TOKEN`                                                                                       | Low-risk upload-only tokens                      |
 
 All environments are restricted to the `main` branch. Low-risk tokens that can only upload metrics or coverage data remain at the repo level.


### PR DESCRIPTION
Retarget the push mirror from Codeberg to the self-hosted Forgejo instance, pinning its ed25519 host key, and drop the README section advertising Codeberg as a second contribution target.