### PR TITLE
perf(sync): sync peers concurrently and stop walking unreachable ones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1320,6 +1320,7 @@ dependencies = [
  "criterion",
  "ctor",
  "ed25519-dalek 2.2.0",
+ "futures-util",
  "handle_trait",
  "hex",
  "instability",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,10 @@ reqwest = { version = "0.12", features = [
     "rustls-tls",
 ], default-features = false }
 async-trait = "0.1"
+# Only for concurrent stream combinators (`buffer_unordered`) in the sync
+# engine. Already in the tree via iroh/axum/reqwest; declared directly so the
+# use is explicit rather than incidental.
+futures-util = { version = "0.3", default-features = false, features = ["std"] }
 iroh = { version = "1.0", default-features = false, features = ["tls-ring"] }
 iroh-tickets = "1.0"
 lru = "0.16"

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -40,6 +40,7 @@ tokio = { workspace = true }
 axum = { workspace = true }
 reqwest = { workspace = true }
 async-trait = { workspace = true }
+futures-util = { workspace = true }
 iroh = { workspace = true }
 iroh-tickets = { workspace = true }
 lru = { workspace = true }

--- a/crates/lib/src/sync/background/mod.rs
+++ b/crates/lib/src/sync/background/mod.rs
@@ -170,6 +170,11 @@ pub struct BackgroundSync {
     command_rx: mpsc::Receiver<SyncCommand>,
 }
 
+/// How many peers a periodic round syncs at once. Bounds concurrent
+/// connections on a large peer set; well above the point where a round stops
+/// being dominated by any single unreachable peer.
+const MAX_CONCURRENT_PEER_SYNCS: usize = 16;
+
 impl BackgroundSync {
     /// Start the background sync engine and return a command sender.
     ///
@@ -642,15 +647,31 @@ impl BackgroundSync {
             }
         };
 
-        // Now sync with peers (transaction is dropped, so no Send issues)
-        for peer_info in peers {
-            if peer_info.status == PeerStatus::Active
-                && let Err(e) = self.sync_with_peer(&peer_info.id).await
-            {
-                // Log individual peer sync failure but continue with others
-                tracing::error!("Periodic sync failed with {}: {e}", peer_info.id);
-            }
-        }
+        // Sync peers concurrently (the transaction is dropped, so no Send
+        // issues). A round is I/O-bound and dominated by peers that are down:
+        // done serially, one unreachable peer delays every peer behind it by a
+        // full connect timeout, so the round degrades with the number of dead
+        // peers rather than with the work there is to do. Concurrently, a round
+        // costs about as long as its slowest peer.
+        //
+        // Bounded so a large peer set can't open an unbounded number of
+        // connections at once. These futures are polled on this task rather
+        // than spawned, so they need no `Send`/`'static` bounds.
+        use futures_util::stream::StreamExt;
+        futures_util::stream::iter(
+            peers
+                .into_iter()
+                .filter(|p| p.status == PeerStatus::Active)
+                .map(|peer_info| async move {
+                    if let Err(e) = self.sync_with_peer(&peer_info.id).await {
+                        // Log individual peer sync failure but continue with others
+                        tracing::error!("Periodic sync failed with {}: {e}", peer_info.id);
+                    }
+                }),
+        )
+        .buffer_unordered(MAX_CONCURRENT_PEER_SYNCS)
+        .collect::<()>()
+        .await;
     }
 
     /// Sync with a specific peer (bidirectional)
@@ -688,11 +709,30 @@ impl BackgroundSync {
 
             info!(peer = %peer_id, tree_count = sync_trees.len(), "Synchronizing trees with peer");
 
-            for tree_id in sync_trees {
-                if let Err(e) = self.sync_tree_with_peer(peer_id, &tree_id, &address).await {
-                    // Log tree sync failure but continue with other trees
-                    tracing::error!("Failed to sync tree {tree_id} with peer {peer_id}: {e}");
+            let tree_count = sync_trees.len();
+            for (synced, tree_id) in sync_trees.into_iter().enumerate() {
+                let Err(e) = self.sync_tree_with_peer(peer_id, &tree_id, &address).await else {
+                    continue;
+                };
+                // A peer we could not connect to for one tree is not going to
+                // answer for the next one, and each attempt costs a full
+                // connect timeout. Walking every tree anyway makes an
+                // unreachable peer cost `timeout * trees` per round — so the
+                // more trees a peer accumulates, the longer it stalls sync for
+                // every *other* peer, since the periodic walk is serial.
+                //
+                // Only bail on genuine unreachability: a peer that answers
+                // "tree not found" is up, and its other trees may sync fine.
+                if matches!(&e, Error::Sync(se) if se.is_peer_unreachable()) {
+                    debug!(
+                        peer = %peer_id,
+                        skipped = tree_count - synced,
+                        "Peer unreachable; skipping its remaining trees this round: {e}"
+                    );
+                    return Err(e);
                 }
+                // Log tree sync failure but continue with other trees
+                tracing::error!("Failed to sync tree {tree_id} with peer {peer_id}: {e}");
             }
 
             info!(peer = %peer_id, "Completed peer synchronization");
@@ -844,5 +884,28 @@ impl BackgroundSync {
             }
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Only a failure to connect generalizes from one tree to the whole
+    /// peer. A peer that answers "tree not found" is up, and its other
+    /// trees must still be attempted.
+    #[test]
+    fn only_connection_failures_count_as_unreachable() {
+        let unreachable = SyncError::ConnectionFailed {
+            address: "127.0.0.1:9801".to_string(),
+            reason: "timed out".to_string(),
+        };
+        assert!(unreachable.is_peer_unreachable());
+
+        let answered = SyncError::Network("Peer returned error: Tree not found: baf…".to_string());
+        assert!(!answered.is_peer_unreachable());
+        // ...but it is still a network error, so the broader classifier is
+        // unchanged for existing callers.
+        assert!(answered.is_network_error());
     }
 }

--- a/crates/lib/src/sync/error.rs
+++ b/crates/lib/src/sync/error.rs
@@ -213,6 +213,18 @@ impl SyncError {
         )
     }
 
+    /// Check if this error means the peer itself could not be reached, as
+    /// opposed to the peer answering and rejecting the request.
+    ///
+    /// Deliberately narrower than [`Self::is_network_error`]: `Network` also
+    /// carries errors the peer *sent back* (e.g. "Peer returned error: Tree
+    /// not found"), which prove the peer is up. Only a failure to establish
+    /// the connection says anything about the peer's reachability, so only
+    /// that is safe to generalize from one tree to the peer as a whole.
+    pub fn is_peer_unreachable(&self) -> bool {
+        matches!(self, SyncError::ConnectionFailed { .. })
+    }
+
     /// Check if this is a protocol error (unexpected response).
     pub fn is_protocol_error(&self) -> bool {
         matches!(self, SyncError::UnexpectedResponse { .. })


### PR DESCRIPTION
The periodic round synced peers one at a time and, for each, walked every tree registered against it. Both amplify an unreachable peer: it costs a full connect timeout per tree, and every peer queued behind it waits. A round therefore degraded with the number of dead peers rather than with the work available, and each tree later registered against a dead peer made it worse for everyone.

- Sync peers concurrently, bounded at 16 in flight. A round now costs about as long as its slowest peer instead of the sum. The futures are polled on the existing task rather than spawned, so this needs no Send/'static bounds and no restructuring of BackgroundSync's ownership.

- Abort a peer's remaining trees once a connect attempt fails, so an unreachable peer costs one timeout rather than one per tree. Scoped to ConnectionFailed via a new is_peer_unreachable: Network also carries errors the peer sent back ("Tree not found"), which prove it is up and whose other trees must still be attempted.

futures-util is promoted to a direct dependency for buffer_unordered. It was already in the tree via iroh, axum and reqwest, so this adds no new crate — only an explicit declaration of an existing use.