### PR TITLE
refactor(auth): drop the vestigial delegation recursion depth guard

### DIFF
--- a/crates/lib/src/auth/errors.rs
+++ b/crates/lib/src/auth/errors.rs
@@ -55,13 +55,6 @@ pub enum AuthError {
     #[error("Empty delegation path")]
     EmptyDelegationPath,
 
-    /// Maximum delegation depth was exceeded to prevent infinite loops.
-    #[error("Maximum delegation depth ({depth}) exceeded")]
-    DelegationDepthExceeded {
-        /// The maximum depth that was exceeded
-        depth: usize,
-    },
-
     /// A delegation step is invalid.
     #[error("Invalid delegation step: {reason}")]
     InvalidDelegationStep {
@@ -288,7 +281,6 @@ impl AuthError {
         matches!(
             self,
             AuthError::EmptyDelegationPath
-                | AuthError::DelegationDepthExceeded { .. }
                 | AuthError::InvalidDelegationStep { .. }
                 | AuthError::DelegatedTreeLoadFailed { .. }
                 | AuthError::InvalidDelegationTips { .. }

--- a/crates/lib/src/auth/validation/delegation.rs
+++ b/crates/lib/src/auth/validation/delegation.rs
@@ -17,9 +17,9 @@ use crate::{
 /// Maximum number of steps in a single delegation path.
 ///
 /// The path is wire-supplied and processed as a flat list, so its length is the
-/// delegation-chain depth. Bounding it caps the backend work an unauthenticated
-/// signature key can force before the authorization gate decides (mirrors the
-/// `MAX_DELEGATION_DEPTH` recursion guard in the resolver).
+/// delegation-chain depth, and checking it here bounds that depth before any
+/// backend work happens. That caps what an unauthenticated signature key can
+/// force the resolver to do before the authorization gate decides.
 const MAX_DELEGATION_STEPS: usize = 10;
 
 /// Maximum number of claimed tips per delegation step.
@@ -43,16 +43,20 @@ impl DelegationResolver {
     /// applying permission clamping at each level. The final hint
     /// is resolved in the last delegated tree's auth settings.
     ///
+    /// Resolution is a flat loop, not recursion: the path arrives as a list, so
+    /// chain depth is `steps.len()` and is bounded up front by
+    /// [`MAX_DELEGATION_STEPS`]. Nothing here re-enters the resolver — the final
+    /// hint is looked up directly in the last tree's settings.
+    ///
     /// Returns all matching ResolvedAuth entries. For name hints that match
     /// multiple keys at the final step, all matches are returned with the
     /// same permission clamping applied to each.
-    pub async fn resolve_delegation_path_with_depth(
+    pub async fn resolve_delegation_path(
         &mut self,
         steps: &[DelegationStep],
         final_hint: &KeyHint,
         auth_settings: &AuthSettings,
         instance: &Instance,
-        _depth: usize,
     ) -> Result<Vec<ResolvedAuth>> {
         if steps.is_empty() {
             return Err(AuthError::EmptyDelegationPath.into());

--- a/crates/lib/src/auth/validation/entry.rs
+++ b/crates/lib/src/auth/validation/entry.rs
@@ -103,7 +103,7 @@ impl AuthValidator {
         // The claimed tips in a delegation SigKey pin resolution: the delegated
         // tree's auth settings are read as of those tips (not its live head), and
         // the tips may not regress below the snapshot the parent tree committed
-        // for the delegation (see DelegationResolver::resolve_delegation_path_with_depth).
+        // for the delegation (see DelegationResolver::resolve_delegation_path).
         //
         // FIXME(security): this is the settings-pointer floor only — still a known
         // gap. Two hardening steps remain: (1) strict per-entry non-regression

--- a/crates/lib/src/auth/validation/resolver.rs
+++ b/crates/lib/src/auth/validation/resolver.rs
@@ -48,32 +48,6 @@ impl KeyResolver {
         auth_settings: &AuthSettings,
         instance: Option<&Instance>,
     ) -> Result<Vec<ResolvedAuth>> {
-        self.resolve_sig_key_with_depth(sig_key, auth_settings, instance, 0)
-            .await
-    }
-
-    /// Resolve authentication identifier with recursion depth tracking
-    ///
-    /// This internal method tracks delegation depth to prevent infinite loops
-    /// and ensures that delegation chains don't exceed reasonable limits.
-    ///
-    /// Returns all matching ResolvedAuth entries.
-    pub async fn resolve_sig_key_with_depth(
-        &mut self,
-        sig_key: &SigKey,
-        auth_settings: &AuthSettings,
-        instance: Option<&Instance>,
-        depth: usize,
-    ) -> Result<Vec<ResolvedAuth>> {
-        // Prevent infinite recursion and overly deep delegation chains
-        const MAX_DELEGATION_DEPTH: usize = 10;
-        if depth >= MAX_DELEGATION_DEPTH {
-            return Err(AuthError::DelegationDepthExceeded {
-                depth: MAX_DELEGATION_DEPTH,
-            }
-            .into());
-        }
-
         match sig_key {
             SigKey::Direct { hint } => self.resolve_direct_key(hint, auth_settings),
             SigKey::Delegation { path, hint } => {
@@ -81,7 +55,7 @@ impl KeyResolver {
                     operation: "delegated tree resolution".to_string(),
                 })?;
                 self.delegation_resolver
-                    .resolve_delegation_path_with_depth(path, hint, auth_settings, instance, depth)
+                    .resolve_delegation_path(path, hint, auth_settings, instance)
                     .await
             }
         }

--- a/crates/lib/src/auth/validation/tests.rs
+++ b/crates/lib/src/auth/validation/tests.rs
@@ -693,38 +693,6 @@ async fn test_nested_delegation_with_permission_clamping() {
     assert_eq!(resolved[0].key_status, KeyStatus::Active);
 }
 
-#[tokio::test]
-async fn test_delegation_depth_limit() {
-    // Test that excessive delegation depth is prevented
-    let mut validator = AuthValidator::new();
-
-    // Create empty auth settings (doesn't matter for depth test)
-    let auth_settings = AuthSettings::new();
-
-    // Test the depth check by directly calling with depth = MAX_DELEGATION_DEPTH
-    let simple_sig_key = SigKey::from_name("base_key");
-
-    // This should succeed (just under the limit)
-    let result = validator
-        .resolver
-        .resolve_sig_key_with_depth(&simple_sig_key, &auth_settings, None, 9)
-        .await;
-    // Should fail due to missing auth configuration, not depth limit
-    assert!(result.is_err());
-    let error = result.unwrap_err();
-    assert!(error.to_string().contains("not found"));
-
-    // This should fail due to depth limit (at the limit)
-    let result = validator
-        .resolver
-        .resolve_sig_key_with_depth(&simple_sig_key, &auth_settings, None, 10)
-        .await;
-    assert!(result.is_err());
-    let error = result.unwrap_err();
-    assert!(error.to_string().contains("Maximum delegation depth"));
-    assert!(error.to_string().contains("exceeded"));
-}
-
 // ===== GLOBAL PERMISSION TESTS =====
 
 #[tokio::test]

--- a/crates/lib/tests/it/auth/delegated_trees.rs
+++ b/crates/lib/tests/it/auth/delegated_trees.rs
@@ -437,12 +437,10 @@ async fn test_delegation_depth_limits() -> Result<()> {
 
     assert!(result.is_err());
     let error_msg = result.unwrap_err().to_string();
-    // The path-length cap rejects the over-limit chain up front; the older
-    // "Maximum delegation depth" / "not found" branches remain valid fallbacks.
+    // The path-length cap rejects the over-limit chain up front, before any
+    // delegated tree is loaded, so this is the only reachable outcome.
     assert!(
-        error_msg.contains("Delegation path too long")
-            || error_msg.contains("Maximum delegation depth")
-            || error_msg.contains("not found"),
+        error_msg.contains("Delegation path too long"),
         "unexpected error for over-limit delegation chain: {error_msg}"
     );
 
@@ -616,7 +614,7 @@ async fn test_delegated_tree_priority_preservation() -> Result<()> {
     Ok(())
 }
 
-/// Test delegation depth limit at exactly MAX_DELEGATION_DEPTH (10)
+/// Test delegation chain length at exactly MAX_DELEGATION_STEPS (10)
 #[tokio::test]
 async fn test_delegation_depth_limit_exact() -> Result<()> {
     let (db, mut user) = crate::helpers::test_local_instance_with_user("test_user").await;
@@ -634,7 +632,7 @@ async fn test_delegation_depth_limit_exact() -> Result<()> {
     // Build a chain exactly 10 levels deep
     let mut delegation_steps = Vec::new();
 
-    // Add 10 intermediate delegation steps (reaches MAX_DELEGATION_DEPTH of 10)
+    // Add 10 intermediate delegation steps (reaches MAX_DELEGATION_STEPS of 10)
     // Using a non-existent ID - test will fail
     let bogus_root_id =
         ID::from_bytes("sha256:0000000000000000000000000000000000000000000000000000000000000000");

--- a/docs/src/design/authentication.md
+++ b/docs/src/design/authentication.md
@@ -941,7 +941,7 @@ AuthKey {
 1. **Direct Keys**: ✅ Fully implemented and tested
 2. **Delegated Databases**: ✅ Fully implemented with comprehensive test coverage
 3. **Permission Clamping**: ✅ Functional for delegation chains
-4. **Delegation Depth Limits**: ✅ Implemented with MAX_DELEGATION_DEPTH=10
+4. **Delegation Depth Limits**: ✅ Implemented with MAX_DELEGATION_STEPS=10 — a delegation path is a flat list, so its length is the chain depth, and it is bounded before any delegated database is loaded
 
 ### Future Enhancements
 


### PR DESCRIPTION
Delegation resolution does not recurse. A delegation path arrives as a flat list of steps, and the resolver walks it with a single loop that never re-enters itself, so chain depth is just the path length.